### PR TITLE
Add parameter to allow purging plugins, handlers, extensions and mutators

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,11 +175,6 @@
 #   Default: false
 #   Valid values: true, false
 #
-# [*purge_scripts*]
-#   Boolean.  If unused plugins, handlers, extensions and mutators should be removed from the system
-#   Default: false
-#   Valid values: true, false
-#
 # [*use_embedded_ruby*]
 #   Boolean.  If the embedded ruby should be used
 #   Default: false
@@ -239,7 +234,6 @@ class sensu (
   $plugins                  = [],
   $plugins_dir              = undef,
   $purge_config             = false,
-  $purge_scripts            = false,
   $use_embedded_ruby        = false,
   $rubyopt                  = '',
   $gem_path                 = '',
@@ -247,7 +241,7 @@ class sensu (
   $dashboard                = false,
 ){
 
-  validate_bool($client, $server, $api, $install_repo, $purge_config, $purge_scripts, $safe_mode, $manage_services)
+  validate_bool($client, $server, $api, $install_repo, $purge_config, $safe_mode, $manage_services)
 
   validate_re($repo, ['^main$', '^unstable$'], "Repo must be 'main' or 'unstable'.  Found: ${repo}")
   validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,6 +175,11 @@
 #   Default: false
 #   Valid values: true, false
 #
+# [*purge_scripts*]
+#   Boolean.  If unused plugins, handlers, extensions and mutators should be removed from the system
+#   Default: false
+#   Valid values: true, false
+#
 # [*use_embedded_ruby*]
 #   Boolean.  If the embedded ruby should be used
 #   Default: false
@@ -234,6 +239,7 @@ class sensu (
   $plugins                  = [],
   $plugins_dir              = undef,
   $purge_config             = false,
+  $purge_scripts            = false,
   $use_embedded_ruby        = false,
   $rubyopt                  = '',
   $gem_path                 = '',
@@ -241,7 +247,7 @@ class sensu (
   $dashboard                = false,
 ){
 
-  validate_bool($client, $server, $api, $install_repo, $purge_config, $safe_mode, $manage_services)
+  validate_bool($client, $server, $api, $install_repo, $purge_config, $purge_scripts, $safe_mode, $manage_services)
 
   validate_re($repo, ['^main$', '^unstable$'], "Repo must be 'main' or 'unstable'.  Found: ${repo}")
   validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -76,7 +76,7 @@ class sensu::package {
     owner   => 'sensu',
     group   => 'sensu',
     recurse => true,
-    purge   => $sensu::purge_scripts,
+    purge   => $sensu::purge_config,
     require => Package['sensu'],
   }
 
@@ -87,7 +87,7 @@ class sensu::package {
       owner   => 'sensu',
       group   => 'sensu',
       recurse => true,
-      purge   => $sensu::purge_scripts,
+      purge   => $sensu::purge_config,
       require => Package['sensu'],
     }
   }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -75,6 +75,8 @@ class sensu::package {
     mode    => '0555',
     owner   => 'sensu',
     group   => 'sensu',
+    recurse => true,
+    purge   => $sensu::purge_scripts,
     require => Package['sensu'],
   }
 
@@ -84,6 +86,8 @@ class sensu::package {
       mode    => '0555',
       owner   => 'sensu',
       group   => 'sensu',
+      recurse => true,
+      purge   => $sensu::purge_scripts,
       require => Package['sensu'],
     }
   }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -59,7 +59,8 @@ class sensu::package {
     require => Package['sensu'],
   }
 
-  file { [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks', '/etc/sensu/conf.d/filters', '/etc/sensu/conf.d/extensions' ]:
+  file { [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks', '/etc/sensu/conf.d/filters', '/etc/sensu/conf.d/extensions',
+      '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators', '/etc/sensu/extensions/handlers' ]:
     ensure  => directory,
     owner   => 'sensu',
     group   => 'sensu',
@@ -70,24 +71,15 @@ class sensu::package {
     require => Package['sensu'],
   }
 
-  file { ['/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators', '/etc/sensu/extensions/handlers']:
-    ensure  => directory,
-    mode    => '0555',
-    owner   => 'sensu',
-    group   => 'sensu',
-    recurse => true,
-    purge   => $sensu::purge_config,
-    require => Package['sensu'],
-  }
-
   if $sensu::_manage_plugins_dir {
     file { '/etc/sensu/plugins':
       ensure  => directory,
       mode    => '0555',
       owner   => 'sensu',
       group   => 'sensu',
-      recurse => true,
       purge   => $sensu::purge_config,
+      recurse => true,
+      force   => true,
       require => Package['sensu'],
     }
   }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -14,6 +14,14 @@ describe 'sensu' do
           :purge  => false
         ) }
       end
+      [ '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
+        '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ].each do |dir|
+        it { should contain_file(dir).with(
+          :ensure  => 'directory',
+          :recurse => true,
+          :purge   => false
+        ) }
+      end
       it { should contain_file('/etc/sensu/config.json').with_ensure('absent') }
       it { should contain_user('sensu') }
       it { should contain_group('sensu') }
@@ -152,6 +160,19 @@ describe 'sensu' do
         ) }
       end
 
+    end
+
+    context 'purge_scripts' do
+      let(:params) { { :purge_scripts => true } }
+
+      [ '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
+        '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ].each do |dir|
+        it { should contain_file(dir).with(
+          :ensure  => 'directory',
+          :recurse => true,
+          :purge   => true
+        ) }
+      end
     end
   end
 

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -8,18 +8,13 @@ describe 'sensu' do
       it { should create_class('sensu::package') }
       it { should contain_package('sensu').with_ensure('latest') }
       it { should contain_file('/etc/default/sensu') }
-      [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks' ].each do |dir|
+      [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks',
+        '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
+        '/etc/sensu/extensions/handlers', '/etc/sensu/plugins'].each do |dir|
         it { should contain_file(dir).with(
           :ensure => 'directory',
-          :purge  => false
-        ) }
-      end
-      [ '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
-        '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ].each do |dir|
-        it { should contain_file(dir).with(
-          :ensure  => 'directory',
           :recurse => true,
-          :purge   => false
+          :purge  => false
         ) }
       end
       it { should contain_file('/etc/sensu/config.json').with_ensure('absent') }
@@ -159,11 +154,6 @@ describe 'sensu' do
           :force   => true
         ) }
       end
-
-    end
-
-    context 'purge_scripts' do
-      let(:params) { { :purge_scripts => true } }
 
       [ '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
         '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ].each do |dir|

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -146,21 +146,14 @@ describe 'sensu' do
     context 'purge_config' do
       let(:params) { { :purge_config => true } }
 
-      [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks' ].each do |dir|
+      [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks',
+        '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
+        '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ].each do |dir|
         it { should contain_file(dir).with(
           :ensure  => 'directory',
           :purge   => true,
           :recurse => true,
           :force   => true
-        ) }
-      end
-
-      [ '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
-        '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ].each do |dir|
-        it { should contain_file(dir).with(
-          :ensure  => 'directory',
-          :recurse => true,
-          :purge   => true
         ) }
       end
     end


### PR DESCRIPTION
The default behaviour is not to purge, matching the existing behaviour.

Currently if I remove a `sensu::plugin`, `sensu::handler` or `sensu::extension` definition, the plugin/handler/extension remains on disk. This parameter allows these to be removed automatically when they are removed from puppet.

NB: there is currently a `purge` setting on `sensu::plugin` which is supposed to do this, but it only works if the `sensu::manage_plugins_dir` parameter is set to `false` - if `sensu::manage_plugins_dir` is `true`, `sensu::package` manages `/etc/sensu/plugins` and doesn't set the `purge` parameter.