### PR TITLE
Update apt.pp - Avoid Source conflict with uchiwa

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -22,16 +22,17 @@ class sensu::repo::apt {
     } else {
       $url = 'http://repos.sensuapp.org/apt'
     }
-
-    apt::source { 'sensu':
-      ensure      => $ensure,
-      location    => $url,
-      release     => 'sensu',
-      repos       => $sensu::repo,
-      include_src => false,
-      key         => $sensu::repo_key_id,
-      key_source  => $sensu::repo_key_source,
-      before      => Package['sensu'],
+    if !defined(Apt::Source['sensu']) {
+      apt::source { 'sensu':
+        ensure      => $ensure,
+        location    => $url,
+        release     => 'sensu',
+        repos       => $sensu::repo,
+        include_src => false,
+        key         => $sensu::repo_key_id,
+        key_source  => $sensu::repo_key_source,
+        before      => Package['sensu'],
+      }
     }
 
   } else {


### PR DESCRIPTION
Source conflict with uchiwa puppet module.

```
Error: Duplicate declaration: Apt::Source[sensu] is already declared in file /tmp/vagrant-puppet-3/modules-0/uchiwa/manifests/repo/apt.pp:34; cannot redeclare at /tmp/vagrant-puppet-3/modules-0/sensu/manifests/repo/apt.pp:35
```
