### PR TITLE
remove world readable permissions from redis.json

### DIFF
--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -14,11 +14,13 @@ class sensu::redis::config {
     $ensure = 'present'
   }
 
+  # redis configuration may contain "secrets"
   file { '/etc/sensu/conf.d/redis.json':
     ensure => $ensure,
     owner  => 'sensu',
     group  => 'sensu',
-    mode   => '0444',
+    mode   => '0440',
+    before => Sensu_redis_config[$::fqdn],
   }
 
   sensu_redis_config { $::fqdn:

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -28,12 +28,26 @@ describe 'sensu' do
 
     context 'with server' do
       let(:params) { { :server => true } }
-      it { should contain_file('/etc/sensu/conf.d/redis.json').with_ensure('present') }
+      it do
+        should contain_file('/etc/sensu/conf.d/redis.json').with(
+          :ensure => 'present',
+          :owner  => 'sensu',
+          :group  => 'sensu',
+          :mode   => '0440'
+        ).that_comes_before("Sensu_redis_config[#{facts[:fqdn]}]")
+      end
     end # with server
 
     context 'with api' do
       let(:params) { { :api => true } }
-      it { should contain_file('/etc/sensu/conf.d/redis.json').with_ensure('present') }
+      it do
+        should contain_file('/etc/sensu/conf.d/redis.json').with(
+          :ensure => 'present',
+          :owner  => 'sensu',
+          :group  => 'sensu',
+          :mode   => '0440'
+        ).that_comes_before("Sensu_redis_config[#{facts[:fqdn]}]")
+      end
     end # with api
 
     context 'purge configs' do


### PR DESCRIPTION
May contain the redis passphrase and should not be world readable.