### PR TITLE
Issue with config.json not being removed

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -19,7 +19,9 @@ class sensu::package(
   package { 'sensu':
     ensure  => $version,
     notify  => $notify_services
-  }
+  } ->
+ 
+  file { '/etc/sensu/config.json': ensure => absent }
 
   if $purge_config {
     file { '/etc/sensu/conf.d':
@@ -37,5 +39,4 @@ class sensu::package(
     require => Package['sensu'],
   }
 
-  file { '/etc/sensu/config.json': ensure => absent }
 }


### PR DESCRIPTION
since File['/etc/sensu/config.json'] was run before the package it actually didnt do what it is suppose to do. need to force removal of /etc/sensu/config.json after the package is actually installed
