### PR TITLE
Use the command parameter if it's defined alongside the source parameter

### DIFF
--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -113,19 +113,24 @@ define sensu::handler(
   if $source {
 
     $filename = inline_template('<%= scope.lookupvar(\'source\').split(\'/\').last %>')
-    $command_real = "${install_path}/${filename}"
+    $handler = "${install_path}/${filename}"
 
     $file_ensure = $ensure ? {
       'absent'  => 'absent',
       default   => 'file'
     }
 
-    file { $command_real:
+    file { $handler:
       ensure  => $file_ensure,
       owner   => 'sensu',
       group   => 'sensu',
       mode    => '0555',
       source  => $source,
+    }
+
+    $command_real = $command ? {
+      undef   => $handler,
+      default => $command,
     }
   } else {
     $command_real = $command

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -7,7 +7,7 @@ describe 'sensu::handler', :type => :define do
 
     let(:params) { {
       :type     => 'pipe',
-      :command  => 'mycommand.rb',
+      :command  => '/etc/sensu/handlers/mycommand.rb',
       :source   => 'puppet:///somewhere/mycommand.rb'
     } }
     it { should contain_file('/etc/sensu/handlers/mycommand.rb').with_source('puppet:///somewhere/mycommand.rb')}
@@ -50,6 +50,16 @@ describe 'sensu::handler', :type => :define do
 
     it { should contain_file('/etc/sensu/handlers/script.sh').with_ensure('file')}
     it { should contain_sensu_handler('myhandler').with_command('/etc/sensu/handlers/script.sh') }
+  end
+
+  context 'source and command' do
+    let(:params) { {
+      :command => 'script.sh',
+      :source  => 'puppet:///sensu/handler/script.sh'
+    } }
+
+    it { should contain_file('/etc/sensu/handlers/script.sh').with_ensure('file') }
+    it { should contain_sensu_handler('myhandler').with_command('script.sh') }
   end
 
   context 'handlers' do


### PR DESCRIPTION
Previously if command and source parameters were both specified, the value of command was in fact ignored. This is not desired when the command might need additional preamble or arguments to function.

Specifically my use case is to install a Ruby-based handler, but due to running CentOS/RHEL 6.x with Ruby 1.8.7 and not wanting to pollute the embedded Ruby installed and used by Sensu I have it working using a Ruby installed as part of the RHEL Software Collections. So my actual command should be:

`env -u GEM_PATH scl enable ruby193 /etc/sensu/handlers/myshinyhandler.rb`

(Annoyingly, I found I need to clear $GEM_PATH otherwise my separate SCL Ruby uses the gems from the embedded Ruby and it still doesn't work)

However when I define my handler like so:

```
::sensu::handler { 'myshinyhandler':
  type    => pipe,
  command => 'env -u GEM_PATH scl enable ruby193 /etc/sensu/handlers/myshinyhandler.rb',
  source  => 'puppet:///modules/mymodule/myshinyhandler.rb',
}
```

The resulting `myshinyhandler.json` config file just has `/etc/sensu/handlers/myshinyhandler.rb` for the command.

This PR just uses the value of command if it's defined alongside source, otherwise behave as before and set it to the concatenation of the install path and the base filename of the handler.
