### PR TITLE
Relax the apt module version restriction

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": [
     { "name": "maestrodev/wget", "version_requirement": ">= 1.4.5 <2.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.1 <2.0.2" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 1.8.0 <3.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
Apt 2.x is now backwards compatible with 1.8.x