### PR TITLE
Add dependency on the package to the plugin and handler directories

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -34,6 +34,7 @@ class sensu::package(
     mode    => '0555',
     owner   => 'sensu',
     group   => 'sensu',
+    require => Package['sensu'],
   }
 
   file { '/etc/sensu/config.json': ensure => absent }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -7,8 +7,8 @@ describe 'sensu::package', :type => :class do
     it { should create_class('sensu::package') }
     it { should include_class('sensu::repo') }
     it { should contain_package('sensu').with_ensure('latest') }
-    it { should contain_file('/etc/sensu/handlers').with_ensure('directory') }
-    it { should contain_file('/etc/sensu/plugins').with_ensure('directory') }
+    it { should contain_file('/etc/sensu/handlers').with_ensure('directory').with_require('Package[sensu]') }
+    it { should contain_file('/etc/sensu/plugins').with_ensure('directory').with_require('Package[sensu]') }
     it { should contain_file('/etc/sensu/config.json').with_ensure('absent') }
   end
 
@@ -25,7 +25,7 @@ describe 'sensu::package', :type => :class do
       'notify'  => 'Class[Sensu::Service::Server]'
     ) }
   end
-  
+
   context 'purge_configs' do
     let(:params) { { :purge_config => true } }
 


### PR DESCRIPTION
On first run (on Ubuntu 12.04 at least, Puppet 3.0.1) I hit an issue on
first run where the module tries to create directories in /etc/sensu
before it is created. /etc/sensu is not defined by the module but is
created by the sensu package. The addition of this dependency
appears to resolve the first run problem.
