### PR TITLE
Sensu handler severities is an array type.

### DIFF
--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -33,7 +33,7 @@ Puppet::Type.newtype(:sensu_handler) do
     desc "Command the handler should run"
   end
 
-  newproperty(:severities) do
+  newproperty(:severities, :array_matching => :all) do
     desc "Severities applicable to this handler"
   end
 


### PR DESCRIPTION
Just one tiny bug. Without this change, Sensu handlers will not accept an array of severities.
