### PR TITLE
Filter attributes are a property, not a param

### DIFF
--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -27,9 +27,8 @@ Puppet::Type.newtype(:sensu_filter) do
     defaultto '/etc/sensu/conf.d/filters/'
   end
 
-  newparam(:attributes) do
-    desc ""
-
+  newproperty(:attributes) do
+    desc "Filter attributes"
     include PuppetX::Sensu::ToType
 
     def is_to_s(hash = @is)


### PR DESCRIPTION
Attributes for filters were not being added because parameters don't call methods.  Attributes for filters are now properties.