### PR TITLE
Use $url param to build apt-key url

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -34,7 +34,7 @@ class sensu::repo::apt {
 
     apt::key { 'sensu':
       key         => '7580C77F',
-      key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg',
+      key_source  => "${url}/pubkey.gpg",
     }
 
   } else {

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -61,6 +61,11 @@ describe 'sensu' do
           context 'override repo url' do
             let(:params) { { :repo_source => 'http://repo.mydomain.com/apt' } }
             it { should contain_apt__source('sensu').with( :location => 'http://repo.mydomain.com/apt') }
+
+            it { should contain_apt__key('sensu').with(
+              :key         => '7580C77F',
+              :key_source  => 'http://repo.mydomain.com/apt/pubkey.gpg'
+            ) }
           end
 
           context 'install_repo => false' do


### PR DESCRIPTION
When using a mirror of sensu I want to also use the mirror to retrieve the repo's apt-key.

This may be related to #165 as it will help it continue to work if using mirrors of the sensu
apt repository with no internet access.
