### PR TITLE
Add support for :reconnect_on_error.

### DIFF
--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -28,6 +28,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
     self.user = resource[:user]
     self.password = resource[:password]
     self.vhost = resource[:vhost]
+    self.reconnect_on_error = resource[:reconnect_on_error] unless resource[:reconnect_on_error].nil?
   end
 
   def destroy
@@ -140,5 +141,13 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
 
   def vhost=(value)
     conf['rabbitmq']['vhost'] = value
+  end
+
+  def reconnect_on_error
+    conf['rabbitmq']['reconnect_on_error']
+  end
+
+  def reconnect_on_error=(value)
+    conf['rabbitmq']['reconnect_on_error'] = (value ? true : false)
   end
 end

--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -20,9 +20,10 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
 
   def create
     conf['redis'] = {}
-    self.port     = resource[:port]
-    self.host     = resource[:host]
+    self.port = resource[:port]
+    self.host = resource[:host]
     self.password = resource[:password] unless resource[:password].nil?
+    self.reconnect_on_error = resource[:reconnect_on_error] unless resource[:reconnect_on_error].nil?
   end
 
   def config_file
@@ -59,5 +60,13 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
 
   def password=(value)
     conf['redis']['password'] = value
+  end
+
+  def reconnect_on_error
+    conf['redis']['reconnect_on_error']
+  end
+
+  def reconnect_on_error=(value)
+    conf['redis']['reconnect_on_error'] = (value ? true : false)
   end
 end

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -79,6 +79,13 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
     defaultto 'sensu'
   end
 
+  newproperty(:reconnect_on_error, :boolean => true) do
+    desc "Attempt to reconnect to RabbitMQ on error"
+
+    newvalues(true, false)
+    defaultto false
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -47,6 +47,13 @@ Puppet::Type.newtype(:sensu_redis_config) do
     desc "The password used to connect to Redis"
   end
 
+  newproperty(:reconnect_on_error, :boolean => true) do
+    desc "Attempt to reconnect to RabbitMQ on error"
+
+    newvalues(true, false)
+    defaultto false
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -70,15 +70,16 @@ class sensu::rabbitmq::config {
   }
 
   sensu_rabbitmq_config { $::fqdn:
-    ensure          => $ensure,
-    port            => $sensu::rabbitmq_port,
-    host            => $sensu::rabbitmq_host,
-    user            => $sensu::rabbitmq_user,
-    password        => $sensu::rabbitmq_password,
-    vhost           => $sensu::rabbitmq_vhost,
-    ssl_transport   => $enable_ssl,
-    ssl_cert_chain  => $ssl_cert_chain,
-    ssl_private_key => $ssl_private_key,
+    ensure             => $ensure,
+    port               => $sensu::rabbitmq_port,
+    host               => $sensu::rabbitmq_host,
+    user               => $sensu::rabbitmq_user,
+    password           => $sensu::rabbitmq_password,
+    vhost              => $sensu::rabbitmq_vhost,
+    ssl_transport      => $enable_ssl,
+    ssl_cert_chain     => $ssl_cert_chain,
+    ssl_private_key    => $ssl_private_key,
+    reconnect_on_error => $sensu::rabbitmq_reconnect_on_error,
   }
 
 }

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -22,10 +22,11 @@ class sensu::redis::config {
   }
 
   sensu_redis_config { $::fqdn:
-    ensure   => $ensure,
-    host     => $sensu::redis_host,
-    port     => $sensu::redis_port,
-    password => $sensu::redis_password,
+    ensure             => $ensure,
+    host               => $sensu::redis_host,
+    port               => $sensu::redis_port,
+    password           => $sensu::redis_password,
+    reconnect_on_error => $sensu::redis_reconnect_on_error,
   }
 
 }


### PR DESCRIPTION
Added properties for both Redis and RabbitMQ types to enable support for the new :reconnect_on_error option in Sensu 1.7.0.