### PR TITLE
updated native types and providers to use base_path/config when puppet i...

### DIFF
--- a/lib/puppet/provider/sensu_api_config/json.rb
+++ b/lib/puppet/provider/sensu_api_config/json.rb
@@ -10,7 +10,7 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   # /etc/sensu/config.json or an empty Hash if the file can not be read.
   def conf
     begin
-      @conf ||= JSON.parse(File.read('/etc/sensu/conf.d/api.json'))
+      @conf ||= JSON.parse(File.read(config_file))
     rescue
       @conf ||= {}
     end
@@ -20,7 +20,7 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   #
   # Returns nothing.
   def flush
-    File.open('/etc/sensu/conf.d/api.json', 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(@conf)
     end
   end
@@ -55,6 +55,11 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   # Returns the String port number.
   def port
     conf['api']['port'].to_s
+  end
+
+
+  def config_file
+    "#{resource[:base_path]}/api.json"
   end
 
   # Public: Set the port that the API should listen on.

--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -20,14 +20,14 @@ Puppet::Type.type(:sensu_check).provide(:json) do
 
   def conf
     begin
-      @conf ||= JSON.parse(File.read("/etc/sensu/conf.d/checks/#{resource[:name]}.json"))
+      @conf ||= JSON.parse(File.read(config_file))
     rescue
       @conf ||= {}
     end
   end
 
   def flush
-    File.open("/etc/sensu/conf.d/checks/#{resource[:name]}.json", 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
   end
@@ -74,6 +74,10 @@ Puppet::Type.type(:sensu_check).provide(:json) do
 
   def interval
     conf['checks'][resource[:name]]['interval'].to_s
+  end
+
+  def config_file
+    "#{resource[:base_path]}/#{resource[:name]}.json"
   end
 
   def interval=(value)

--- a/lib/puppet/provider/sensu_check_config/json.rb
+++ b/lib/puppet/provider/sensu_check_config/json.rb
@@ -12,14 +12,14 @@ Puppet::Type.type(:sensu_check_config).provide(:json) do
 
   def conf
     begin
-      @conf ||= JSON.parse(File.read("/etc/sensu/conf.d/checks/config_#{resource[:name]}.json"))
+      @conf ||= JSON.parse(File.read(config_file))
     rescue
       @conf ||= {}
     end
   end
 
   def flush
-    File.open("/etc/sensu/conf.d/checks/config_#{resource[:name]}.json", 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
   end
@@ -48,6 +48,10 @@ Puppet::Type.type(:sensu_check_config).provide(:json) do
         conf.has_key?(resource[:name])
       end
     end
+  end
+
+  def config_file
+    "#{resource[:base_path]}/config_#{resource[:name]}.json"
   end
 
   def config

--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -16,16 +16,20 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
     super
 
     begin
-      @conf = JSON.parse(File.read('/etc/sensu/conf.d/client.json'))
+      @conf = JSON.parse(File.read(config_file))
     rescue
       @conf = {}
     end
   end
 
   def flush
-    File.open('/etc/sensu/conf.d/client.json', 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(@conf)
     end
+  end
+
+  def config_file
+    "#{resource[:base_path]}/client.json"
   end
 
   def create

--- a/lib/puppet/provider/sensu_client_subscription/json.rb
+++ b/lib/puppet/provider/sensu_client_subscription/json.rb
@@ -8,16 +8,20 @@ Puppet::Type.type(:sensu_client_subscription).provide(:json) do
     super
 
     begin
-      @conf = JSON.parse(File.read("/etc/sensu/conf.d/subscription_#{resource[:name]}.json"))
+      @conf = JSON.parse(File.read(config_file))
     rescue
       @conf = {}
     end
   end
 
   def flush
-    File.open("/etc/sensu/conf.d/subscription_#{resource[:name]}.json", 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(@conf)
     end
+  end
+
+  def config_file
+    "#{resource[:base_path]}/subscription_#{resource[:name]}.json"
   end
 
   def create

--- a/lib/puppet/provider/sensu_dashboard_config/json.rb
+++ b/lib/puppet/provider/sensu_dashboard_config/json.rb
@@ -6,14 +6,14 @@ Puppet::Type.type(:sensu_dashboard_config).provide(:json) do
 
   def conf
     begin
-      @conf ||= JSON.parse(File.read('/etc/sensu/conf.d/dashboard.json'))
+      @conf ||= JSON.parse(File.read(config_file))
     rescue
       @conf ||= {}
     end
   end
 
   def flush
-    File.open('/etc/sensu/conf.d/dashboard.json', 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
   end
@@ -24,6 +24,10 @@ Puppet::Type.type(:sensu_dashboard_config).provide(:json) do
     self.host = resource[:host]
     self.user = resource[:user]
     self.password = resource[:password]
+  end
+
+  def config_file
+    "#{resource[:base_path]}/dashboard.json"
   end
 
   def destroy

--- a/lib/puppet/provider/sensu_filter/json.rb
+++ b/lib/puppet/provider/sensu_filter/json.rb
@@ -19,14 +19,18 @@ Puppet::Type.type(:sensu_filter).provide(:json) do
 
   def conf
     begin
-      @conf ||= JSON.parse(File.read("/etc/sensu/conf.d/filters/#{resource[:name]}.json"))
+      @conf ||= JSON.parse(File.read(config_file))
     rescue
       @conf ||= {}
     end
   end
 
+  def config_file
+    "#{resource[:base_path]}/#{resource[:name]}.json"
+  end
+
   def flush
-    File.open("/etc/sensu/conf.d/filters/#{resource[:name]}.json", 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
   end

--- a/lib/puppet/provider/sensu_handler/json.rb
+++ b/lib/puppet/provider/sensu_handler/json.rb
@@ -8,14 +8,14 @@ Puppet::Type.type(:sensu_handler).provide(:json) do
     super
 
     begin
-      @conf = JSON.parse(File.read("/etc/sensu/conf.d/handlers/#{resource[:name]}.json"))
+      @conf = JSON.parse(File.read(config_file))
     rescue
       @conf = {}
     end
   end
 
   def flush
-    File.open("/etc/sensu/conf.d/handlers/#{resource[:name]}.json", 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(@conf)
     end
   end
@@ -33,6 +33,10 @@ Puppet::Type.type(:sensu_handler).provide(:json) do
     self.mutator = resource[:mutator] unless resource[:mutator].nil?
     self.severities = resource[:severities] unless resource[:severities].nil?
     self.filters = resource[:filters] unless resource[:filters].nil?
+  end
+
+  def config_file
+    "#{resource[:base_path]}/#{resource[:name]}.json"
   end
 
   def destroy

--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -6,14 +6,14 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
 
   def conf
     begin
-      @conf ||= JSON.parse(File.read('/etc/sensu/conf.d/rabbitmq.json'))
+      @conf ||= JSON.parse(File.read(config_file))
     rescue
       @conf ||= {}
     end
   end
 
   def flush
-    File.open('/etc/sensu/conf.d/rabbitmq.json', 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
   end
@@ -77,6 +77,10 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
     else
       (conf['rabbitmq']['ssl'] ||= {})['cert_chain_file'] = value
     end
+  end
+
+  def config_file
+    "#{resource[:base_path]}/rabbitmq.json"
   end
 
   def port

--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -6,14 +6,14 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
 
   def conf
     begin
-      @conf ||= JSON.parse(File.read('/etc/sensu/conf.d/redis.json'))
+      @conf ||= JSON.parse(File.read(config_file))
     rescue
       @conf ||= {}
     end
   end
 
   def flush
-    File.open('/etc/sensu/conf.d/redis.json', 'w') do |f|
+    File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
   end
@@ -22,6 +22,10 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
     conf['redis'] = {}
     self.port = resource[:port]
     self.host = resource[:host]
+  end
+
+  def config_file
+    "#{resource[:base_path]}/redis.json"
   end
 
   def destroy

--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -38,6 +38,11 @@ Puppet::Type.newtype(:sensu_api_config) do
     defaultto 'localhost'
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/'
+  end
+
   newproperty(:user) do
     desc "The username used for clients to authenticate against the Sensu API"
   end

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -48,6 +48,11 @@ Puppet::Type.newtype(:sensu_check) do
     desc "How frequently the check runs in seconds"
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/checks'
+  end
+
   newproperty(:low_flap_threshold) do
     desc "A host is determined to be flapping when the percent change is below this threshold."
   end

--- a/lib/puppet/type/sensu_check_config.rb
+++ b/lib/puppet/type/sensu_check_config.rb
@@ -26,6 +26,11 @@ Puppet::Type.newtype(:sensu_check_config) do
     desc "The check name to configure"
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/checks'
+  end
+
   newparam(:config) do
     desc "Check configuration for the client to use"
   end

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -43,6 +43,11 @@ Puppet::Type.newtype(:sensu_client_config) do
     desc ""
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/'
+  end
+
   newproperty(:safe_mode, :boolean => true) do
     desc "Require checks to be defined on server and client"
     newvalues(:true, :false)

--- a/lib/puppet/type/sensu_client_subscription.rb
+++ b/lib/puppet/type/sensu_client_subscription.rb
@@ -25,6 +25,11 @@ Puppet::Type.newtype(:sensu_client_subscription) do
     desc "The subscription name"
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/'
+  end
+
   newparam(:subscriptions) do
     desc "Subscriptions included"
     defaultto :name

--- a/lib/puppet/type/sensu_dashboard_config.rb
+++ b/lib/puppet/type/sensu_dashboard_config.rb
@@ -43,6 +43,11 @@ Puppet::Type.newtype(:sensu_dashboard_config) do
     defaultto 'sensu'
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/'
+  end
+
   newproperty(:password) do
     desc "The password to use when connecting to the Sensu Dashboard"
   end

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -27,6 +27,10 @@ Puppet::Type.newtype(:sensu_filter) do
     desc "The name of the filter."
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/filters/'
+  end
 
   newparam(:attributes) do
     desc ""

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -55,6 +55,11 @@ Puppet::Type.newtype(:sensu_handler) do
     defaultto {}
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/handlers/'
+  end
+
   newproperty(:mutator) do
     desc "Handler specific data massager"
   end

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -27,6 +27,11 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
     desc "This value has no effect, set it to what ever you want."
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/'
+  end
+
   newproperty(:ssl_private_key) do
     desc "The path on disk to the SSL private key needed to connect to RabbitMQ"
 

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -26,6 +26,11 @@ Puppet::Type.newtype(:sensu_redis_config) do
     desc "This value has no effect, set it to what ever you want."
   end
 
+  newparam(:base_path) do
+    desc "The base path to the client config file"
+    defaultto '/etc/sensu/conf.d/'
+  end
+
   newproperty(:port) do
     desc "The port that Redis is listening on"
 


### PR DESCRIPTION
Currently this module is written for puppet with the root user in mind as are most modules.  For folks like me where we don't have root control we need a way to tell puppet where the files are since this module hard codes the path by default.  I have added a base path parameter that allows one to override the default location of the config file for all native types.  Additionally, the parameter defaults to the originally hard coded value so that this parameter is purely optional.

This is part 1 of what needs to be changed, since this sets defaults for base_path we can add this ability now and work on the manifests to be nonroot compliant later.

I already have a completely finished non root module working but need to generalize most of the variable names in order to make them consumable by everyone.  So there will be a part two that updates the manifests to be non root friendly.
