### PR TITLE
Added direct support for timeout,aggregate,handle,publish,occurrences and refresh parameters to sensu_check

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -48,13 +48,11 @@ Puppet::Type.type(:sensu_check).provide(:json) do
     self.aggregate = resource[:aggregate] unless resource[:aggregate].nil?
     self.handle = resource[:handle] unless resource[:handle].nil?
     self.publish = resource[:publish] unless resource[:publish].nil?
-    self.occurrences = resource[:occurrences] unless resource[:occurrences].nil?
-    self.refresh = resource[:refresh] unless resource[:refresh].nil?
     self.custom = resource[:custom] unless resource[:custom].nil?
   end
 
   def check_args
-    ['handlers','command','interval','subscribers','type','standalone','high_flap_threshold','low_flap_threshold','timeout','aggregate','handle','publish','occurrences','refresh','custom']
+    ['handlers','command','interval','subscribers','type','standalone','high_flap_threshold','low_flap_threshold','timeout','aggregate','handle','publish','custom']
   end
 
   def custom
@@ -202,22 +200,6 @@ Puppet::Type.type(:sensu_check).provide(:json) do
     else
       conf['checks'][resource[:name]]['publish'] = value
     end
-  end
-
-  def occurrences
-    conf['checks'][resource[:name]]['occurrences'].to_s
-  end
-
-  def occurrences=(value)
-    conf['checks'][resource[:name]]['occurrences'] = value.to_i
-  end
-
-  def refresh
-    conf['checks'][resource[:name]]['refresh'].to_s
-  end
-
-  def refresh=(value)
-    conf['checks'][resource[:name]]['refresh'] = value.to_i
   end
 
   def standalone

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -109,14 +109,6 @@ Puppet::Type.newtype(:sensu_check) do
     desc "Whether check is unpublished"
   end
 
-  newproperty(:occurrences) do
-    desc "Trigger handler notification only after X occurrences"
-  end
-
-  newproperty(:refresh) do
-    desc "Trigger repeated handler notification only after X seconds"
-  end
-
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -58,14 +58,6 @@
 #   of commands that are not actually 'checks' per say, but actually arbitrary commands for remediation
 #   Default: undef
 #
-# [*occurrences*]
-#   Integer.  Handler specific. Trigger handler notification only each X occurrences of event
-#   Default: undef
-#
-# [*refresh*]
-#   Integer.  Handler specific. Trigger repeated handler notification only after X seconds of refresh
-#   Default: undef
-#
 define sensu::check(
   $command,
   $ensure              = 'present',
@@ -80,8 +72,6 @@ define sensu::check(
   $aggregate           = undef,
   $handle              = undef,
   $publish             = undef,
-  $occurrences         = undef,
-  $refresh             = undef,
   $custom              = undef,
 ) {
 
@@ -98,12 +88,6 @@ define sensu::check(
   }
   if $timeout and !is_float($timeout) {
     fail("sensu::check{${name}}: timeout must be an float (got: ${timeout})")
-  }
-  if $occurrences and !is_integer($occurrences) {
-    fail("sensu::check{${name}}: timeout must be an integer (got: ${occurrences})")
-  }
-  if $refresh and !is_integer($refresh) {
-    fail("sensu::check{${name}}: timeout must be an integer (got: ${refresh})")
   }
 
   $check_name = regsubst(regsubst($name, ' ', '_', 'G'), '[\(\)]', '', 'G')
@@ -130,8 +114,6 @@ define sensu::check(
     aggregate           => $aggregate,
     handle              => $handle,
     publish             => $publish,
-    occurrences         => $occurrences,
-    refresh             => $refresh,
     custom              => $custom,
     require             => File['/etc/sensu/conf.d/checks'],
     notify              => [ Class['sensu::client::service'], Class['sensu::server::service'] ],

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -30,9 +30,7 @@ describe 'sensu::check', :type => :define do
         :timeout             => 0.5,
         :aggregate           => true,
         :handle              => true,
-        :publish             => true,
-        :occurrences         => 3,
-        :refresh             => 1800
+        :publish             => true
       } }
 
       it { should contain_sensu_check('mycheck').with(
@@ -48,9 +46,7 @@ describe 'sensu::check', :type => :define do
         :timeout             => 0.5,
         :aggregate           => true,
         :handle              => true,
-        :publish             => true,
-        :occurrences         => 3,
-        :refresh             => 1800
+        :publish             => true
       ) }
     end
 


### PR DESCRIPTION
As suggested on IRC. timeout/aggregate/handle/publish are used by sensu server, and occurrences/refresh by sensu handler, so its logical to have them usable directly. you can still feed them with custom param too, so should be backwards compatible.
