### PR TITLE
Restrict access to the client config file to protect client tokens

### DIFF
--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -18,7 +18,7 @@ class sensu::client::config {
     ensure => $ensure,
     owner  => 'sensu',
     group  => 'sensu',
-    mode   => '0444',
+    mode   => '0440',
   }
 
   sensu_client_config { $::fqdn:


### PR DESCRIPTION
When using command token substitution we put passwords in the client
config file.  In order to properly protect the passwords this file
must not be world readable.