### PR TITLE
remove world readable permissions from <handler>.json

### DIFF
--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -140,11 +140,12 @@ define sensu::handler(
     $command_real = $command
   }
 
+  # handler configuration may contain "secrets"
   file { "/etc/sensu/conf.d/handlers/${name}.json":
-    ensure => $ensure,
+    ensure => $file_ensure,
     owner  => 'sensu',
     group  => 'sensu',
-    mode   => '0444',
+    mode   => '0440',
     before => Sensu_handler[$name],
   }
 

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -18,6 +18,14 @@ describe 'sensu::handler', :type => :define do
       :filters     => [],
       :severities  => ['ok', 'warning', 'critical', 'unknown']
     ) }
+    it do
+      should contain_file("/etc/sensu/conf.d/handlers/#{title}.json").with(
+        :ensure => 'file',
+        :owner  => 'sensu',
+        :group  => 'sensu',
+        :mode   => '0440'
+      ).that_comes_before("Sensu_Handler[#{title}]")
+    end
   end
 
   context 'absent' do
@@ -28,6 +36,11 @@ describe 'sensu::handler', :type => :define do
       :source => 'puppet:///somewhere/mycommand.rb'
     } }
     it { should contain_sensu_handler('myhandler').with_ensure('absent') }
+    it do
+      should contain_file("/etc/sensu/conf.d/handlers/#{title}.json").
+        with_ensure('absent').
+        that_comes_before("Sensu_Handler[#{title}]")
+    end
   end
 
   context 'install path' do


### PR DESCRIPTION
The handler configuration may contain "secrets" such as passphrases or
API keys that should not be world readable.