### PR TITLE
fix subscribers parameter in sensu_check

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -103,7 +103,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def subscribers
-    conf['checks'][resource[:name]]['subscribers']
+    conf['checks'][resource[:name]]['subscribers'] || []
   end
 
   def subscribers=(value)


### PR DESCRIPTION
Hi,

Today I faced with the issue when tried to define subscribers for existed check:
```
Error: /Stage[main]/Lmm_sensu::Checks/Lmm_sensu::Checks::Elasticsearch[***]/Sensu::Check[***]/Sensu_check[***]/subscribers: change from  to lmm failed: undefined method `sort' for nil:NilClass
```

it is related to such part of code:


```ruby
lib/puppet/type/sensu_check.rb

   81   newproperty(:subscribers, :array_matching => :all) do
   82     desc "Who is subscribed to this check"
   83     def insync?(is)
>  84       is.sort == should.sort
   85     end
   86   end
```