### PR TITLE
Adds puppetforge version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Sensu-Puppet
 
 Installs and manages the open source monitoring framework [Sensu](http://sensuapp.org).
+[![Puppet Forge](http://img.shields.io/puppetforge/v/sensu/sensu.svg)](https://forge.puppetlabs.com/sensu/sensu)
 
 ## Tested with Travis CI
 


### PR DESCRIPTION
It is nice when the readme links to the puppetforge and shows the latest forge version. 
This adds a puppet forge badge, similar to the travis build status badge.
