### PR TITLE
Fixing dependencies parameter on sensu_check type

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -36,7 +36,7 @@ Puppet::Type.newtype(:sensu_check) do
     desc "Command to be run by the check"
   end
 
-  newproperty(:dependencies) do
+  newproperty(:dependencies, :array_matching => :all) do
     desc "Dependencies of this check"
   end
 


### PR DESCRIPTION
It appears that currently the sensu_check dependencies parameter is treating a given array as a string.  

With the following configuration

```
sensu::check { 'mycheck':
        command      => '/etc/sensu/plugins/mycommand',
        interval     => 120,
        standalone   => false,
        subscribers  => ['mygroup'],
        dependencies => ['my-first-check', 'my-second-check']
}
```

Will produce a configuration file which dependencies section looks like:

```
"dependencies": [
  "my-first-test"
],
```

Adding this change seems to fix the issue.  I am fairly new to this so if there is a better way to fix this please let me know.  
