### PR TITLE
Add a notify between server and client when both are running

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,7 @@ class sensu (
 
   if $server == 'true' or $server == true {
     if $client == 'true' or $client == true {
+      Class['sensu::service::server'] ~> Class['sensu::service::client']
       $notify_services = [ Class['sensu::service::client'], Class['sensu::service::server'] ]
     } else {
       $notify_services = Class['sensu::service::server']


### PR DESCRIPTION
When running the client and the server on the same node, on first run
it's possible that the client starts before the server. This appears to
cause it not to appear until you manually (or otherwise) kick the
client. Adding this notification fixes that problem.

For a test case try https://github.com/garethr/sensu-playground. Without
this fix the first time the server instance is created the client
doesn't register. It's possible it's a bug in the (stripped down)
manifests too, if you spot that instead let me know.
