### PR TITLE
Fix typo in api_password type

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -138,7 +138,7 @@
 #   Default: undef
 #
 # [*api_password*]
-#   Integer. Password of the sensu api service
+#   String. Password of the sensu api service
 #   Default: undef
 #
 # [*subscriptions*]


### PR DESCRIPTION
Change api_password type from Integer to String.