### PR TITLE
set version on dependencies in Modulefile

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -1,8 +1,9 @@
 version '0.7.5'
 name 'sensu-puppet'
-dependency 'puppetlabs/apt'
 license 'MIT'
 summary 'A module to intall the Sensu monitoring framework'
 project_page 'https://github.com/sensu/sensu-puppet'
-dependency 'puppetlabs/stdlib'
+
+dependency 'puppetlabs/apt', '>= 0.0.1'
+dependency 'puppetlabs/stdlib', '>= 0.0.1'
 


### PR DESCRIPTION
This commit sets dependency version and orders them together in the Modulefile for better readability.

The version dependency is to get past [pull 94](https://github.com/rodjek/librarian-puppet/pull/94) in librarian-puppet.
