### PR TITLE
Fixed incorrect documentation in check configuration

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -50,7 +50,7 @@
 #   Default: undef
 #
 # [*handle*]
-#   Boolean.  When true, check will not be sent to handlers
+#   Boolean.  When false, check will not be sent to handlers
 #   Default: undef
 #
 # [*publish*]


### PR DESCRIPTION
When setting "handle" to false Sensu will not send event data to a handler.  So updated documentation to reflect this.
