### PR TITLE
Set a GEM_PATH variable in /etc/default/sensu

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -165,6 +165,10 @@
 #   String.  Ruby opts to be passed to the sensu services
 #   Default: ''
 #
+# [*gem_path*]
+#   String.  Paths to add to GEM_PATH if we need to look for different dirs.
+#   Default: ''
+#
 # [*log_level*]
 #   String.  Sensu log level to be used
 #   Default: 'info'
@@ -210,6 +214,7 @@ class sensu (
   $purge_config             = false,
   $use_embedded_ruby        = false,
   $rubyopt                  = '',
+  $gem_path                 = '',
   $log_level                = 'info',
 ){
 

--- a/templates/sensu.erb
+++ b/templates/sensu.erb
@@ -1,4 +1,5 @@
 EMBEDDED_RUBY=<%= scope.lookupvar("sensu::use_embedded_ruby") %>
 LOG_LEVEL=<%= scope.lookupvar("sensu::log_level") %>
 RUBYOPT="<%= scope.lookupvar("sensu::rubyopt") %>"
+GEM_PATH="<%= scope.lookupvar("sensu::gem_path") %>"
 


### PR DESCRIPTION
If we have gems installed in different locations, we'd like to be able to use them without having to mess around the /opt/sensu directory.

We have a use case where we want to install all ruby gems via debian packages, but we don't want to be messing around with the system's gem, or the embedded gem, etc. Would it be possible to extend the module to have this option in `/etc/default/sensu`?

I haven't seen there are tests for this, but let me know if there is anything I can do. 

Also, I'm slightly confused with `GEM_PATH` and `GEM_HOME`. Does the former need to include/respect the latter?

Thanks.
