### PR TITLE
fix rerun of socket port

### DIFF
--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -39,6 +39,28 @@ Puppet::Type.newtype(:sensu_handler) do
 
   newproperty(:socket) do
     desc "Socket information used by the udp type"
+
+    def is_to_s(hash = @is)
+      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
+    end
+
+    def should_to_s(hash = @should)
+      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is['port'] == (@should[0]['port'] = @should[0]['port'].to_i)
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
   end
 
   newproperty(:mutator) do


### PR DESCRIPTION
When using puppet it always returns returns as sync, the value of port
is an int in the file on disk but in the catalouge it's a string. This
commit uses insync?(is) to always convert socket[:port] to an integer.

This fixes a problem where the change will be applied for every puppet
run.
