### PR TITLE
Add `purge` parameter to control all purging, deprecate `purge_config…

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ and configures Sensu on each individual node via
 ### common.yaml
 
     sensu::install_repo: false
-    sensu::purge_config: true
+    sensu::purge:
+      config: true
     sensu::rabbitmq_host: 10.31.0.90
     sensu::rabbitmq_password: password
     sensu::rabbitmq_port: 5672
@@ -340,6 +341,28 @@ DaemonTools or SupervisorD, you can disable the module's internal
 service management functions like so:
 
     sensu::manage_services: false
+
+## Purging Configuration
+
+By default, any sensu plugins, extensions, handlers, mutators, and
+configuration not defined using this puppet module will be left on
+the filesystem. This can be changed using the `purge` parameter.
+
+If all sensu plugins, extensions, handlers, mutators, and configuration
+should be managed by puppet, set the `purge` parameter to `true` to
+delete files which are not defined using this puppet module:
+
+    sensu::purge: true
+
+To get more fine-grained control over what is purged, set the `purge`
+parameter to a hash. The possible keys are: `config`, `plugins`,
+`extensions`, `handlers`, `mutators`. Any key whose value is `true`
+cause files of that type which are not defined using this puppet module
+to be deleted. Keys which are not specified will not be purged:
+
+    sensu::purge:
+      config: true
+      plugins: true
 
 ## Including Sensu monitoring in other modules
 

--- a/manifests/api/config.pp
+++ b/manifests/api/config.pp
@@ -8,7 +8,7 @@ class sensu::api::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $sensu::purge_config and !$sensu::server and !$sensu::api {
+  if $sensu::_purge_config and !$sensu::server and !$sensu::api {
     $ensure = 'absent'
   } else {
     $ensure = 'present'

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -8,7 +8,7 @@ class sensu::client::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $sensu::purge_config and !$sensu::client {
+  if $sensu::_purge_config and !$sensu::client {
     $ensure = 'absent'
   } else {
     $ensure = 'present'

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -73,17 +73,42 @@ class sensu::package {
     owner   => 'sensu',
     group   => 'sensu',
     mode    => '0555',
-    purge   => $sensu::purge_config,
+    purge   => $sensu::_purge_config,
     recurse => true,
     force   => true,
     require => Package['sensu'],
   }
 
-  file { ['/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators', '/etc/sensu/extensions/handlers']:
+  file { '/etc/sensu/handlers':
     ensure  => directory,
     mode    => '0555',
     owner   => 'sensu',
     group   => 'sensu',
+    purge   => $sensu::_purge_handlers,
+    recurse => true,
+    force   => true,
+    require => Package['sensu'],
+  }
+
+  file { ['/etc/sensu/extensions', '/etc/sensu/extensions/handlers']:
+    ensure  => directory,
+    mode    => '0555',
+    owner   => 'sensu',
+    group   => 'sensu',
+    purge   => $sensu::_purge_extensions,
+    recurse => true,
+    force   => true,
+    require => Package['sensu'],
+  }
+
+  file { '/etc/sensu/mutators':
+    ensure  => directory,
+    mode    => '0555',
+    owner   => 'sensu',
+    group   => 'sensu',
+    purge   => $sensu::_purge_mutators,
+    recurse => true,
+    force   => true,
     require => Package['sensu'],
   }
 
@@ -93,7 +118,7 @@ class sensu::package {
       mode    => '0555',
       owner   => 'sensu',
       group   => 'sensu',
-      purge   => $sensu::purge_plugins_dir,
+      purge   => $sensu::_purge_plugins,
       recurse => true,
       force   => true,
       require => Package['sensu'],

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -8,7 +8,7 @@ class sensu::rabbitmq::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $sensu::purge_config and !$sensu::server and !$sensu::client {
+  if $sensu::_purge_config and !$sensu::server and !$sensu::client {
     $ensure = 'absent'
   } else {
     $ensure = 'present'

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -8,7 +8,7 @@ class sensu::redis::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $sensu::purge_config and !$sensu::server and !$sensu::api {
+  if $sensu::_purge_config and !$sensu::server and !$sensu::api {
     $ensure = 'absent'
   } else {
     $ensure = 'present'

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -45,7 +45,7 @@ describe 'sensu class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily
         class { 'sensu':
           server                   => true,
           api                      => true,
-          purge_config             => true,
+          purge                    => true,
           rabbitmq_password        => 'secret',
           rabbitmq_host            => 'localhost',
         }

--- a/spec/classes/sensu_api_spec.rb
+++ b/spec/classes/sensu_api_spec.rb
@@ -14,8 +14,8 @@ describe 'sensu', :type => :class do
 
       context 'purge config' do
         let(:params) { {
-          :purge_config => true,
-          :server       => false,
+          :purge  => { 'config' => true },
+          :server => false,
         } }
 
         it { should contain_file('/etc/sensu/conf.d/api.json').with_ensure('absent') }
@@ -89,9 +89,9 @@ describe 'sensu', :type => :class do
 
       context 'purge config' do
         let(:params) { {
-          :purge_config => true,
-          :api          => false,
-          :server       => false,
+          :purge  => { 'config' => true },
+          :api    => false,
+          :server => false,
         } }
 
         it { should contain_file('/etc/sensu/conf.d/api.json').with_ensure('absent') }

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -46,7 +46,7 @@ describe 'sensu', :type => :class do
       end # setting config params
 
       context 'purge config' do
-        let(:params) { { :purge_config => true } }
+        let(:params) { { :purge => { 'config' => true } } }
         it { should contain_file('/etc/sensu/conf.d/client.json').with_ensure('present') }
       end # purge config
 
@@ -89,7 +89,7 @@ describe 'sensu', :type => :class do
     context 'config' do
 
       context 'purge config' do
-        let(:params) { { :purge_config => true, :client => false } }
+        let(:params) { { :purge => { 'config' => true }, :client => false } }
         it { should contain_file('/etc/sensu/conf.d/client.json').with_ensure('absent') }
       end # purge config
 

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -16,6 +16,18 @@ describe 'sensu', :type => :class do
     it { expect { should create_class('sensu') }.to raise_error(/Sensu-dashboard is deprecated, use a dashboard module/) }
   end
 
+  context 'fail if purge_config parameter present' do
+    let(:params) { { :purge_config => true } }
+
+    it { expect { should create_class('sensu') }.to raise_error(/purge_config is deprecated, set the purge parameter to a hash containing `config => true` instead/) }
+  end
+
+  context 'fail if purge_plugins_dir parameter present' do
+    let(:params) { { :purge_plugins_dir => true } }
+
+    it { expect { should create_class('sensu') }.to raise_error(/purge_plugins_dir is deprecated, set the purge parameter to a hash containing `plugins => true` instead/) }
+  end
+
 end
 
 

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -149,9 +149,9 @@ describe 'sensu', :type => :class do
 
     context 'purge config' do
       let(:params) { {
-        :purge_config => true,
-        :server       => false,
-        :client       => false
+        :purge  => { 'config' => true },
+        :server => false,
+        :client => false
       } }
 
       it { should contain_file('/etc/sensu/conf.d/rabbitmq.json').with_ensure('absent') }

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -52,9 +52,9 @@ describe 'sensu' do
 
     context 'purge configs' do
       let(:params) { {
-        :purge_config => true,
-        :server       => false,
-        :api          => false,
+        :purge  => { 'config' => true },
+        :server => false,
+        :api    => false,
       } }
 
       it { should contain_file('/etc/sensu/conf.d/redis.json').with_ensure('absent') }


### PR DESCRIPTION
…` and `purge_plugins`

The `purge` parameter can either be `true`/`false` (in which case it controls purging
everything), or a hash controlling each type of purge-able thing.

Fixes #328

Might need changing if we decide that the old `purge_config`/`purge_plugins` parameters should be handled differently, or if the boolean/hash usage is too confusing.