### PR TITLE
Update sensu_gem provider

### DIFF
--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
     source is not present at all, the gem will be installed from the default gem
     repositories."
 
-  has_feature :versionable
+  has_feature :versionable, :install_options
 
   commands :gemcmd => "/opt/sensu/embedded/bin/gem"
 end

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -38,7 +38,10 @@ class sensu::package {
 
   package { 'sensu-plugin' :
     ensure   => $sensu::sensu_plugin_version,
-    provider => 'gem',
+    provider => $sensu::use_embedded_ruby ? {
+      true    => 'sensu_gem',
+      default => 'gem',
+    }
   }
 
   file { '/etc/default/sensu':


### PR DESCRIPTION
I'm sorry that these were missed on the last PR, but this should make the provider do something useful.
- Added the feature install_options to the provider.
- Updated package install to use the sensu_gem provider if using
  the embedded ruby.
