### PR TITLE
Fix sensu dashboard config type conversion to always be a string

### DIFF
--- a/lib/puppet/provider/sensu_dashboard_config/json.rb
+++ b/lib/puppet/provider/sensu_dashboard_config/json.rb
@@ -51,7 +51,7 @@ Puppet::Type.type(:sensu_dashboard_config).provide(:json) do
   end
 
   def user
-    conf['dashboard']['user']
+    conf['dashboard']['user'].to_s
   end
 
   def user=(value)
@@ -60,7 +60,7 @@ Puppet::Type.type(:sensu_dashboard_config).provide(:json) do
   end
 
   def password
-    conf['dashboard']['password']
+    conf['dashboard']['password'].to_s
   end
 
   def password=(value)


### PR DESCRIPTION
I believe that when puppet queries the provider for "user" and "password", when they are not there in the json they are "null". This manifests itself on the terminal as an empty string though, so it is not obvious why it doesn't converge:

However, when you ask the parameters to be "" like:

``` puppet
class { 'puppet':
  dashboard_user => '',
  dashboard_password => '',
}
```

```
user changed '' to ''
password changed '' to ''
```

The provider removes the user and password entries in the json as requested, but the catalog never converges because null != '', and never will.

This change fixes this by making the type conversion happen in the provider, allowing the catalog to converge by "faking" the value as an empty string just like we kinda fake the setting of it by removing it out of the json. 

I don't know really how to test for this without serverspec stuff and testing for convergence?
