### PR TITLE
Make the rabbitmq_vhost defaults match the docs

### DIFF
--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -69,7 +69,7 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   newproperty(:vhost) do
     desc "The vhost to use when connecting to RabbitMQ"
 
-    defaultto '/sensu'
+    defaultto 'sensu'
   end
 
   autorequire(:package) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -195,7 +195,7 @@ class sensu (
   $rabbitmq_host            = 'localhost',
   $rabbitmq_user            = 'sensu',
   $rabbitmq_password        = '',
-  $rabbitmq_vhost           = '/sensu',
+  $rabbitmq_vhost           = 'sensu',
   $rabbitmq_ssl_private_key = undef,
   $rabbitmq_ssl_cert_chain  = undef,
   $redis_host               = 'localhost',


### PR DESCRIPTION
Documentation and tests were updated in #184, but the actual code wasn't. Make the
code match the documentation.
