### PR TITLE
Add install_options for (sensu-)gem provider(s)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -219,6 +219,13 @@
 #   Integer.  Number of seconds to wait for the init stop script to run
 #   Default: 10
 #
+# [*gem_install_options*]
+#   Optional configuration to use for the installation of the
+#   sensu plugin gem with sensu_gem provider.
+#   See: https://docs.puppetlabs.com/references/latest/type.html#package-attribute-install_options
+#   Default: undef
+#   Example value: [{ '-p' => 'http://user:pass@myproxy.company.org:8080' }]
+#
 class sensu (
   $version                     = 'latest',
   $sensu_plugin_name           = 'sensu-plugin',
@@ -271,6 +278,7 @@ class sensu (
   $log_level                   = 'info',
   $dashboard                   = false,
   $init_stop_max_wait          = 10,
+  $gem_install_options         = undef,
 ){
 
   validate_bool($client, $server, $api, $install_repo, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error)

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -45,9 +45,17 @@ class sensu::package {
     }
   }
 
-  package { $::sensu::sensu_plugin_name :
-    ensure   => $sensu::sensu_plugin_version,
-    provider => $plugin_provider,
+  if $plugin_provider =~ /gem/ and $::sensu::gem_install_options {
+    package { $::sensu::sensu_plugin_name :
+      ensure          => $sensu::sensu_plugin_version,
+      provider        => $plugin_provider,
+      install_options => $::sensu::gem_install_options,
+    }
+  } else {
+    package { $::sensu::sensu_plugin_name :
+      ensure   => $sensu::sensu_plugin_version,
+      provider => $plugin_provider,
+    }
   }
 
   file { '/etc/default/sensu':


### PR DESCRIPTION
This is a proposed solution for issue #339, which allows to pass install_options to the parent gem provider.