### PR TITLE
Fix warnings from ruby like this:

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -61,7 +61,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
 
   def custom=(value)
     conf['checks'][resource[:name]].delete_if { |k,v| not check_args.include?(k) }
-    conf['checks'][resource[:name]].merge!(to_type value)
+    conf['checks'][resource[:name]].merge!(to_type(value))
   end
 
   def destroy

--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -79,7 +79,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
 
   def custom=(value)
     @conf['client'].delete_if { |k,v| not check_args.include?(k) }
-    @conf['client'].merge!(to_type value)
+    @conf['client'].merge!(to_type(value))
   end
 
   def safe_mode

--- a/lib/puppet/provider/sensu_filter/json.rb
+++ b/lib/puppet/provider/sensu_filter/json.rb
@@ -68,7 +68,7 @@ Puppet::Type.type(:sensu_filter).provide(:json) do
   end
 
   def attributes=(value)
-    conf['filter'][resource[:name]]['attributes'].merge!(to_type value)
+    conf['filter'][resource[:name]]['attributes'].merge!(to_type(value))
   end
 
 end


### PR DESCRIPTION
/var/lib/puppet/lib/puppet/provider/sensu_client_config/json.rb:82: warning: parenthesize argument(s) for future version
/var/lib/puppet/lib/puppet/provider/sensu_check/json.rb:64: warning: parenthesize argument(s) for future version
