### PR TITLE
Sort array properties before comparison

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -38,10 +38,16 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:dependencies, :array_matching => :all) do
     desc "Dependencies of this check"
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:handlers, :array_matching => :all) do
     desc "List of handlers that responds to this check"
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:high_flap_threshold) do
@@ -71,6 +77,9 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:subscribers, :array_matching => :all) do
     desc "Who is subscribed to this check"
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:custom) do

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -41,6 +41,9 @@ Puppet::Type.newtype(:sensu_client_config) do
 
   newproperty(:subscriptions, :array_matching => :all) do
     desc ""
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:bind) do

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -70,14 +70,23 @@ Puppet::Type.newtype(:sensu_handler) do
 
   newproperty(:filters, :array_matching => :all) do
     desc "Handler filters"
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:severities, :array_matching => :all) do
     desc "Severities applicable to this handler"
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:handlers, :array_matching => :all) do
     desc "Handlers this handler mutexes into"
+    def insync?(is)
+      is.sort == should.sort
+    end
   end
 
   newproperty(:config) do


### PR DESCRIPTION
The order of properties can be different when a catalog is compiled by a
different puppet master (i.e. clustered puppet masters).

Sorting in the type should prevent resources from being updated just to
change the sort order of an array.