### PR TITLE
change default for filters param of sensu::handler (fix #374)

### DIFF
--- a/lib/puppet/provider/sensu_handler/json.rb
+++ b/lib/puppet/provider/sensu_handler/json.rb
@@ -101,7 +101,7 @@ Puppet::Type.type(:sensu_handler).provide(:json) do
   end
 
   def filters
-    conf['handlers'][resource[:name]]['filters']
+    conf['handlers'][resource[:name]]['filters'] || []
   end
 
   def filters=(value)

--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -44,7 +44,7 @@
 #
 # [*filters*]
 #   Array.  Filter command to apply
-#   Default: undef
+#   Default: []
 #
 # [*source*]
 #   String.  Source of the puppet handler
@@ -69,7 +69,7 @@ define sensu::handler(
   $pipe         = undef,
   $mutator      = undef,
   $socket       = undef,
-  $filters      = undef,
+  $filters      = [],
   # Used to install the handler
   $source       = undef,
   $install_path = '/etc/sensu/handlers',
@@ -82,7 +82,7 @@ define sensu::handler(
   if $exchange { validate_hash($exchange) }
   if $pipe { validate_hash($pipe) }
   if $socket { validate_hash($socket) }
-  validate_array($severities)
+  validate_array($severities, $filters)
   if $source { validate_re($source, ['^puppet://'] ) }
 
   if $type == 'pipe' and $ensure != 'absent' and !$command and !$source and !$mutator {

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -15,6 +15,7 @@ describe 'sensu::handler', :type => :define do
       :ensure      => 'present',
       :type        => 'pipe',
       :command     => '/etc/sensu/handlers/mycommand.rb',
+      :filters     => [],
       :severities  => ['ok', 'warning', 'critical', 'unknown']
     ) }
   end


### PR DESCRIPTION
https://github.com/sensu/sensu-puppet/issues/374

New filters will be created with empty list as value of filters. Old handlers whose json file doesn't have "filters" key should remain unchanged until at least one filter is added to a given handler.