### PR TITLE
fix apt::source dependency on apt::key

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -36,7 +36,6 @@ class sensu::repo::apt {
       repos       => $sensu::repo,
       include_src => false,
       key         => $sensu::repo_key_id,
-      require     => Apt::Key['sensu'],
       before      => Package['sensu'],
     }
 


### PR DESCRIPTION
Hi,
on fresh installations, the apt::key does not always come before apt::source so it will break the puppet-run.
https://github.com/sensu/sensu-puppet/pull/202 tries to fix that but adds too much not needed code. apt::source will call apt-get update itself, but it needs to be in the correct dependency order.
