### PR TITLE
fix filters docstring in sensu::handler

### DIFF
--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -43,7 +43,7 @@
 #   Default: undef
 #
 # [*filters*]
-#   Hash.  Filter command to apply
+#   Array.  Filter command to apply
 #   Default: undef
 #
 # [*source*]


### PR DESCRIPTION
Looks to me like filters param of sensu::handler is expected to be an Array, not a Hash, no?