### PR TITLE
Keepalived config not merged since you are specifying the json in the puppet hash variable

### DIFF
--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -99,8 +99,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
   end
 
   def keepalive=(value)
-    conf['client']['keepalive'] ||= {}
-    conf['client']['keepalive'].merge!(to_type(value))
+    conf['client']['keepalive'] = value
   end
 
   def safe_mode


### PR DESCRIPTION
I think the config json shouldn't be merged, but just applied as it is because you are defining the actual hash in the puppet variable. Why?
Because i've been having this issue:

This was my client config file
```json
{
  "client": {
    "name": "myhost",
    "address": "123.123.123.123",
    "bind": "127.0.0.1",
    "keepalive": {
      "extra_useless_parameter": 100,
      "thresholds": {
        "warning": 300,
        "critical": 600
      },
      "handlers": [
        "default",
        "mailer"
      ],
      "occurrences": 5,
      "refresh": 2702
    },
  }
}
```

I wanted to remove that "extra_useless_parameter", so i removed it in puppet. This sensu-puppet module is aware that the config file values changed, so it notifies the sensu service and provokes a restart.
So far, so good, the problem is that the "sensu_client_config" resource that you created, is not removing that "extra_useless_value" because is doing a json merge between the old config file and the new values, therefore the state of the config file is exactly the same as the previous one. This is causing that everytime puppet runs, it notifies the sensu service and restart it forever and ever.