### PR TITLE
Fix for issue #233: accomodating for install_repo, with specs

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,12 +12,20 @@ class sensu::package {
 
     'Debian': {
       class { 'sensu::repo::apt': }
-      $repo_require = Apt::Source['sensu']
+      if str2bool($sensu::install_repo) {
+        $repo_require = Apt::Source['sensu']
+      } else {
+        $repo_require = undef
+      }
     }
 
     'RedHat': {
       class { 'sensu::repo::yum': }
-      $repo_require = Yumrepo['sensu']
+      if str2bool($sensu::install_repo) {
+        $repo_require = Yumrepo['sensu']
+      } else {
+        $repo_require = undef
+      }
     }
 
     default: { alert("${::osfamily} not supported yet") }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -88,6 +88,8 @@ describe 'sensu' do
               :key         => '7580C77F',
               :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg'
             ) }
+
+            it { should contain_package('sensu').with( :require => nil ) }
           end
         end
 
@@ -121,6 +123,7 @@ describe 'sensu' do
         context 'install_repo => false' do
           let(:params) { { :install_repo => false } }
           it { should_not contain_yumrepo('sensu') }
+          it { should contain_package('sensu').with( :require => nil ) }
         end
       end
     end


### PR DESCRIPTION
Updated module to reflect $sensu::install_repo when setting the package dependency. Included spec tests as well. Successfully tested on Centos 6.4 vagrant box.
