### PR TITLE
Add standalone / aggregate to the sensu_check define.

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -6,17 +6,22 @@
 #
 
 define sensu::check(
-                    $command,
-                    $handlers    = [],
-                    $interval    = '60',
-                    $subscribers = []
-                    ) {
+  $command,
+  $handlers    = [],
+  $interval    = '60',
+  $standalone  = false,
+  $aggregate   = false,
+  $subscribers = []
+) {
 
   sensu_check_config { $name:
     realname    => $name,
     command     => $command,
     handlers    => $handlers,
     interval    => $interval,
+    standalone  => $standalone,
+    aggregate   => $aggregate,
     subscribers => $subscribers,
   }
+
 }


### PR DESCRIPTION
Add these as default options so we can pass them into the provider / type.
