### PR TITLE
Update of apt::source to support new version of puppetlabs-apt

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -28,9 +28,10 @@ class sensu::repo::apt {
       location    => $url,
       release     => 'sensu',
       repos       => $sensu::repo,
-      include_src => false,
-      key         => $sensu::repo_key_id,
-      key_source  => $sensu::repo_key_source,
+      key         => {
+        id     => $sensu::repo_key_id,
+        source => $sensu::repo_key_source
+      },
       before      => Package['sensu'],
     }
 

--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": [
     { "name": "maestrodev/wget", "version_requirement": ">= 1.4.5 <2.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.1 <2.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 <3.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
   ]
 }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -63,8 +63,10 @@ describe 'sensu' do
               :release     => 'sensu',
               :repos       => 'main',
               :include_src => false,
-              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
-              :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg',
+              :key         => {
+                :id     => '8911D8FF37778F24B4E726A218609E3D7580C77F',
+                :source => 'http://repos.sensuapp.org/apt/pubkey.gpg'
+              },
               :before      => 'Package[sensu]'
             ) }
           end
@@ -79,8 +81,10 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with( :location => 'http://repo.mydomain.com/apt') }
 
             it { should_not contain_apt__key('sensu').with(
-              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
-              :key_source  => 'http://repo.mydomain.com/apt/pubkey.gpg'
+              :key         => {
+                :id     => '8911D8FF37778F24B4E726A218609E3D7580C77F',
+                :source => 'http://repos.sensuapp.org/apt/pubkey.gpg'
+              }
             ) }
           end
 
@@ -88,8 +92,10 @@ describe 'sensu' do
             let(:params) { { :repo_key_id => 'FFFFFFFF', :repo_key_source => 'http://repo.mydomina.com/apt/pubkey.gpg' } }
 
             it { should_not contain_apt__key('sensu').with(
-              :key         => 'FFFFFFFF',
-              :key_source  => 'http://repo.mydomain.com/apt/pubkey.gpg'
+              :key         => {
+                :id     => 'FFFFFFFF',
+                :source => 'http://repo.mydomain.com/apt/pubkey.gpg'
+              }
             ) }
           end
 
@@ -98,8 +104,10 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with_ensure('absent') }
 
             it { should_not contain_apt__key('sensu').with(
-              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
-              :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg'
+              :key         => {
+                :id     => '8911D8FF37778F24B4E726A218609E3D7580C77F',
+                :source => 'http://repos.sensuapp.org/apt/pubkey.gpg'
+              }
             ) }
 
             it { should contain_package('sensu').with( :require => nil ) }


### PR DESCRIPTION
This is needed for supporting new puppetlabs-apt module versions.