### PR TITLE
changed chmod values for all files to be nonroot friendly

### DIFF
--- a/manifests/api/config.pp
+++ b/manifests/api/config.pp
@@ -18,7 +18,7 @@ class sensu::api::config {
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0440',
+    mode    => '0640',
   }
 
   sensu_api_config { $::fqdn:

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -96,7 +96,7 @@ define sensu::check(
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0440',
+    mode    => '0640',
     before  => Sensu_check[$check_name],
   }
 

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -18,7 +18,7 @@ class sensu::client::config {
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0444',
+    mode    => '0644',
   }
 
   sensu_client_config { $::fqdn:

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -29,7 +29,7 @@ define sensu::config (
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0444',
+    mode    => '0644',
     before  => Sensu_check[$name],
   }
 

--- a/manifests/dashboard/config.pp
+++ b/manifests/dashboard/config.pp
@@ -18,7 +18,7 @@ class sensu::dashboard::config {
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0440',
+    mode    => '0640',
   }
 
   sensu_dashboard_config { $::fqdn:

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -37,7 +37,7 @@ define sensu::filter (
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0444',
+    mode    => '0644',
     before  => Sensu_filter[$name],
   }
 

--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -113,7 +113,7 @@ define sensu::handler(
       ensure  => $file_ensure,
       owner   => 'sensu',
       group   => 'sensu',
-      mode    => '0555',
+      mode    => '0755',
       source  => $source,
     }
   } else {
@@ -124,7 +124,7 @@ define sensu::handler(
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0444',
+    mode    => '0644',
     before  => Sensu_handler[$name],
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -31,7 +31,7 @@ class sensu::package {
     content => template("${module_name}/sensu.erb"),
     owner   => '0',
     group   => '0',
-    mode    => '0444',
+    mode    => '0644',
     require => Package['sensu'],
   }
 
@@ -39,7 +39,7 @@ class sensu::package {
     ensure  => directory,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0555',
+    mode    => '0755',
     purge   => $sensu::purge_config,
     recurse => true,
     force   => true,
@@ -48,7 +48,7 @@ class sensu::package {
 
   file { ['/etc/sensu/plugins', '/etc/sensu/handlers']:
     ensure  => directory,
-    mode    => '0555',
+    mode    => '0755',
     owner   => 'sensu',
     group   => 'sensu',
     require => Package['sensu'],

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -51,14 +51,14 @@ define sensu::plugin(
 
       file { "${install_path}/${filename}":
         ensure  => file,
-        mode    => '0555',
+        mode    => '0755',
         source  => $name,
       }
     }
     'directory':  {
       file { $install_path:
         ensure  => directory,
-        mode    => '0555',
+        mode    => '0755',
         source  => $name,
         recurse => $recurse,
         purge   => $purge,

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -29,7 +29,7 @@ class sensu::rabbitmq::config {
         source  => $sensu::rabbitmq_ssl_cert_chain,
         owner   => 'sensu',
         group   => 'sensu',
-        mode    => '0444',
+        mode    => '0644',
         require => File['/etc/sensu/ssl'],
         before  => Sensu_rabbitmq_config[$::fqdn],
       }
@@ -45,7 +45,7 @@ class sensu::rabbitmq::config {
         source  => $sensu::rabbitmq_ssl_private_key,
         owner   => 'sensu',
         group   => 'sensu',
-        mode    => '0440',
+        mode    => '0640',
         require => File['/etc/sensu/ssl'],
         before  => Sensu_rabbitmq_config[$::fqdn],
       }
@@ -63,7 +63,7 @@ class sensu::rabbitmq::config {
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0440',
+    mode    => '0640',
     before  => Sensu_rabbitmq_config[$::fqdn],
   }
 

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -18,7 +18,7 @@ class sensu::redis::config {
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0444',
+    mode    => '0644',
   }
 
   sensu_redis_config { $::fqdn:

--- a/manifests/subscription.pp
+++ b/manifests/subscription.pp
@@ -19,7 +19,7 @@ define sensu::subscription (
     ensure  => $ensure,
     owner   => 'sensu',
     group   => 'sensu',
-    mode    => '0444',
+    mode    => '0644',
     before  => Sensu_client_subscription[$name],
   }
 


### PR DESCRIPTION
- previously the chmod values for files were set in a way that
  allowed the initial creation of the file, but subsequent puppet runs
  errored out due to permission denied errors.  This error is only noticable
  when the module is installed under nonroot.  While these changes alone
  will not make nonroot installs possible it does set the groundwork for
  future nonroot modifications.  In the end it might save somebody hours of
  of headaches.  Moreover, this is a general error but since this is normally
  run under root user we dont' see the issue because root is godlike.
