### PR TITLE
Override path of yum repo if rhel or centos 7.

### DIFF
--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -12,11 +12,19 @@ class sensu::repo::yum {
     if $sensu::repo_source {
       $url = $sensu::repo_source
     } else {
-      $url = $sensu::repo ? {
-        'unstable'  => "http://repos.sensuapp.org/yum-unstable/el/${::operatingsystemmajrelease}/\$basearch/",
-        default     => "http://repos.sensuapp.org/yum/el/${::operatingsystemmajrelease}/\$basearch/"
+      if $operatingsystemmajrelease == 7 {
+          $url = $sensu::repo ? {
+            'unstable'  => "http://repos.sensuapp.org/yum-unstable/el/6/\$basearch/",
+            default     => "http://repos.sensuapp.org/yum/el/6/\$basearch/"
+          }
+      } else {
+          $url = $sensu::repo ? {
+            'unstable'  => "http://repos.sensuapp.org/yum-unstable/el/${::operatingsystemmajrelease}/\$basearch/",
+            default     => "http://repos.sensuapp.org/yum/el/${::operatingsystemmajrelease}/\$basearch/"
+          }
       }
     }
+
 
     yumrepo { 'sensu':
       enabled  => 1,


### PR DESCRIPTION
Override path of yum repo if rhel or centos 7.

In current realisation it doesn't work with rhel7 and centos7:
http://repos.sensuapp.org/yum/el/7/x86_64/repodata/repomd.xml: [Errno 14] HTTP Error 404 - Not Found

Maybe it will be fixed later, when packages for 7 release will be available?
