### PR TITLE
Expose the occurrences check parameter

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -19,6 +19,7 @@ define sensu::check(
   $high_flap_threshold  = undef,
   $refresh              = undef,
   $aggregate            = undef,
+  $occurrences          = undef,
   $config               = undef,
   $purge_config         = 'false',
 ) {
@@ -41,6 +42,7 @@ define sensu::check(
     high_flap_threshold => $high_flap_threshold,
     refresh             => $refresh,
     aggregate           => $aggregate,
+    occurrences         => $occurrences,
     config              => $config,
     require             => File['/etc/sensu/conf.d/checks'],
   }

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -29,6 +29,7 @@ describe 'sensu::check', :type => :define do
       :high_flap_threshold  => 15,
       :refresh              => 1800,
       :aggregate            => true,
+      :occurrences          => 5,
     } }
 
     it { should contain_sensu_check('mycheck').with(
@@ -43,7 +44,8 @@ describe 'sensu::check', :type => :define do
       'low_flap_threshold'  => '10',
       'high_flap_threshold' => '15',
       'refresh'             => '1800',
-      'aggregate'           => true
+      'aggregate'           => true,
+      'occurrences'         => '5'
     ) }
   end
 


### PR DESCRIPTION
The occurrences check parameter had already been partially implemented in 107aa7df but wasn't implemented in the manifest.  This adds it, and a test.
