### PR TITLE
Change yumrepo attribute 'name' to 'descr' to suppress yum warning

### DIFF
--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -18,6 +18,7 @@ class sensu::repo::yum (
     enabled  => $enabled,
     baseurl  => 'http://repos.sensuapp.org/yum/el/$releasever/$basearch/',
     gpgcheck => 0,
+    name     => 'sensu',
     descr    => 'sensu',
     before   => Package['sensu'],
   }


### PR DESCRIPTION
To suppress yum warning: 'Repository 'sensu' is missing name in
configuration, using id'
- **descr**
  A human-readable description of the repository.
  This corresponds to the name parameter in `yum.conf(5)`.
  Set this to `absent` to remove it from the file completely.  Valid
  values are `absent`.  Values can match `/.*/`.
