### PR TITLE
add option to purge plugins directory

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -239,7 +239,7 @@ class sensu (
   $plugins                  = [],
   $plugins_dir              = undef,
   $purge_config             = false,
-  $purge_plugins_dir        = true,
+  $purge_plugins_dir        = false,
   $use_embedded_ruby        = false,
   $rubyopt                  = '',
   $gem_path                 = '',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -239,6 +239,7 @@ class sensu (
   $plugins                  = [],
   $plugins_dir              = undef,
   $purge_config             = false,
+  $purge_plugins_dir        = true,
   $use_embedded_ruby        = false,
   $rubyopt                  = '',
   $gem_path                 = '',

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -84,6 +84,9 @@ class sensu::package {
       mode    => '0555',
       owner   => 'sensu',
       group   => 'sensu',
+      purge   => $sensu::purge_plugins_dir,
+      recurse => true,
+      force   => true,
       require => Package['sensu'],
     }
   }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -17,6 +17,7 @@ describe 'sensu' do
       it { should contain_file('/etc/sensu/config.json').with_ensure('absent') }
       it { should contain_user('sensu') }
       it { should contain_group('sensu') }
+      it { should contain_file('/etc/sensu/plugins').with_purge(false) }
     end
 
     context 'setting version' do
@@ -146,6 +147,15 @@ describe 'sensu' do
       [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks' ].each do |dir|
         it { should contain_file(dir).with(
           :ensure  => 'directory',
+          :purge   => true,
+          :recurse => true,
+          :force   => true
+        ) }
+      end
+
+      context 'purge_plugins_dir' do
+        let(:params) { { :purge_plugins_dir => true } }
+        it { should contain_file('/etc/sensu/plugins').with(
           :purge   => true,
           :recurse => true,
           :force   => true


### PR DESCRIPTION
/etc/sensu/plugins is not purged by puppet even when manage manage_plugins_dir is set to true. This seems very counterintuitive to me.