### PR TITLE
to_type convert :undef into string

### DIFF
--- a/lib/puppet_x/sensu/to_type.rb
+++ b/lib/puppet_x/sensu/to_type.rb
@@ -14,6 +14,8 @@ module Puppet_X
             true
           when false, 'false', 'False', :false
             false
+          when :undef
+            'undef'
           when /^([0-9])+$/
             value.to_i
           else


### PR DESCRIPTION
i'm not digging too much into why puppet is inconsistent with the `@should` variable between client/server and standalone modes, but that's how it is. `@should` contains :undef as a symbol and that makes bunch of types not in sync because values read from json never contain ruby symbols.