### PR TITLE
Added safe_mode property

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -79,6 +79,11 @@ Puppet::Type.newtype(:sensu_check) do
     desc "Check configuration for the client to use"
   end
 
+  newproperty(:safe_mode) do
+    desc "Requires that checks are defined on the client"
+    newvalues(:true, :false)
+  end
+
   newproperty(:standalone, :boolean => true) do
     desc "Whether this is a standalone check"
 


### PR DESCRIPTION
In reference to issue #79, I found that lib/puppet/type/sensu_check.rb was lacking the definition for safe_mode.

Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Invalid parameter safe_mode at /etc/puppet/modules/common/sensu/manifests/client.pp:32 on node [removed].

I'm a bit new to this, but I think this will correct that error; it did in my environment.
