### PR TITLE
Fix #318: Introducing custom uninstall in sensu_gem

### DIFF
--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -12,4 +12,14 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
   has_feature :versionable, :install_options
 
   commands :gemcmd => "/opt/sensu/embedded/bin/gem"
+
+  def uninstall
+    command = [command(:gemcmd), "uninstall"]
+    command << "-x" << "-a" << resource[:name]
+    output = execute(command)
+
+    # Apparently some stupid gem versions don't exit non-0 on failure
+    self.fail "Could not uninstall: #{output.chomp}" if output.include?("ERROR")
+  end
+
 end


### PR DESCRIPTION
sensu_gem inherits the methods from its parent, gem.rb.

The uninstall method in gem.rb contains a bug that prevents the right gem command from being issued. `/usr/bin/gem uninstall -x -a sensu-plugin` is executed instead of `/opt/sensu/embedded/bin/gem
uninstall -x -a sensu-plugin`.

Issue [PUP-4191](https://tickets.puppetlabs.com/browse/PUP-4191) has been raised in the puppet project and [PR #3708](https://github.com/puppetlabs/puppet/pull/3708) has been opened in puppetlabs/puppet.

As temporary workaround, we should overwrite the gem.rb uninstall method to use the execute function, which then issues the right gem command.

This produces an idempotent puppet run.
Before this fix was applied, puppet was constantly attempting to remove `sensu-plugin` from the system gem (/usr/bin/gem), producing the following output during every single puppet run:

```
Notice: Compiled catalog for monitoring.vagrant in environment production in 9.62 seconds
Notice: /Stage[main]/Sensu::Package/Package[sensu-plugin]/ensure: removed
Notice: /Stage[main]/Sensu::Client::Service/Service[sensu-client]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Sensu::Api::Service/Service[sensu-api]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Sensu::Server::Service/Service[sensu-server]: Triggered 'refresh' from 1 events
Notice: Finished catalog run in 39.52 seconds
```

After applying the fix, a clean puppet run is produced:

```
Notice: Compiled catalog for monitoring.vagrant in environment production in 9.80 seconds
Notice: Finished catalog run in 29.02 seconds
```