### PR TITLE
Added API parameters for user and password

### DIFF
--- a/lib/puppet/provider/sensu_api_config/json.rb
+++ b/lib/puppet/provider/sensu_api_config/json.rb
@@ -32,6 +32,8 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
     conf['api'] = {}
     self.port = resource[:port]
     self.host = resource[:host]
+    self.user = resource[:user] unless resource[:user].nil?
+    self.password = resource[:password] unless resource[:password].nil?
   end
 
   # Public: Remove the API configuration section.
@@ -75,4 +77,33 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   def host=(value)
     conf['api']['host'] = value
   end
+
+  # Public: Retrieve the api username
+  #
+  # Returns the String hostname.
+  def user
+    conf['api']['user']
+  end
+
+  # Public: Set the api user
+  #
+  # Returns nothing.
+  def user=(value)
+    conf['api']['user'] = value
+  end
+
+  # Public: Retrieve the password for the api
+  #
+  # Returns the String password.
+  def password
+    conf['api']['password']
+  end
+
+  # Public: Set the api password
+  #
+  # Returns nothing.
+  def password=(value)
+    conf['api']['password'] = value
+  end
+
 end

--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -38,6 +38,14 @@ Puppet::Type.newtype(:sensu_api_config) do
     defaultto 'localhost'
   end
 
+  newproperty(:user) do
+    desc "The username used for clients to authenticate against the Sensu API"
+  end
+
+  newproperty(:password) do
+    desc "The password use for client authentication against the Sensu API"
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/api/config.pp
+++ b/manifests/api/config.pp
@@ -18,13 +18,15 @@ class sensu::api::config {
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0444',
+    mode    => '0440',
   }
 
   sensu_api_config { $::fqdn:
-    ensure  => $ensure,
-    host    => $sensu::api_host,
-    port    => $sensu::api_port,
+    ensure   => $ensure,
+    host     => $sensu::api_host,
+    port     => $sensu::api_port,
+    user     => $sensu::api_user,
+    password => $sensu::api_password,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -91,8 +91,16 @@
 #   Default: localhost
 #
 # [*api_port*]
-#   Integer.  Port of the sensu api service
+#   Integer. Port of the sensu api service
 #   Default: 4567
+#
+# [*api_user*]
+#   String.  Password of the sensu api service
+#   Default: undef
+#
+# [*api_password*]
+#   Integer. Password of the sensu api service
+#   Default: undef
 #
 # [*dashboard_host*]
 #   String.  Hostname of the dahsboard host
@@ -175,6 +183,8 @@ class sensu (
   $redis_port               = 6379,
   $api_host                 = 'localhost',
   $api_port                 = 4567,
+  $api_user                 = undef,
+  $api_password             = undef,
   $dashboard_host           = $::ipaddress,
   $dashboard_port           = 8080,
   $dashboard_user           = 'admin',

--- a/spec/classes/sensu_api_spec.rb
+++ b/spec/classes/sensu_api_spec.rb
@@ -56,6 +56,8 @@ describe 'sensu', :type => :class do
           :host   => 'localhost',
           :port   => 4567
         ) }
+        it { should contain_sensu_api_config('testhost.domain.com').without_api_user }
+        it { should contain_sensu_api_config('testhost.domain.com').without_api_password }
       end # defaults
 
       context 'set config params' do
@@ -68,6 +70,25 @@ describe 'sensu', :type => :class do
           :ensure => 'present',
           :host   => 'sensuapi.domain.com',
           :port   => 5678
+        ) }
+        it { should contain_sensu_api_config('testhost.domain.com').without_api_user }
+        it { should contain_sensu_api_config('testhost.domain.com').without_api_password }
+      end # set config params
+
+      context 'set config params including authentication' do
+        let(:params) { {
+          :api          => true,
+          :api_host     => 'sensuapi.domain.com',
+          :api_port     => 5678,
+          :api_user     => 'test_user',
+          :api_password => 'test_password'
+        } }
+        it { should contain_sensu_api_config('testhost.domain.com').with(
+          :ensure   => 'present',
+          :host     => 'sensuapi.domain.com',
+          :port     => 5678,
+          :user     => 'test_user',
+          :password => 'test_password'
         ) }
       end # set config params
 


### PR DESCRIPTION
This is my first attempt at adding the capability of setting the API username and password.

The use of types for configuring sensu is a little advanced for me, but I think I got it right.

It does have an unexpected (to me) behavior of not removing the api_user and api_password from the json when you remove the parameters. I guess this is a side effect of how the provider is implemented? May I ask, why not just use an erb?

I don't understand the build failures though. They seem to be unrelated to my changes? And I seem to get them, even when I run against the upstream master?

I've also set the sensitive config files to 440.
