### PR TITLE
Use `lookupvar` to find variables in `sensu::` namespace

### DIFF
--- a/templates/sensu.erb
+++ b/templates/sensu.erb
@@ -1,4 +1,4 @@
-EMBEDDED_RUBY=<%= @use_embedded_ruby %>
-LOG_LEVEL=<%= @log_level %>
-RUBYOPT="<%= @rubyopt %>"
+EMBEDDED_RUBY=<%= scope.lookupvar("sensu::use_embedded_ruby") %>
+LOG_LEVEL=<%= scope.lookupvar("sensu::log_level") %>
+RUBYOPT="<%= scope.lookupvar("sensu::rubyopt") %>"
 


### PR DESCRIPTION
`sensu::package` use some variables defined in `sensu` class in template. This template assumes that these variables are in current scope, but these variables are in top level scope.
