### PR TITLE
Fix issue with array checking when no array present.

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -82,7 +82,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def handlers
-    conf['checks'][resource[:name]]['handlers']
+    conf['checks'][resource[:name]]['handlers'] || []
   end
 
   def handlers=(value)
@@ -113,7 +113,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def dependencies
-    conf['checks'][resource[:name]]['dependencies']
+    conf['checks'][resource[:name]]['dependencies'] || []
   end
 
   def dependencies=(value)


### PR DESCRIPTION
The introduction of `issync?` in the `sensu_check` type for the handlers and dependencies properties introduced an assumption that the values sourced are always arrays, yet `:array_matching` is set.

In the event that an empty array is passed to the property within Puppet, Puppet will match this against an non-existing (`nil`) value and so will not write out the key/value pair on flush. When re-reading the file to analyze for changes, a `nil` value is loaded in return, but a `NilClass` has no `sort` method and so compilation of the catalog fails.

This change sets the defaults within the type's JSON provider to always return an empty array unless something else is configured, preventing the `issync?` method from raising an exception on `NilClass`es.