### PR TITLE
Remove default username for sensu

### DIFF
--- a/lib/puppet/type/sensu_dashboard_config.rb
+++ b/lib/puppet/type/sensu_dashboard_config.rb
@@ -46,7 +46,6 @@ Puppet::Type.newtype(:sensu_dashboard_config) do
   newproperty(:user) do
     desc "The username to use when connecting to the Sensu Dashboard"
 
-    defaultto 'sensu'
   end
 
   newparam(:base_path) do


### PR DESCRIPTION
In some cases we need a passwordless sensu dashboard for different reasons, for example if we would like to manage the Auth using Nginx + Google_Auth_proxy[1].

Adding the default sensu user on the provider would mean that we have to authenticate everytime which doesn't make much sense. Also managing default values on the type limits the usage of the $sensu::dashboard_user which might be intended to manage our configurations. Having two entry points is difficult to handle imho.

closes #205
[1] https://github.com/bitly/google_auth_proxy
