### PR TITLE
Fix client keepalive cycling

### DIFF
--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -49,7 +49,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
   end
 
   def check_args
-    ['name', 'address', 'subscriptions', 'safe_mode', 'bind']
+    ['name', 'address', 'subscriptions', 'safe_mode', 'bind', 'keepalive']
   end
 
   def client_name


### PR DESCRIPTION
keepalive wasn't in the check_args list so it would cycle on and off on
each puppet run
