### PR TITLE
Fixes for dependencies and subscribers properties in sensu::check.

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -44,11 +44,12 @@ Puppet::Type.type(:sensu_check).provide(:json) do
     self.aggregate = resource[:aggregate] unless resource[:aggregate].nil?
     self.handle = resource[:handle] unless resource[:handle].nil?
     self.publish = resource[:publish] unless resource[:publish].nil?
+    self.dependencies = resource[:dependencies] unless resource[:dependencies].nil?
     self.custom = resource[:custom] unless resource[:custom].nil?
   end
 
   def check_args
-    ['handlers','command','interval','occurrences','refresh','subscribers','type','standalone','high_flap_threshold','low_flap_threshold','timeout','aggregate','handle','publish','custom']
+    ['handlers','command','interval','occurrences','refresh','subscribers','type','standalone','high_flap_threshold','low_flap_threshold','timeout','aggregate','handle','publish','dependencies','custom']
   end
 
   def custom

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -77,7 +77,7 @@ define sensu::check(
   $interval            = 60,
   $occurrences         = undef,
   $refresh             = undef,
-  $subscribers         = [],
+  $subscribers         = undef,
   $low_flap_threshold  = undef,
   $high_flap_threshold = undef,
   $timeout             = undef,

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -11,8 +11,7 @@ describe 'sensu::check', :type => :define do
 
       it { should contain_sensu_check('mycheck').with(
         :command     => '/etc/sensu/somecommand.rb',
-        :interval    => 60,
-        :subscribers => []
+        :interval    => 60
       ) }
 
     end
@@ -69,8 +68,7 @@ describe 'sensu::check', :type => :define do
 
       it { should contain_sensu_check('mycheck_foobar').with(
         :command     => '/etc/sensu/somecommand.rb',
-        :interval    => '60',
-        :subscribers => []
+        :interval    => '60'
       ) }
 
       it { should contain_file('/etc/sensu/conf.d/checks/mycheck_foobar.json') }
@@ -85,8 +83,7 @@ describe 'sensu::check', :type => :define do
 
       it { should contain_sensu_check('mycheck_foo_bar').with(
         'command'     => '/etc/sensu/somecommand.rb',
-        'interval'    => '60',
-        'subscribers' => []
+        'interval'    => '60'
       ) }
 
       it { should contain_file('/etc/sensu/conf.d/checks/mycheck_foo_bar.json') }


### PR DESCRIPTION
Fixes two issues with the Puppet configuration:

- The dependencies property is not handled correctly by the provider causing it to be added or removed with alternate runs; and
- Set subscribers property in sensu::check as undef to prevent empty array output in configuration.