### PR TITLE
Make integers come out in JSON as integers.

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -1,8 +1,11 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 
+require 'puppet_x/sensu/to_type'
+
 Puppet::Type.type(:sensu_check).provide(:json) do
   confine :feature => :json
+  include Puppet_X::Sensu::Totype
 
   def initialize(*args)
     super
@@ -48,22 +51,8 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def custom=(value)
-    value.each { |k, v| value[k] = to_type(v) }
     conf['checks'][resource[:name]].delete_if { |k,v| not check_args.include?(k) }
-    conf['checks'][resource[:name]].merge!(value)
-  end
-
-  def to_type(value)
-    case value
-    when true, 'true', 'True', :true
-      true
-    when false, 'false', 'False', :false
-      false
-    when /^([0-9])+$/
-      value.to_i
-    else
-      value
-    end
+    conf['checks'][resource[:name]].merge!(to_type value)
   end
 
   def destroy

--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -1,8 +1,11 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 
+require 'puppet_x/sensu/to_type'
+
 Puppet::Type.type(:sensu_client_config).provide(:json) do
   confine :feature => :json
+  include Puppet_X::Sensu::Totype
 
   def initialize(*args)
     super
@@ -71,7 +74,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
 
   def custom=(value)
     @conf['client'].delete_if { |k,v| not check_args.include?(k) }
-    @conf['client'].merge!(value)
+    @conf['client'].merge!(to_type value)
   end
 
   def safe_mode

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -1,3 +1,4 @@
+require 'puppet_x/sensu/to_type'
 Puppet::Type.newtype(:sensu_check) do
   @doc = ""
 
@@ -52,6 +53,7 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:custom) do
     desc "Custom check variables"
+    include Puppet_X::Sensu::Totype
 
     def is_to_s(hash = @is)
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
@@ -70,19 +72,6 @@ Puppet::Type.newtype(:sensu_check) do
         end
       else
         true
-      end
-    end
-
-    def to_type(value)
-      case value
-      when true, 'true', 'True', :true
-        true
-      when false, 'false', 'False', :false
-        false
-      when /^([0-9])+$/
-        value.to_i
-      else
-        value
       end
     end
 

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -1,3 +1,4 @@
+require 'puppet_x/sensu/to_type'
 Puppet::Type.newtype(:sensu_client_config) do
   @doc = ""
 
@@ -45,12 +46,26 @@ Puppet::Type.newtype(:sensu_client_config) do
   newproperty(:custom) do
     desc "Custom client variables"
 
+    include Puppet_X::Sensu::Totype
+
     def is_to_s(hash = @is)
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
     end
 
     def should_to_s(hash = @should)
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
     end
 
     defaultto {}

--- a/lib/puppet_x/sensu/to_type.rb
+++ b/lib/puppet_x/sensu/to_type.rb
@@ -1,0 +1,27 @@
+module Puppet_X
+  module Sensu
+    module Totype
+      def to_type(value)
+        if value.is_a?(Hash)
+          new = Hash.new
+          value.each { |k,v| new[k] = to_type v }
+          new
+        elsif value.is_a?(Array)
+          value.collect { |v| to_type v }
+        else
+          case value
+          when true, 'true', 'True', :true
+            true
+          when false, 'false', 'False', :false
+            false
+          when /^([0-9])+$/
+            value.to_i
+          else
+            value
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/unit/puppet_x_sensu_totype_spec.rb
+++ b/spec/unit/puppet_x_sensu_totype_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'puppet_x/sensu/to_type'
+
+class TotypeFixtureClass
+  include Puppet_X::Sensu::Totype
+end
+
+describe TotypeFixtureClass do
+  let(:helper) { TotypeFixtureClass.new }
+  it 'should be callable with int, and return int' do
+    helper.to_type(1).should == 1
+  end
+  it 'should be callable with string int, and return int' do
+    helper.to_type('1').should == 1
+  end
+  it 'should be callable with string, and return string' do
+    helper.to_type('1 foo').should == '1 foo'
+  end
+  it 'should be callable with false' do
+    helper.to_type(false).should == false
+  end
+  it 'should be callable with true' do
+    helper.to_type(true).should == true
+  end
+  it 'should be callable with nil' do
+    helper.to_type(nil).should == nil
+  end
+  it 'should be callable with array and return munged array' do
+    helper.to_type([1, '1', '1 foo', false, true, nil]).should == [1, 1, '1 foo', false, true, nil]
+  end
+  it 'should be callable with hash and return munged hash' do
+    helper.to_type({:a => 1, :b => '1', :c => '1 foo', :d => false, :e => true, :f => nil}).should == {:a => 1, :b => 1, :c => '1 foo', :d => false, :e => true, :f => nil}
+  end
+  it 'should be able to recurse' do
+    helper.to_type({:a => 1, :b => '1', :c => '1 foo', :d => false, :e => true, :f => nil, :g => {:a => 1, :b => '1', :c => '1 foo', :d => false, :e => true, :f => nil}, :h => [1, '1', '1 foo', false, true, nil]}).should == {:a => 1, :b => 1, :c => '1 foo', :d => false, :e => true, :f => nil, :g => {:a => 1, :b => 1, :c => '1 foo', :d => false, :e => true, :f => nil}, :h => [1, 1, '1 foo', false, true, nil]}
+  end
+end
+


### PR DESCRIPTION
There are places (for example if you pass keepalive/threshold values to
the keepalive check in custom_client) where it matters about the type
of the variable coming from the JSON - Sensu looks for .is_a?(Integer)
and so if you quote the integers in the client config then it breaks.

There is already a to_type method which was replicated in a number of
places - however it wasn't recursive, and (at least in the case of
the client config) you can have a hash of hashes.

I've pulled this method out into a common mixin, and reused it from all
the places which use it currently + added it to the custom= methods
in providers so that things are munged on the way in, and also to the
client_config type to make data comparisions work as expected
