### PR TITLE
Exclude brackets from the name as this makes sensu barf

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -65,7 +65,7 @@ define sensu::check(
     fail("sensu::check{${name}}: high_flap_threshold must be an integer (got: ${high_flap_threshold})")
   }
 
-  $check_name = regsubst($name, ' ', '_', 'G')
+  $check_name = regsubst(regsubst($name, ' ', '_', 'G'), '[\(\)]', '', 'G')
 
   file { "/etc/sensu/conf.d/checks/${check_name}.json":
     ensure  => $ensure,

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -64,7 +64,23 @@ describe 'sensu::check', :type => :define do
       it { should contain_file('/etc/sensu/conf.d/checks/mycheck_foobar.json') }
 
     end
+  end
 
+  context 'with brackets in name' do
+    let(:title) { 'mycheck (foo) bar' }
+    context 'defaults' do
+      let(:params) { { :command => '/etc/sensu/somecommand.rb' } }
+
+      it { should contain_sensu_check('mycheck_foo_bar').with(
+        'command'     => '/etc/sensu/somecommand.rb',
+        'handlers'    => '',
+        'interval'    => '60',
+        'subscribers' => ''
+      ) }
+
+      it { should contain_file('/etc/sensu/conf.d/checks/mycheck_foo_bar.json') }
+    end
   end
 
 end
+


### PR DESCRIPTION
Re-apply commit which was originally
d85c270db31e0bde549a71b191b7c34da147eced
as this was accidentally removed in commit
95ef05e2d3d2e2a568f229b9dc2f533e2d2cecb6
