### PR TITLE
Allow custom check metadata to be sent to Handler

### DIFF
--- a/lib/puppet/provider/sensu_check_config/json.rb
+++ b/lib/puppet/provider/sensu_check_config/json.rb
@@ -22,7 +22,8 @@ Puppet::Type.type(:sensu_check_config).provide(:json) do
 
   def create
     @conf[resource[:name]] = {}
-    self.config = resource[:config]
+    self.config = resource[:config] unless resource[:config].nil?
+    self.additional = resource[:additional] unless resource[:additional].nil?
   end
 
   def destroy
@@ -40,4 +41,10 @@ Puppet::Type.type(:sensu_check_config).provide(:json) do
   def config=(value)
     @conf[resource[:name]] = value
   end
+
+  def additional=(value)
+    @conf['checks'] = {}
+    @conf['checks'][resource[:name]] = value
+  end
+
 end

--- a/lib/puppet/type/sensu_check_config.rb
+++ b/lib/puppet/type/sensu_check_config.rb
@@ -25,6 +25,10 @@ Puppet::Type.newtype(:sensu_check_config) do
     desc "Configuration for the check"
   end
 
+  newproperty(:additional) do
+    desc "Additional cnfiguration to send with events to handlers"
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -18,7 +18,8 @@ define sensu::check(
   $high_flap_threshold  = undef,
   $refresh              = undef,
   $aggregate            = undef,
-  $config               = '',
+  $additional           = undef,
+  $config               = undef,
   $config_key           = $name,
   $purge_config         = 'false',
 ) {
@@ -26,9 +27,10 @@ define sensu::check(
   # Handler config
   case $ensure {
     'present': {
-      $config_present = $config ? {
-        ''      => 'absent',
-        default => 'present'
+      if ($config) or ($additional) {
+        $config_present = 'present'
+      } else {
+        $config_present = 'absent'
       }
     }
     default: {
@@ -58,8 +60,9 @@ define sensu::check(
   }
 
   sensu_check_config { $config_key:
-    ensure  => $config_present,
-    config  => $config,
+    ensure     => $config_present,
+    additional => $additional,
+    config     => $config,
   }
 
 }

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -30,8 +30,6 @@ describe 'sensu::check', :type => :define do
       :high_flap_threshold  => 15,
       :refresh              => 1800,
       :aggregate            => true,
-      :config               => { 'foo' => 'bar' },
-      :config_key           => 'mykey'
     } }
 
     it { should contain_sensu_check('mycheck').with(
@@ -48,7 +46,31 @@ describe 'sensu::check', :type => :define do
       'refresh'             => '1800',
       'aggregate'           => true
     ) }
+
+    it { should contain_file('/etc/sensu/conf.d/mycheck.json').with_ensure('absent') }
+  end
+
+  context 'additional metadata without config' do
+    let(:params) { { :command => 'ls', :handlers => ['default'],  :additional => { 'foo' => 'bar' } } }
+    it { should contain_file('/etc/sensu/conf.d/mycheck.json').with_ensure('present') }
+    it { should contain_sensu_check_config('mycheck').with_additional({'foo' => 'bar'} ) }
+    it { should contain_sensu_check_config('mycheck').without_config }
+  end
+
+  context 'config without additional metadata' do
+    let(:params) { { :command => 'ls', :handlers => ['default'], :config_key => 'mykey', :config => { 'foo' => 'bar' } } }
+    it { should contain_file('/etc/sensu/conf.d/mykey.json').with_ensure('present') }
+    it { should contain_sensu_check_config('mykey').with_config({ 'foo' => 'bar'}) }
     it { should contain_sensu_check_config('mykey').with_ensure('present')}
+    it { should contain_sensu_check_config('mykey').without_additional }
+  end
+
+  context 'config and additional metadata' do
+    let(:params) { { :command => 'ls', :handlers => ['default'], :additional => { 'foo' => 'bar' }, :config => { 'foo' => 'bar' } } }
+    it { should contain_file('/etc/sensu/conf.d/check_mycheck.json').with_ensure('present') }
+    it { should contain_file('/etc/sensu/conf.d/mycheck.json').with_ensure('present') }
+    it { should contain_sensu_check_config('mycheck').with_config({ 'foo' => 'bar'}) }
+    it { should contain_sensu_check_config('mycheck').with_additional({ 'foo' => 'bar'}) }
   end
 
   context 'ensure absent' do


### PR DESCRIPTION
Allows for custom metadata (Like config) on the check itself to be sent to the handler. The config directive on sensu_check_config specifies local configurations for the check itself. This would allow metadata on the check to be described to be sent to the handler. Such as the email address to notify when a check fails, or the playbook / runbook used to solve the issue.

Example Check

<pre>
  sensu::check { 'namenode_alive':
    command => '/usr/lib/nagios/plugins/check_http -e 200 -s "Started" -H localhost -p 50070 -u /dfshealth.jsp',
    handlers => ['pagerduty', 'sendgrid'],
    interval => '60',
    standalone => true,
    subscribers => ['namenode'],
    additional => { 'sendgrid' => { 'mail_to' => 'oncall@email.com' }, 'runbook' => 'https://url#NameNodeprocessdownalert' }
  }
</pre>


Resulting JSON

<pre>
{
  "checks": {
    "namenode_alive": {
      "runbook": "https://url#NameNodeprocessdownalert",
      "sendgrid": {
        "mail_to": "oncall@myemail.com"
      }
    }
  }
}
</pre>
