### PR TITLE
Prevent executing sensu::check resource every puppet run

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -130,7 +130,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def refresh
-    conf['checks'][resource[:name]]['refresh']
+    conf['checks'][resource[:name]]['refresh'].to_s
   end
 
   def refresh=(value)


### PR DESCRIPTION
If sensu::check is called with refresh attribute set to an integer, puppet refreshes the sensu::check resources every run
