### PR TITLE
make apt class compliant with puppetlabs/apt

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -10,6 +10,8 @@ class sensu::repo::apt {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
+  include '::apt'
+
   if defined(apt::source) {
 
     $ensure = $sensu::install_repo ? {
@@ -24,14 +26,19 @@ class sensu::repo::apt {
     }
 
     apt::source { 'sensu':
-      ensure      => $ensure,
-      location    => $url,
-      release     => 'sensu',
-      repos       => $sensu::repo,
-      include_src => false,
-      key         => $sensu::repo_key_id,
-      key_source  => $sensu::repo_key_source,
-      before      => Package['sensu'],
+      ensure   => $ensure,
+      location => $url,
+      release  => 'sensu',
+      repos    => $sensu::repo,
+      key      => {
+        'id'     => $sensu::repo_key_id,
+        'source' => $sensu::repo_key_source,
+      },
+      include  => {
+        'src' => false,
+        'deb' => true,
+      },
+      before   => Package['sensu'],
     }
 
   } else {


### PR DESCRIPTION
I've got this error with the last version of puppetlabs/apt:
Error: Invalid parameter include_src on Apt::Source[sensu] at /srv/puppet/test/puppet/modules-ext/sensu/manifests/repo/apt.pp:35 on node lab07.xilopix.net
Wrapped exception:
Invalid parameter include_src

This commit fix it.