### PR TITLE
Updating APT source to use new apt module version

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -24,14 +24,18 @@ class sensu::repo::apt {
     }
 
     apt::source { 'sensu':
-      ensure      => $ensure,
-      location    => $url,
-      release     => 'sensu',
-      repos       => $sensu::repo,
-      include_src => false,
-      key         => $sensu::repo_key_id,
-      key_source  => $sensu::repo_key_source,
-      before      => Package['sensu'],
+      ensure   => $ensure,
+      location => $url,
+      release  => 'sensu',
+      repos    => $sensu::repo,
+      include  => {
+        'src' => false,
+      },
+      key      => {
+        'id'     => $sensu::repo_key_id,
+        'source' => $sensu::repo_key_source,
+      },
+      before   => Package['sensu'],
     }
 
   } else {

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": [
     { "name": "maestrodev/wget", "version_requirement": ">= 1.4.5 <2.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.1 <2.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.1 <2.0.2" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
   ]
 }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -54,7 +54,7 @@ describe 'sensu' do
         let(:facts) { { :osfamily => 'Debian' } }
 
         context 'with puppet-apt installed' do
-          let(:pre_condition) { [ 'define apt::source ($ensure, $location, $release, $repos, $include_src, $key, $key_source) {}' ] }
+          let(:pre_condition) { [ 'define apt::source ($ensure, $location, $release, $repos, $include, $key) {}' ] }
 
           context 'default' do
             it { should contain_apt__source('sensu').with(
@@ -62,9 +62,8 @@ describe 'sensu' do
               :location    => 'http://repos.sensuapp.org/apt',
               :release     => 'sensu',
               :repos       => 'main',
-              :include_src => false,
-              :key         => '7580C77F',
-              :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg',
+              :include     => { 'src' => false },
+              :key         => { 'id'     => '7580C77F', 'source' => 'http://repos.sensuapp.org/apt/pubkey.gpg' },
               :before      => 'Package[sensu]'
             ) }
           end


### PR DESCRIPTION
New version of Puppet APT module was released the PR will fix this issue:
``` 
Puppet (err): Invalid parameter include_src on Apt::Source[sensu] at /etc/puppet/modules/sensu/manifests/repo/apt.pp:35
```