### PR TITLE
Also allow rabbitmq_ssl_private_key to accept the key itself (or a varialbe contianing the key) or a value in hiera; in this case, the will be written to a file.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -101,9 +101,10 @@
 #   Defaul: false
 #
 # [*rabbitmq_ssl_private_key*]
-#   String.  Private key to be used by sensu to connect to rabbitmq
-#     If the value starts with 'puppet://' the file will be copied and used.  The key itself can be
-#     defined inline or using hiera.  Absolute paths will just be used
+#   String.  Private key to be used by sensu to connect to rabbitmq. If the value starts with
+#     'puppet://' the file will be copied and used.  Also the key itself can be given as the
+#     parameter value, or a variable, or using hiera.  Absolute paths will just be used as
+#     a file reference, as you'd normally configure sensu.
 #   Default: undef
 #
 # [*rabbitmq_ssl_cert_chain*]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -102,7 +102,8 @@
 #
 # [*rabbitmq_ssl_private_key*]
 #   String.  Private key to be used by sensu to connect to rabbitmq
-#     If the value starts with 'puppet://' the file will be copied and used.  Absolute paths will just be used
+#     If the value starts with 'puppet://' the file will be copied and used.  The key itself can be
+#     defined inline or using hiera.  Absolute paths will just be used
 #   Default: undef
 #
 # [*rabbitmq_ssl_cert_chain*]

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -49,7 +49,19 @@ class sensu::rabbitmq::config {
         require => File['/etc/sensu/ssl'],
         before  => Sensu_rabbitmq_config[$::fqdn],
       }
+    } else if $sensu::rabbitmq_ssl_private_key and $sensu::rabbitmq_ssl_private_key =~ /BEGIN RSA PRIVATE KEY/ {
+      file { '/etc/sensu/ssl/key.pem':
+        ensure  => present,
+        content => $sensu::rabbitmq_ssl_private_key,
+        owner   => 'sensu',
+        group   => 'sensu',
+        mode    => '0440',
+        require => File['/etc/sensu/ssl'],
+        before  => Sensu_rabbitmq_config[$::fqdn],
+      }
+    }
 
+    if $sensu::rabbitmq_ssl_private_key and ($sensu::rabbitmq_ssl_private_key =~ /^puppet:\/\// or $sensu::rabbitmq_ssl_private_key =~ /BEGIN RSA PRIVATE KEY/) {
       $ssl_private_key = '/etc/sensu/ssl/key.pem'
     } else {
       $ssl_private_key = $sensu::rabbitmq_ssl_private_key


### PR DESCRIPTION
This should retain the current functionality and add the option to use heira, a variable containing the key, or a string with the key itself.  Any of these three options would cause the key.pem file to be written with the value given.
