### PR TITLE
convert sensu_client_subscription Puppet::notice -> Puppet::debug

### DIFF
--- a/lib/puppet/type/sensu_client_subscription.rb
+++ b/lib/puppet/type/sensu_client_subscription.rb
@@ -44,7 +44,7 @@ Puppet::Type.newtype(:sensu_client_subscription) do
     end
 
     def insync?(is)
-      Puppet.notice "is: #{is.inspect}, should: #{should.inspect}"
+      Puppet.debug "is: #{is.inspect}, should: #{should.inspect}"
       is.sort == should.sort
     end
   end


### PR DESCRIPTION
The notice invocation was clearly intended debugging statement and it is
not helpful to have notices as in the example below appear the agent
log on every run:

    ==> master: Notice: is: ["sensu-server"], should: ["sensu-server"]
    ==> master: Notice: is: ["jenkins-master"], should: ["jenkins-master"]
    ==> master: Notice: is: ["base"], should: ["base"]
    ==> master: Notice: is: ["jenkins-slave"], should: ["jenkins-slave"]