### PR TITLE
Documentation fix: refresh values

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,8 +173,11 @@ apache/manifests/monitoring/sensu.pp
       sensu::check { 'apache-running':
         handlers    => 'default',
         command     => '/etc/sensu/plugins/check-procs.rb -p /usr/sbin/httpd -w 100 -c 200 -C 1',
-        refresh     => 1800,
         standalone  => true,
+        custom      => {
+          refresh     => 1800,
+          occurrences => 2,
+        },
       }
     }
 


### PR DESCRIPTION
Commit 1efc321cb8ba8d5da831539773dfc2cf55b39e7d moved refresh, sla and occurrences values under 'custom' parameters, but this was not reflected in the documentation.
