### PR TITLE
Converted timeout to numeric

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -132,8 +132,13 @@ Puppet::Type.type(:sensu_check).provide(:json) do
     conf['checks'][resource[:name]]['timeout'].to_s
   end
 
+  def trim num
+    i, f = num.to_i, num.to_f
+    i == f ? i : f
+  end
+
   def timeout=(value)
-    conf['checks'][resource[:name]]['timeout'] = value.to_f
+    conf['checks'][resource[:name]]['timeout'] = trim(value)
   end
 
   def aggregate

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -41,7 +41,7 @@
 #   Default: undef
 #
 # [*timeout*]
-#   Integer.  Check timeout in seconds, after it fails
+#   Numeric.  Check timeout in seconds, after it fails
 #   Default: undef
 #
 # [*aggregate*]
@@ -86,8 +86,8 @@ define sensu::check(
   if $high_flap_threshold and !is_integer($high_flap_threshold) {
     fail("sensu::check{${name}}: high_flap_threshold must be an integer (got: ${high_flap_threshold})")
   }
-  if $timeout and !is_float($timeout) {
-    fail("sensu::check{${name}}: timeout must be an float (got: ${timeout})")
+  if $timeout and !is_numeric($timeout) {
+    fail("sensu::check{${name}}: timeout must be a numeric (got: ${timeout})")
   }
 
   $check_name = regsubst(regsubst($name, ' ', '_', 'G'), '[\(\)]', '', 'G')


### PR DESCRIPTION
Converted timeout to numeric - perhaps provider can be done better, but this works for both integer and float
