### PR TITLE
Enable the installation and configuration of 3rd party dashboard

### DIFF
--- a/manifests/dashboard/config.pp
+++ b/manifests/dashboard/config.pp
@@ -14,22 +14,30 @@ class sensu::dashboard::config {
     $ensure = 'present'
   }
 
-  file { '/etc/sensu/conf.d/dashboard.json':
-    ensure  => $ensure,
-    owner   => 'sensu',
-    group   => 'sensu',
-    mode    => '0440',
-  }
-
-  sensu_dashboard_config { $::fqdn:
-    ensure    => $ensure,
-    bind      => $sensu::dashboard_bind,
-    host      => $sensu::dashboard_host,
-    port      => $sensu::dashboard_port,
-    user      => $sensu::dashboard_user,
-    password  => $sensu::dashboard_password,
-    notify    => Class['sensu::dashboard::service'],
-
+  if is_bool($sensu::dashboard) and $sensu::dashboard {
+    file { $sensu::dashboard_config_file :
+      ensure  => $ensure,
+      owner   => 'sensu',
+      group   => 'sensu',
+      mode    => '0440',
+    }
+    sensu_dashboard_config { $::fqdn:
+      ensure    => $ensure,
+      bind      => $sensu::dashboard_bind,
+      host      => $sensu::dashboard_host,
+      port      => $sensu::dashboard_port,
+      user      => $sensu::dashboard_user,
+      password  => $sensu::dashboard_password,
+      notify    => Class['sensu::dashboard::service'],
+    }
+  } elsif !is_bool($sensu::dashboard) and $sensu::dashboard {
+    file { $sensu::dashboard_config_file :
+      ensure  => $ensure,
+      owner   => 'sensu',
+      group   => 'sensu',
+      mode    => '0644',
+      content => template("sensu/dashboard/${sensu::dashboard}.erb"),
+    }
   }
 
 }

--- a/manifests/dashboard/package.pp
+++ b/manifests/dashboard/package.pp
@@ -1,0 +1,17 @@
+# = Class: sensu::dashboard::package
+#
+# Install the Sensu dashboard package
+#
+class sensu::dashboard::package {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private class ${name} by ${caller_module_name}")
+  }
+
+  if $sensu::dashboard and !is_bool($sensu::dashboard) {
+    package { $sensu::dashboard :
+      ensure => $sensu::dashboard_version,
+    }
+  }
+
+}

--- a/manifests/dashboard/service.pp
+++ b/manifests/dashboard/service.pp
@@ -11,21 +11,27 @@ class sensu::dashboard::service {
   if $sensu::manage_services {
 
     case $sensu::dashboard {
-      true: {
-        $ensure = 'running'
-        $enable = true
-      }
-      default: {
+      false: {
         $ensure = 'stopped'
         $enable = false
       }
+      default: {
+        $ensure = 'running'
+        $enable = true
+      }
     }
 
-    service { 'sensu-dashboard':
+    if is_bool($sensu::dashboard) and $sensu::dashboard {
+      $service_name_real = 'sensu-dashboard'
+    } elsif !is_bool($sensu::dashboard) and $sensu::dashboard {
+      $service_name_real = $sensu::dashboard
+    }
+
+    service { $service_name_real :
       ensure     => $ensure,
       enable     => $enable,
       hasrestart => true,
-      subscribe  => [ Class['sensu::package'], Class['sensu::dashboard::config'], Class['sensu::api::config'], Class['sensu::redis::config'] ]
+      subscribe  => [ Class['sensu::package'], Class['sensu::dashboard::package'],Class['sensu::dashboard::config'], Class['sensu::api::config'], Class['sensu::redis::config'] ]
     }
   }
 }

--- a/templates/dashboard/uchiwa.erb
+++ b/templates/dashboard/uchiwa.erb
@@ -1,0 +1,20 @@
+module.exports = {
+  sensu: [
+    {
+      name: 'Sensu',
+      host: '<%= @api_host %>',
+      ssl: false,
+      port: <%= @api_port %>,
+      user: '',
+      pass: '',
+      path: '',
+      timeout: 5000
+    }
+  ],
+  uchiwa: {
+    user: '',
+    pass: '',
+    stats: 10,
+    refresh: 10000
+  }
+}


### PR DESCRIPTION
Currently in the module, the only dashboard available is sensu-dashboard.
Unfortunately, from sensu 0.13, sensu-dashboard isn't available anymore,
this leads to a run error when sensu::dashboard is set to true.

One can stick to $sensu::version = 0.12.x-y but since sensu aims to distribute
3rd party dasbhoard in its repo, the module could benefit from it.

The following patchset aims to let one specify the dashboard system one wants
to set. So  $dashboard can be set to 'uchiwa', or any other dashboard name
available in sensu repos.
