### PR TITLE
allow modification of hasrestart attribute for services

### DIFF
--- a/manifests/api/service.pp
+++ b/manifests/api/service.pp
@@ -2,7 +2,17 @@
 #
 # Manages the Sensu api service
 #
-class sensu::api::service {
+# == Parameters
+#
+# [*hasrestart*]
+#   Boolean. Value of hasrestart attribute for this service.
+#   Default: true
+#
+class sensu::api::service (
+  $hasrestart = true,
+) {
+
+  validate_bool($hasrestart)
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -24,7 +34,7 @@ class sensu::api::service {
     service { 'sensu-api':
       ensure     => $ensure,
       enable     => $enable,
-      hasrestart => true,
+      hasrestart => $hasrestart,
       subscribe  => [ Class['sensu::package'], Class['sensu::api::config'], Class['sensu::redis::config'] ]
     }
   }

--- a/manifests/client/service.pp
+++ b/manifests/client/service.pp
@@ -2,7 +2,17 @@
 #
 # Manages the Sensu client service
 #
-class sensu::client::service {
+# == Parameters
+#
+# [*hasrestart*]
+#   Bolean. Value of hasrestart attribute for this service.
+#   Default: true
+#
+class sensu::client::service (
+  $hasrestart = true,
+) {
+
+  validate_bool($hasrestart)
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -24,7 +34,7 @@ class sensu::client::service {
     service { 'sensu-client':
       ensure     => $ensure,
       enable     => $enable,
-      hasrestart => true,
+      hasrestart => $hasrestart,
       subscribe  => [Class['sensu::package'], Class['sensu::client::config'], Class['sensu::rabbitmq::config'] ],
     }
   }

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -2,7 +2,17 @@
 #
 # Manages the Sensu server service
 #
-class sensu::server::service {
+# == Parameters
+#
+# [*hasrestart*]
+#   Boolean. Value of hasrestart attribute for this service.
+#   Default: true
+
+class sensu::server::service (
+  $hasrestart = true,
+) {
+
+  validate_bool($hasrestart)
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")
@@ -24,7 +34,7 @@ class sensu::server::service {
     service { 'sensu-server':
       ensure     => $ensure,
       enable     => $enable,
-      hasrestart => true,
+      hasrestart => $hasrestart,
       subscribe  => [ Class['sensu::package'], Class['sensu::api::config'], Class['sensu::redis::config'], Class['sensu::rabbitmq::config'] ],
     }
   }

--- a/spec/classes/sensu_api_spec.rb
+++ b/spec/classes/sensu_api_spec.rb
@@ -116,6 +116,15 @@ describe 'sensu', :type => :class do
         it { should_not contain_service('sensu-api') }
       end # not managing services
 
+      context 'with hasrestart=false' do
+        let(:params) { { :api => true, :hasrestart => false } }
+        it { should contain_service('sensu-api').with(
+          :ensure     => 'running',
+          :enable     => true,
+          :hasrestart => false
+        )}
+      end # with hasrestart=false
+
     end # service
 
   end # with api

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -71,6 +71,15 @@ describe 'sensu', :type => :class do
         it { should_not contain_service('sensu-client') }
       end # not managing service
 
+      context 'with hasrestart=false' do
+        let(:params) { { :client => true, :hasrestart => false } }
+        it { should contain_service('sensu-client').with(
+          :ensure     => 'running',
+          :enable     => true,
+          :hasrestart => false
+        ) }
+      end # with hasrestart=false
+
     end #service
 
   end #with client

--- a/spec/classes/sensu_server_spec.rb
+++ b/spec/classes/sensu_server_spec.rb
@@ -23,5 +23,14 @@ describe 'sensu' do
     ) }
   end # with server
 
+  context 'with hasrestart=false' do
+    let(:params) { { :server => true, :hasrestart => false } }
+    it { should contain_service('sensu-server').with(
+      :ensure     => 'running',
+      :enable     => true,
+      :hasrestart => false
+    ) }
+  end # with hasrestart=false
+
 end
 


### PR DESCRIPTION
At my company we ship our own startup scripts that use upstart. When those scripts change, in order for upstart to pick up the changes, a job needs to be stopped and then started (see http://upstart.ubuntu.com/faq.html#reload).

With hasrestart hard coded to true, it's not possible. This change allows us to control hasrestart attribute.

This change is fully backwards compatible - by default value of hasrestart everywhere is true.