### PR TITLE
fix capitalization of resource references

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -37,8 +37,8 @@ define sensu::check(
   }
 
   if $purge_config {
-    file { "/etc/sensu/conf.d/check_${name}.json": ensure => $ensure, before => sensu_check[$name] }
-    file { "/etc/sensu/conf.d/${config_key}.json": ensure => $config_present, before => sensu_check_config[$config_key] }
+    file { "/etc/sensu/conf.d/check_${name}.json": ensure => $ensure, before => Sensu_check[$name] }
+    file { "/etc/sensu/conf.d/${config_key}.json": ensure => $config_present, before => Sensu_check_config[$config_key] }
   }
 
   sensu_check { $name:

--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -63,8 +63,8 @@ define sensu::handler(
   }
 
   if $purge_config {
-    file { "/etc/sensu/conf.d/handler_${name}.json": ensure => $ensure, before => sensu_handler[$name] }
-    file { "/etc/sensu/conf.d/${config_key}.json": ensure => $config_present, before => sensu_handler_config[$config_key] }
+    file { "/etc/sensu/conf.d/handler_${name}.json": ensure => $ensure, before => Sensu_handler[$name] }
+    file { "/etc/sensu/conf.d/${config_key}.json": ensure => $config_present, before => Sensu_handler_config[$config_key] }
   }
 
   sensu_handler { $name:

--- a/manifests/rabbitmq.pp
+++ b/manifests/rabbitmq.pp
@@ -68,7 +68,7 @@ class sensu::rabbitmq(
     }
 
     if $purge_config {
-      file { '/etc/sensu/conf.d/rabbitmq.json': before => sensu_rabbitmq_config[$::fqdn] }
+      file { '/etc/sensu/conf.d/rabbitmq.json': before => Sensu_rabbitmq_config[$::fqdn] }
     }
 
     sensu_rabbitmq_config { $::fqdn:

--- a/manifests/subscription.pp
+++ b/manifests/subscription.pp
@@ -11,7 +11,7 @@ define sensu::subscription (
 ) {
 
   if $purge_config {
-    file { "/etc/sensu/conf.d/subscription_${name}.json": ensure => $ensure, before => sensu_client_subscription[$name] }
+    file { "/etc/sensu/conf.d/subscription_${name}.json": ensure => $ensure, before => Sensu_client_subscription[$name] }
   }
 
   sensu_client_subscription { $name: ensure => $ensure }


### PR DESCRIPTION
Fixes warnings:

```
Warning: Deprecation notice:  Resource references should now be capitalized
```

Thanks!
