### PR TITLE
Boolean properties and misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ before_install:
   - gem update --system 2.1.11
   - gem --version
 env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.1.0"
-  - PUPPET_VERSION="~> 3.2.0"
   - PUPPET_VERSION="~> 3.3.0"
   - PUPPET_VERSION="~> 3.4.0"
   - PUPPET_VERSION="~> 3.5.0"
@@ -23,20 +20,6 @@ env:
   - PUPPET_VERSION="~> 3.7.0"
 matrix:
   exclude:
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.0.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.2.0"
     - rvm: 2.1.0
       env: PUPPET_VERSION="~> 3.3.0"
     - rvm: 2.1.0

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ end
 if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else
-  gem 'puppet', '< 4.0.0', :require => false
+  gem 'puppet', '>= 3.3.0', '< 4.0.0', :require => false
 end
 
 # vim:ft=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ end
 if puppetversion = ENV['PUPPET_GEM_VERSION']
   gem 'puppet', puppetversion, :require => false
 else
-  gem 'puppet', :require => false
+  gem 'puppet', '< 4.0.0', :require => false
 end
 
 # vim:ft=ruby

--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -167,14 +167,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def aggregate
-    case conf['checks'][resource[:name]]['aggregate']
-    when true
-      :true
-    when false
-      :false
-    else
-      conf['checks'][resource[:name]]['aggregate']
-    end
+    conf['checks'][resource[:name]]['aggregate']
   end
 
   def aggregate=(value)
@@ -189,71 +182,31 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def handle
-    case conf['checks'][resource[:name]]['handle']
-    when true
-      :true
-    when false
-      :false
-    else
-      conf['checks'][resource[:name]]['handle']
-    end
+    conf['checks'][resource[:name]]['handle']
   end
 
   def handle=(value)
-    case value
-    when true, 'true', 'True', :true, 1 && resource[:handlers]
+    if value && resource[:handlers]
       Puppet.notice("Do not use 'handle' and 'handlers' together. Your 'handle' value has been overridden with 'handlers'")
       return
-    when true, 'true', 'True', :true, 1
-      conf['checks'][resource[:name]]['handle'] = true
-    when false, 'false', 'False', :false, 0
-      conf['checks'][resource[:name]]['handle'] = false
-    else
-      conf['checks'][resource[:name]]['handle'] = value
     end
+
+    conf['checks'][resource[:name]]['handle'] = value
   end
 
   def publish
-    case conf['checks'][resource[:name]]['publish']
-    when true
-      :true
-    when false
-      :false
-    else
-      conf['checks'][resource[:name]]['publish']
-    end
+    conf['checks'][resource[:name]]['publish']
   end
 
   def publish=(value)
-    case value
-    when true, 'true', 'True', :true, 1
-      conf['checks'][resource[:name]]['publish'] = true
-    when false, 'false', 'False', :false, 0
-      conf['checks'][resource[:name]]['publish'] = false
-    else
-      conf['checks'][resource[:name]]['publish'] = value
-    end
+    conf['checks'][resource[:name]]['publish'] = value
   end
 
   def standalone
-    case conf['checks'][resource[:name]]['standalone']
-    when true
-      :true
-    when false
-      :false
-    else
-      conf['checks'][resource[:name]]['standalone']
-    end
+    conf['checks'][resource[:name]]['standalone']
   end
 
   def standalone=(value)
-    case value
-    when true, 'true', 'True', :true, 1
-      conf['checks'][resource[:name]]['standalone'] = true
-    when false, 'false', 'False', :false, 0
-      conf['checks'][resource[:name]]['standalone'] = false
-    else
-      conf['checks'][resource[:name]]['standalone'] = value
-    end
+    conf['checks'][resource[:name]]['standalone'] = value
   end
 end

--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -35,6 +35,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
     self.client_name = resource[:client_name]
     self.address = resource[:address]
     self.bind = resource[:bind]
+    self.port = resource[:port]
     self.subscriptions = resource[:subscriptions]
     self.safe_mode = resource[:safe_mode]
     self.custom = resource[:custom] unless resource[:custom].nil?

--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -111,23 +111,11 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
   end
 
   def safe_mode
-    case conf['client']['safe_mode']
-    when true
-      :true
-    when false
-      :false
-    else
-      conf['client']['safe_mode']
-    end
+    conf['client']['safe_mode']
   end
 
   def safe_mode=(value)
-    case value
-    when true, 'true', 'True', :true, 1
-      conf['client']['safe_mode'] = true
-    else
-      conf['client']['safe_mode'] = false
-    end
+    conf['client']['safe_mode'] = value
   end
 
 end

--- a/lib/puppet/provider/sensu_filter/json.rb
+++ b/lib/puppet/provider/sensu_filter/json.rb
@@ -46,21 +46,11 @@ Puppet::Type.type(:sensu_filter).provide(:json) do
   end
 
   def negate
-    case conf['filters'][resource[:name]]['negate']
-    when true
-      :true
-    else
-      :false
-    end
+    conf['filters'][resource[:name]]['negate']
   end
 
   def negate=(value)
-    case value
-    when true, 'true', 'True', :true, 1
-      conf['filters'][resource[:name]]['negate'] = true
-    else
-      conf['filters'][resource[:name]]['negate'] = false
-    end
+    conf['filters'][resource[:name]]['negate'] = value
   end
 
   def attributes

--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -28,7 +28,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
     self.user = resource[:user]
     self.password = resource[:password]
     self.vhost = resource[:vhost]
-    self.reconnect_on_error = resource[:reconnect_on_error] unless resource[:reconnect_on_error].nil?
+    self.reconnect_on_error = resource[:reconnect_on_error]
   end
 
   def destroy
@@ -144,22 +144,10 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def reconnect_on_error
-    case conf['rabbitmq']['reconnect_on_error']
-    when true
-      :true
-    when false
-      :false
-    else
-      conf['rabbitmq']['reconnect_on_error']
-    end
+    conf['rabbitmq']['reconnect_on_error']
   end
 
   def reconnect_on_error=(value)
-    case value
-    when true, 'true', 'True', :true, 1
-      conf['rabbitmq']['reconnect_on_error'] = true
-    else
-      conf['rabbitmq']['reconnect_on_error'] = false
-    end
+     conf['rabbitmq']['reconnect_on_error'] = value
   end
 end

--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -23,7 +23,7 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
     self.port = resource[:port]
     self.host = resource[:host]
     self.password = resource[:password] unless resource[:password].nil?
-    self.reconnect_on_error = resource[:reconnect_on_error] unless resource[:reconnect_on_error].nil?
+    self.reconnect_on_error = resource[:reconnect_on_error]
   end
 
   def config_file
@@ -63,22 +63,10 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
   end
 
   def reconnect_on_error
-    case conf['redis']['reconnect_on_error']
-    when true
-      :true
-    when false
-      :false
-    else
-      conf['redis']['reconnect_on_error']
-    end
+    conf['redis']['reconnect_on_error']
   end
 
   def reconnect_on_error=(value)
-    case value
-    when true, 'true', 'True', :true, 1
-      conf['redis']['reconnect_on_error'] = true
-    else
-      conf['redis']['reconnect_on_error'] = false
-    end
+    conf['redis']['reconnect_on_error'] = value
   end
 end

--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:sensu_api_config) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-api]",

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -1,3 +1,5 @@
+require 'puppet/property/boolean'
+
 begin
   require 'puppet_x/sensu/to_type'
 rescue LoadError => e
@@ -113,32 +115,24 @@ Puppet::Type.newtype(:sensu_check) do
     desc "What type of check is this"
   end
 
-  newproperty(:standalone) do
+  newproperty(:standalone, :parent => Puppet::Property::Boolean) do
     desc "Whether this is a standalone check"
-
-    newvalues(:true, :false)
   end
 
   newproperty(:timeout) do
     desc "Check timeout in seconds, after it fails"
   end
 
-  newproperty(:aggregate) do
+  newproperty(:aggregate, :parent => Puppet::Property::Boolean) do
     desc "Whether check is aggregate"
-
-    newvalues(:true, :false)
   end
 
-  newproperty(:handle) do
+  newproperty(:handle, :parent => Puppet::Property::Boolean) do
     desc "Whether check event send to a handler"
-
-    newvalues(:true, :false)
   end
 
-  newproperty(:publish) do
+  newproperty(:publish, :parent => Puppet::Property::Boolean) do
     desc "Whether check is unpublished"
-
-    newvalues(:true, :false)
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:sensu_check) do
     desc "What type of check is this"
   end
 
-  newproperty(:standalone, :boolean => true) do
+  newproperty(:standalone) do
     desc "Whether this is a standalone check"
 
     newvalues(:true, :false)
@@ -123,19 +123,19 @@ Puppet::Type.newtype(:sensu_check) do
     desc "Check timeout in seconds, after it fails"
   end
 
-  newproperty(:aggregate, :boolean => true) do
+  newproperty(:aggregate) do
     desc "Whether check is aggregate"
 
     newvalues(:true, :false)
   end
 
-  newproperty(:handle, :boolean => true) do
+  newproperty(:handle) do
     desc "Whether check event send to a handler"
 
     newvalues(:true, :false)
   end
 
-  newproperty(:publish, :boolean => true) do
+  newproperty(:publish) do
     desc "Whether check is unpublished"
 
     newvalues(:true, :false)

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -8,7 +8,7 @@ Puppet::Type.newtype(:sensu_check) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-client]",

--- a/lib/puppet/type/sensu_check_config.rb
+++ b/lib/puppet/type/sensu_check_config.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:sensu_check_config) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-client]",

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -61,7 +61,7 @@ Puppet::Type.newtype(:sensu_client_config) do
     defaultto '/etc/sensu/conf.d/'
   end
 
-  newproperty(:safe_mode, :boolean => true) do
+  newproperty(:safe_mode) do
     desc "Require checks to be defined on server and client"
     newvalues(:true, :false)
   end

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -8,7 +8,7 @@ Puppet::Type.newtype(:sensu_client_config) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-client]",

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -1,3 +1,5 @@
+require 'puppet/property/boolean'
+
 begin
   require 'puppet_x/sensu/to_type'
 rescue LoadError => e
@@ -61,9 +63,10 @@ Puppet::Type.newtype(:sensu_client_config) do
     defaultto '/etc/sensu/conf.d/'
   end
 
-  newproperty(:safe_mode) do
+  newproperty(:safe_mode, :parent => Puppet::Property::Boolean) do
     desc "Require checks to be defined on server and client"
-    newvalues(:true, :false)
+
+    defaultto :false # property assumed as managed in provider (no nil? checks)
   end
 
   newproperty(:custom) do

--- a/lib/puppet/type/sensu_client_subscription.rb
+++ b/lib/puppet/type/sensu_client_subscription.rb
@@ -8,7 +8,7 @@ Puppet::Type.newtype(:sensu_client_subscription) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-client]",

--- a/lib/puppet/type/sensu_extension.rb
+++ b/lib/puppet/type/sensu_extension.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:sensu_extension) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-api]",

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -1,3 +1,5 @@
+require 'puppet/property/boolean'
+
 begin
   require 'puppet_x/sensu/to_type'
 rescue LoadError => e
@@ -56,10 +58,10 @@ Puppet::Type.newtype(:sensu_filter) do
     defaultto {}
   end
 
-  newproperty(:negate) do
+  newproperty(:negate, :parent => Puppet::Property::Boolean) do
     desc ""
 
-    newvalues(:true, :false)
+    defaultto :false # provider assumes it's managed
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -56,7 +56,7 @@ Puppet::Type.newtype(:sensu_filter) do
     defaultto {}
   end
 
-  newproperty(:negate, :boolean => true) do
+  newproperty(:negate) do
     desc ""
 
     newvalues(:true, :false)

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -7,10 +7,6 @@ end
 Puppet::Type.newtype(:sensu_filter) do
   @doc = ""
 
-  def initialize(*args)
-    super
-  end
-
   ensurable do
     newvalue(:present) do
       provider.create

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:sensu_handler) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-server]",

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -35,7 +35,6 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   newproperty(:ssl_transport) do
     desc "Enable SSL transport to connect to RabbitMQ"
 
-    newvalues(true, false)
     defaultto false
   end
 
@@ -82,7 +81,6 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   newproperty(:reconnect_on_error) do
     desc "Attempt to reconnect to RabbitMQ on error"
 
-    newvalues(:true, :false)
     defaultto :false
   end
 

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -32,7 +32,7 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
     defaultto '/etc/sensu/conf.d/'
   end
 
-  newproperty(:ssl_transport, :boolean => true) do
+  newproperty(:ssl_transport) do
     desc "Enable SSL transport to connect to RabbitMQ"
 
     newvalues(true, false)
@@ -79,7 +79,7 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
     defaultto 'sensu'
   end
 
-  newproperty(:reconnect_on_error, :boolean => true) do
+  newproperty(:reconnect_on_error) do
     desc "Attempt to reconnect to RabbitMQ on error"
 
     newvalues(:true, :false)

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-server]",

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -2,7 +2,7 @@ Puppet::Type.newtype(:sensu_redis_config) do
   @doc = ""
 
   def initialize(*args)
-    super
+    super *args
 
     self[:notify] = [
       "Service[sensu-api]",

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -1,3 +1,5 @@
+require 'puppet/property/boolean'
+
 Puppet::Type.newtype(:sensu_redis_config) do
   @doc = ""
 
@@ -47,11 +49,11 @@ Puppet::Type.newtype(:sensu_redis_config) do
     desc "The password used to connect to Redis"
   end
 
-  newproperty(:reconnect_on_error) do
+  newproperty(:reconnect_on_error, :parent => Puppet::Property::Boolean) do
     desc "Attempt to reconnect to RabbitMQ on error"
 
-    newvalues(:true, :false)
-    defaultto :false
+    defaultto :false # not boolean since puppet ignores non-truthy defaults
+                     # will still be munged to boolean
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -47,7 +47,7 @@ Puppet::Type.newtype(:sensu_redis_config) do
     desc "The password used to connect to Redis"
   end
 
-  newproperty(:reconnect_on_error, :boolean => true) do
+  newproperty(:reconnect_on_error) do
     desc "Attempt to reconnect to RabbitMQ on error"
 
     newvalues(:true, :false)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,7 +38,7 @@
 
 # [*repo_key_id*]
 #   String.  The apt GPG key id
-#   Default: 7580C77F
+#   Default: 8911D8FF37778F24B4E726A218609E3D7580C77F
 #
 # [*repo_key_source*]
 #   String.  URL of the apt GPG key
@@ -227,7 +227,7 @@ class sensu (
   $install_repo                = true,
   $repo                        = 'main',
   $repo_source                 = undef,
-  $repo_key_id                 = '7580C77F',
+  $repo_key_id                 = '8911D8FF37778F24B4E726A218609E3D7580C77F',
   $repo_key_source             = 'http://repos.sensuapp.org/apt/pubkey.gpg',
   $client                      = true,
   $server                      = false,

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -63,7 +63,7 @@ describe 'sensu' do
               :release     => 'sensu',
               :repos       => 'main',
               :include_src => false,
-              :key         => '7580C77F',
+              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
               :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg',
               :before      => 'Package[sensu]'
             ) }
@@ -79,7 +79,7 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with( :location => 'http://repo.mydomain.com/apt') }
 
             it { should_not contain_apt__key('sensu').with(
-              :key         => '7580C77F',
+              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
               :key_source  => 'http://repo.mydomain.com/apt/pubkey.gpg'
             ) }
           end
@@ -98,7 +98,7 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with_ensure('absent') }
 
             it { should_not contain_apt__key('sensu').with(
-              :key         => '7580C77F',
+              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
               :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg'
             ) }
 

--- a/spec/unit/sensu_redis_config_spec.rb
+++ b/spec/unit/sensu_redis_config_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_redis_config) do
+  provider_class = described_class.provider(:json)
+
+  let :resource_hash do
+    {
+        :title   => 'foo.example.com',
+        :catalog => Puppet::Resource::Catalog.new(),
+    }
+  end
+
+  let :type_instance do
+    result = described_class.new(resource_hash)
+    provider_instance = provider_class.new(resource_hash)
+    result.provider = provider_instance
+    result
+  end
+
+  describe 'reconnect_on_error property' do
+    it 'defaults to false' do
+      expect(type_instance[:reconnect_on_error]).to be false
+    end
+
+    [true, :true, 'true', 'True', :yes, 'yes'].each do |v|
+      it "accepts #{v.inspect} as true" do
+        type_instance[:reconnect_on_error] = v
+        expect(type_instance[:reconnect_on_error]).to be true
+      end
+    end
+
+    [false, :false, 'false', 'False', :no, 'no'].each do |v|
+      it "accepts #{v.inspect} as false" do
+        type_instance[:reconnect_on_error] = v
+        expect(type_instance[:reconnect_on_error]).to be false
+      end
+    end
+
+    it 'rejects "foobar" as a value' do
+      expect {
+        type_instance[:reconnect_on_error] = 'foobar'
+      }.to raise_error Puppet::Error, /expected a boolean value/
+    end
+
+  end
+
+
+end


### PR DESCRIPTION
As mentioned in https://github.com/sensu/sensu-puppet/commit/05999a605345ed49e455d6c92cbb34dc67fd3b85#commitcomment-10864529 , implement the boolean properties through a superclass.

Unfortunately, `Puppet::Parameter::Boolean` was only introduced in 3.3, so we must implement our own superclass. In the process, fixed some other issues.