### PR TITLE
notify sensu-api when check config is changed

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -13,6 +13,7 @@ Puppet::Type.newtype(:sensu_check) do
     self[:notify] = [
       "Service[sensu-client]",
       "Service[sensu-server]",
+      "Service[sensu-api]",
     ].select { |ref| catalog.resource(ref) }
   end
 


### PR DESCRIPTION
I'm new to Sensu but I think that sensu-api should be restarted when check config changes. Otherwise, I cannot see my updated check command in the dashboard.

I expected that if $api is true, sensu_check would notify Class['sensu-api'] based on $::sensu::check_notify and the sensu-api service would be restarted when checks are changed or added. This is not happening.

From what I can tell, the notify targets are actually set in sensu_check.rb. I added sensu-api to the list and it is now working correctly for me. If there is a better way to fix this problem, please reject this request and I will file an issue.

thanks,
Joe