### PR TITLE
plugin: Rewrite the logic of define_plugins_dir

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -50,7 +50,12 @@ define sensu::plugin(
     'file':       {
       $filename = inline_template('<%= scope.lookupvar(\'name\').split(\'/\').last %>')
 
-      define_plugins_dir { $install_path: }
+      define_plugins_dir { "${name}-${install_path}":
+        path    => $install_path,
+        purge   => $purge,
+        recurse => $recurse,
+        force   => $force,
+      }
           
       file { "${install_path}/${filename}":
         ensure  => file,
@@ -62,7 +67,12 @@ define sensu::plugin(
     'url' : {
         $filename = inline_template('<%= scope.lookupvar(\'name\').split(\'/\').last %>')
 
-        define_plugins_dir { $install_path: }
+        define_plugins_dir { "${name}-${install_path}":
+          path    => $install_path,
+          purge   => $purge,
+          recurse => $recurse,
+          force   => $force,
+        }
 
         wget::fetch { $name :
           destination => "${install_path}/${filename}",
@@ -98,13 +108,21 @@ define sensu::plugin(
   }
 }
 # This is to verify the install_dir exists without duplicate declarations
-define define_plugins_dir ($path = $name) {
+define define_plugins_dir (
+  $path = $name,
+  $force,
+  $purge,
+  $recurse,
+) {
   if ! defined(File[$path]) {
     file { $path:
-      ensure => directory,
-      mode => '0555',
-      owner => 'sensu',
-      group => 'sensu',
+      ensure  => directory,
+      mode    => '0555',
+      owner   => 'sensu',
+      group   => 'sensu',
+      recurse => $recurse,
+      purge   => $purge,
+      force   => $force,
       require => Package['sensu'],
     }
   }


### PR DESCRIPTION
Currently, there is a duplicate error duplication when
compiling the catalog. This is due to the fact that the
call to `define_plugins_dir` is called with the exact same
parameter `$install_path` hence causing the error.

By including the name of the plugin within the name of the resource
we ensure the resource name is unique during catalog compilation.
