### PR TITLE
Ensure Package[sensu] is not already define

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -10,7 +10,7 @@ class sensu::repo::apt {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if defined(apt::source) {
+  if (defined(apt::source)) and (!defined(Apt::Source[sensu])) {
 
     $ensure = $sensu::install_repo ? {
       true    => 'present',
@@ -34,7 +34,7 @@ class sensu::repo::apt {
       before      => Package['sensu'],
     }
 
-  } else {
+  } elsif (!defined(Apt::Source[sensu])) {
     fail('This class requires puppetlabs-apt module')
   }
 


### PR DESCRIPTION
Because we can run both sensu-puppet and puppet-uchiwa recipe on the same host we should verify if the other package doesn't declare Package[sensu] before.