### PR TITLE
Correct api_password type description

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,7 +138,7 @@
 #   Default: undef
 #
 # [*api_password*]
-#   Integer. Password of the sensu api service
+#   String. Password of the sensu api service
 #   Default: undef
 #
 # [*subscriptions*]


### PR DESCRIPTION
Change from Integer to String.  Minor.