### PR TITLE
fix updating handler socket => host value

### DIFF
--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -44,20 +44,12 @@ Puppet::Type.newtype(:sensu_handler) do
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
     end
 
-    def should_to_s(hash = @should)
+    def should_to_s(hash = @should[0])
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
     end
 
     def insync?(is)
-      if defined? @should[0]
-        if is['port'] == (@should[0]['port'] = @should[0]['port'].to_i)
-          true
-        else
-          false
-        end
-      else
-        true
-      end
+      is_to_s(is) == should_to_s
     end
 
     defaultto {}

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -68,6 +68,19 @@ describe 'sensu::handler', :type => :define do
     it { should contain_sensu_handler('myhandler').with_exchange({'type' => 'topic'}) }
   end
 
+  context 'tcp' do
+    let(:params) {
+      {
+        :type => 'tcp',
+        :socket => {
+          'host' => '192.168.23.23',
+          'port' => '2003'
+        }
+      }
+    }
+    it { should contain_sensu_handler('myhandler').with_socket({'host' => '192.168.23.23', 'port' => '2003'}) }
+  end
+
   context 'mutator' do
     let(:params) { { :mutator => 'only_check_output' } }
 


### PR DESCRIPTION
When updating a handler, the socket value only updated if the port had changed. It was also doing some verbose checking that wasn't future proof.

This change includes a general spec along with using existing required method definitions to compare the `is` and `should` values
