### PR TITLE
Add optional pipe property to sensu_handler

### DIFF
--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -80,6 +80,7 @@ define sensu::handler(
   validate_re($ensure, ['^present$', '^absent$'] )
   validate_re($type, [ '^pipe$', '^tcp$', '^udp$', '^amqp$', '^set$', '^transport$' ] )
   if $exchange { validate_hash($exchange) }
+  if $pipe { validate_hash($pipe) }
   if $socket { validate_hash($socket) }
   validate_array($severities)
   if $source { validate_re($source, ['^puppet://'] ) }
@@ -95,7 +96,7 @@ define sensu::handler(
     fail('exchange must be set with type amqp')
   }
 
-  if $type == 'transport' and !pipe {
+  if $type == 'transport' and !$pipe {
     fail('pipe must be set with type transport')
   }
 

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -81,6 +81,30 @@ describe 'sensu::handler', :type => :define do
     it { should contain_sensu_handler('myhandler').with_socket({'host' => '192.168.23.23', 'port' => '2003'}) }
   end
 
+  context 'transport' do
+    let(:params) {
+      {
+        :type       => 'transport',
+        :pipe       => {
+          'type'    => 'topic',
+          'name'    => 'events',
+          'options' => {
+            'passive' => 'true',
+            'durable' => 'true'
+          }
+        }
+      }
+    }
+    it { should contain_sensu_handler('myhandler').with_pipe({
+      'type'    => 'topic',
+      'name'    => 'events',
+      'options' => {
+        'passive' => 'true',
+        'durable' => 'true'
+      }
+    }) }
+  end
+
   context 'mutator' do
     let(:params) { { :mutator => 'only_check_output' } }
 


### PR DESCRIPTION
The pipe property is a hash. It is required when describing a sensu
handler of type transport. The transport type was introduced in sensu
0.13 and replaces the amqp type.
