### PR TITLE
Changed alert to fail if OS is not supported

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -18,7 +18,7 @@ class sensu::package {
       class { 'sensu::repo::yum': }
     }
 
-    default: { alert("${::operatingsystem} not supported yet") }
+    default: { fail("${::operatingsystem} not supported yet") }
 
   }
 


### PR DESCRIPTION
When attempting install a repo on an unsupported OS we should fail as
soon as possible rather than altering and attempting to continue and
letting puppet spewing out numerous "failed dependencies".

Note sure if it's my puppet setup but I don't see anything on the
console when attempting to debug.

Before:

`puppet agent -tvd --logdest console 2>&1 | grep -i sensu | grep -i "not supported"`

After:

`puppet agent -tvd --logdest console 2>&1 | grep -i sensu | grep -i "not supported"
Error: Could not retrieve catalog from remote server: Error 400 on
SERVER: Scientific not supported yet at
/etc/puppet/environments/production/modules/sensu/manifests/package.pp:21`
