### PR TITLE
Support for transport pipe configuration

### DIFF
--- a/lib/puppet/provider/sensu_handler/json.rb
+++ b/lib/puppet/provider/sensu_handler/json.rb
@@ -26,6 +26,7 @@ Puppet::Type.type(:sensu_handler).provide(:json) do
     # Optional arguments
     self.config = resource[:config] unless resource[:config].nil?
     self.exchange = resource[:exchange] unless resource[:exchange].nil?
+    self.pipe = resource[:pipe] unless resource[:pipe].nil?
     self.socket = resource[:socket] unless resource[:socket].nil?
     self.handlers = resource[:handlers] unless resource[:handlers].nil?
     self.mutator = resource[:mutator] unless resource[:mutator].nil?
@@ -67,6 +68,14 @@ Puppet::Type.type(:sensu_handler).provide(:json) do
 
   def exchange=(value)
     conf['handlers'][resource[:name]]['exchange'] = value
+  end
+
+  def pipe
+    conf['handlers'][resource[:name]]['pipe']
+  end
+
+  def pipe=(value)
+    conf['handlers'][resource[:name]]['pipe'] = value
   end
 
   def socket

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -37,6 +37,10 @@ Puppet::Type.newtype(:sensu_handler) do
     desc "Exchange information used by the amqp type"
   end
 
+  newproperty(:pipe) do
+    desc "Pipe information used by the transport type"
+  end
+
   newproperty(:socket) do
     desc "Socket information used by the udp type"
 

--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -32,6 +32,11 @@
 #   Keys: host, port
 #   Default: undef
 #
+# [*pipe*]
+#   Hash.  Pipe information used when type=transport
+#   Keys: name, type, options 
+#   Default: undef
+#
 # [*socket*]
 #   Hash.  Socket information when type=tcp or type=udp
 #   Keys: host, port
@@ -61,6 +66,7 @@ define sensu::handler(
   $handlers     = undef,
   $severities   = ['ok', 'warning', 'critical', 'unknown'],
   $exchange     = undef,
+  $pipe         = undef,
   $mutator      = undef,
   $socket       = undef,
   $filters      = undef,
@@ -87,6 +93,10 @@ define sensu::handler(
 
   if $type == 'amqp' and !$exchange {
     fail('exchange must be set with type amqp')
+  }
+
+  if $type == 'transport' and !pipe {
+    fail('pipe must be set with type transport')
   }
 
   if $type == 'set' and !$handlers {
@@ -129,18 +139,19 @@ define sensu::handler(
   }
 
   sensu_handler { $name:
-    ensure     => $ensure,
-    type       => $type,
-    command    => $command_real,
-    handlers   => $handlers,
-    severities => $severities,
-    exchange   => $exchange,
-    socket     => $socket,
-    mutator    => $mutator,
-    filters    => $filters,
-    config     => $config,
-    notify     => $notify_services,
-    require    => File['/etc/sensu/conf.d/handlers'],
+    ensure       => $ensure,
+    type         => $type,
+    command      => $command_real,
+    handlers     => $handlers,
+    severities   => $severities,
+    exchange     => $exchange,
+    pipe         => $pipe,
+    socket       => $socket,
+    mutator      => $mutator,
+    filters      => $filters,
+    config       => $config,
+    notify       => $notify_services,
+    require      => File['/etc/sensu/conf.d/handlers'],
   }
 
 }


### PR DESCRIPTION
With Sensu 0.13, the transport option was added, replacing the aqmp option. This pull request allows the transport option to be configured, including the option array. See example below.

```
puppet configuration:
  sensu::handler { 'graphite':
    type     => 'transport',
    pipe     => {
      type    => 'topic',
      name    => 'metrics',
      options => {
        durable => 'true',
        passive => 'true',
      },
    },
    mutator  => 'only_check_output',
  }

Results in sensu handler configuration:
{
  "handlers": {
    "graphite": {
      "type": "transport",
      "pipe": {
        "options": {
          "passive": "true",
          "durable": "true"
        },
        "type": "topic",
        "name": "metrics"
      },
      "mutator": "only_check_output",
    }
  }
}
```
