### PR TITLE
Machines which don't have internet access can't pull the repo key

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -22,7 +22,6 @@ class sensu::repo::apt {
     } else {
       $url = 'http://repos.sensuapp.org/apt'
     }
-
     if $ensure == 'present' {
       apt::key { 'sensu':
         key         => '7580C77F',

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -62,7 +62,7 @@ describe 'sensu' do
             let(:params) { { :repo_source => 'http://repo.mydomain.com/apt' } }
             it { should contain_apt__source('sensu').with( :location => 'http://repo.mydomain.com/apt') }
 
-            it { should contain_apt__key('sensu').with(
+            it { should_not contain_apt__key('sensu').with(
               :key         => '7580C77F',
               :key_source  => 'http://repo.mydomain.com/apt/pubkey.gpg'
             ) }
@@ -72,7 +72,7 @@ describe 'sensu' do
             let(:params) { { :install_repo => false, :repo => 'main' } }
             it { should contain_apt__source('sensu').with_ensure('absent') }
 
-            it { should contain_apt__key('sensu').with(
+            it { should_not contain_apt__key('sensu').with(
               :key         => '7580C77F',
               :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg'
             ) }


### PR DESCRIPTION
So if you're not using the public repositories, it shouldn't try pulling the gpg key for them..
