### PR TITLE
Fix redis noauth

### DIFF
--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -22,7 +22,7 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
     conf['redis'] = {}
     self.port     = resource[:port]
     self.host     = resource[:host]
-    self.password = resource[:password]
+    self.password = resource[:password] unless resource[:password].nil?
   end
 
   def config_file

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -120,7 +120,7 @@
 #
 # [*redis_password*]
 #   String.  Password to be used to connect to Redis
-#   Default: ''
+#   Default: undef
 #
 # [*api_bind*]
 #   String.  IP to bind api service
@@ -223,7 +223,7 @@ class sensu (
   $rabbitmq_ssl_cert_chain  = undef,
   $redis_host               = 'localhost',
   $redis_port               = 6379,
-  $redis_password           = '',
+  $redis_password           = undef,
   $api_bind                 = '0.0.0.0',
   $api_host                 = 'localhost',
   $api_port                 = 4567,


### PR DESCRIPTION
Commit 9ece56f8 adds support for Redis authentication, but breaks previously working setups, because Sensu now tries to authenticate with an empty password if none was specified.

This commit means that existing setups will continue to function, but allows Redis authentication to be used if desired.