### PR TITLE
Added template support for /etc/default/sensu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -32,6 +32,7 @@ class sensu (
   $client_name              = $::fqdn,
   $plugins                  = [],
   $purge_config             = false,
+  $use_embedded_ruby        = false,
 ){
 
   Class['sensu::package'] ->
@@ -61,10 +62,11 @@ class sensu (
   }
 
   class { 'sensu::package':
-    version         => $version,
-    install_repo    => $install_repo,
-    notify_services => $notify_services,
-    purge_config    => $purge_config,
+    version           => $version,
+    install_repo      => $install_repo,
+    notify_services   => $notify_services,
+    purge_config      => $purge_config,
+    use_embedded_ruby => $use_embedded_ruby,
   }
 
   class { 'sensu::rabbitmq':

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -10,6 +10,7 @@ class sensu::package(
   $notify_services  = [],
   $install_repo     = 'true',
   $purge_config     = 'false',
+  $use_embedded_ruby = 'true',
 ) {
 
   if $install_repo == 'true' or $install_repo == true {
@@ -27,6 +28,17 @@ class sensu::package(
       recurse => true,
       force   => true,
     }
+  }
+
+  file { 'sensu':
+    ensure  => file,
+    path    => '/etc/default/sensu',
+    content => template("${module_name}/sensu.erb"),
+    owner   => '0',
+    group   => '0',
+    mode    => '0644',
+    require => Package['sensu'],
+    notify  => $notify_services,
   }
 
   file { ['/etc/sensu/plugins', '/etc/sensu/handlers']:

--- a/templates/sensu.erb
+++ b/templates/sensu.erb
@@ -1,0 +1,2 @@
+EMBEDDED_RUBY=<%= use_embedded_ruby %>
+


### PR DESCRIPTION
Only a single variable is managed in /etc/default/sensu, EMBEDDED_RUBY. It is defaulted to false for compatibility reasons, but if you want to set it to true you can now specify use_embedded_ruby => true in the sensu class.

Example:
  class { 'sensu':
     rabbitmq_password  => 'mypass',
     rabbitmq_host      => 'yourhost',
     subscriptions      => [ 'sensu-general',
                             'sensu-ss',
     ],
     install_repo       => false,
     use_embedded_ruby  => true, 
  }
