### PR TITLE
Fix sensu check json

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -98,7 +98,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def occurrences=(value)
-    conf['checks'][resource[:name]]['occurrences'] = value
+    conf['checks'][resource[:name]]['occurrences'] = value.to_i
   end
 
   def refresh
@@ -106,7 +106,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def refresh=(value)
-    conf['checks'][resource[:name]]['refresh'] = value
+    conf['checks'][resource[:name]]['refresh'] = value.to_i
   end
 
   def command


### PR DESCRIPTION
When creating sensu checks with sensu::check, it will create a json with:

```
root@controller:/etc/sensu/conf.d/checks# cat nova_api.json 
{
  "checks": {
    "nova_api": {
      "handlers": [
        "hipchat"
      ],
      "standalone": true,
      "interval": 60,
      "command": "PATH=$PATH:/usr/lib/nagios/plugins/ check_nova_api --auth_url http://10.0.80.148:5000/v2.0 --username admin --password keystone_admin_password_oeikoa7eiThi8 --tenant admin",
      "refresh": "60",
      "subscribers": [

      ]
    }
  }
}
```

The sensu-plugin will there fail because refresh is interpreted as string instead of an integer. The provider is missing .to_i for refresh and occurrences like it is used for interval.
