### PR TITLE
Fix check of $sensu::install_repo

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -12,7 +12,7 @@ class sensu::package {
 
     'Debian': {
       class { 'sensu::repo::apt': }
-      if str2bool($sensu::install_repo) {
+      if $sensu::install_repo {
         $repo_require = Apt::Source['sensu']
       } else {
         $repo_require = undef


### PR DESCRIPTION
It seems that a str2bool call was added to a value that should already
be a bool, making it fail.

This seems to be a similar fix to a0e9363be3b690f0f6ec4703bacadf0b4d5034d1, but for Debian. It seems it's been going back and forth over the last few hours :smile: 
