### PR TITLE
Fix dependency chain when deploy plugins directory

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -100,6 +100,7 @@ define sensu::plugin(
         recurse => $recurse,
         purge   => $purge,
         force   => $force,
+        require => Package['sensu'],
       }
     }
     'package':    {


### PR DESCRIPTION
When deploying a whole directory of plugins, the module wasn't ensuring that the sensu package was already installed.