### PR TITLE
fix source param in sensu_check

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -134,6 +134,14 @@ Puppet::Type.type(:sensu_check).provide(:json) do
     conf['checks'][resource[:name]]['high_flap_threshold'] = value.to_i
   end
 
+  def source
+    conf['checks'][resource[:name]]['source']
+  end
+
+  def source=(value)
+    conf['checks'][resource[:name]]['source'] = value
+  end
+
   def timeout
     conf['checks'][resource[:name]]['timeout'].to_s
   end


### PR DESCRIPTION
Hi,

This fix is related to #368 pull request. Issue:
```
Error: /Stage[main]/Lmm_sensu::Checks/Lmm_sensu::Checks::Kafka[***]/Sensu::Check[***]/Sensu_check[***]: C
ould not evaluate: undefined method `source' for #<Puppet::Type::Sensu_check::ProviderJson:0x7f88911c6490>
```
