### PR TITLE
fix rabbitmq ssl config

### DIFF
--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -54,9 +54,11 @@ class sensu::rabbitmq::config {
     } else {
       $ssl_private_key = $sensu::rabbitmq_ssl_private_key
     }
+    $enable_ssl = true
   } else {
     $ssl_cert_chain = undef
     $ssl_private_key = undef
+    $enable_ssl = $sensu::rabbitmq_ssl
   }
 
   file { '/etc/sensu/conf.d/rabbitmq.json':
@@ -74,7 +76,7 @@ class sensu::rabbitmq::config {
     user            => $sensu::rabbitmq_user,
     password        => $sensu::rabbitmq_password,
     vhost           => $sensu::rabbitmq_vhost,
-    ssl_transport   => $sensu::rabbitmq_ssl,
+    ssl_transport   => $enable_ssl,
     ssl_cert_chain  => $ssl_cert_chain,
     ssl_private_key => $ssl_private_key,
   }


### PR DESCRIPTION
The intent, per the comments in the module, is that $sensu::rabbitmq_ssl
would be set to true if you set either a certificate or a key. That var
defaults to false. Current code does not actually override this value.
When the sensu_rabbitmq_config is called, it directly references this var,
so unless you've specifically set it in your config, it's always false.
This makes it behave the way the module comments describe.
