### PR TITLE
Remove unused $notify in check.pp

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -95,18 +95,6 @@ define sensu::check(
     fail("sensu::check{${name}}: timeout must be a numeric (got: ${timeout})")
   }
 
-  if $client {
-    if $server {
-
-    } else {
-      $notify = Class['sensu::client::service']
-    }
-  } elsif $server {
-    $notify = Class['sensu::client::service']
-  } else {
-    $notify = []
-  }
-
   $check_name = regsubst(regsubst($name, ' ', '_', 'G'), '[\(\)]', '', 'G')
 
   file { "/etc/sensu/conf.d/checks/${check_name}.json":


### PR DESCRIPTION
Currenlty its not possible to run the sensu puppet module with
puppet 3.6 because of a redelcaration of $notify in check.pp
This var was introduced with 62d7c948ca3ad8c16ab8aa5939dbaa69584f9f82
but is obsolete since a296283c193b166859d7390a23960346f6c12aa9 because
of the renaming.

@jamtur01 i needed to close pull request #204 
would be cool if @jlambert121 could verify the PR. 
