### PR TITLE
Fix Sensu Enterprise services when not using enterprise

### DIFF
--- a/manifests/enterprise/dashboard/service.pp
+++ b/manifests/enterprise/dashboard/service.pp
@@ -11,8 +11,8 @@ class sensu::enterprise::dashboard::service (
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $::sensu::manage_services {
-    case $::sensu::enterprise_dashboard {
+  if $::sensu::enterprise_dashboard {
+    case $::sensu::manage_services {
       true: {
         $ensure = 'running'
         $enable = true

--- a/manifests/enterprise/service.pp
+++ b/manifests/enterprise/service.pp
@@ -8,8 +8,8 @@ class sensu::enterprise::service (
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $sensu::manage_services {
-    case $sensu::enterprise {
+  if $sensu::enterprise {
+    case $sensu::manage_services {
       true: {
         $ensure = 'running'
         $enable = true

--- a/spec/classes/sensu_enterprise_spec.rb
+++ b/spec/classes/sensu_enterprise_spec.rb
@@ -20,10 +20,6 @@ describe 'sensu', :type => :class do
           ) }
           it { should contain_service('sensu-enterprise') }
           it { should_not contain_yumrepo('sensu-enterprise-dashboard') }
-          it { should contain_service('sensu-enterprise-dashboard').with(
-            'enable' => false,
-            'ensure' => 'stopped'
-          ) }
         end
 
         context 'with manage_services => false' do
@@ -34,6 +30,10 @@ describe 'sensu', :type => :class do
             :manage_services      => false,
           } }
           it { should_not contain_service('puppet-enterprise-dashboard') }
+          it { should contain_service('sensu-enterprise-dashboard').with(
+            'enable' => false,
+            'ensure' => 'stopped'
+          ) }
         end
 
         context 'with enterprise_dashboard => true' do
@@ -103,10 +103,7 @@ describe 'sensu', :type => :class do
           it { should contain_yumrepo('sensu-enterprise') }
           it { should contain_service('sensu-enterprise') }
           it { should_not contain_yumrepo('sensu-enterprise-dashboard') }
-          it { should contain_service('sensu-enterprise-dashboard').with(
-            'enable' => false,
-            'ensure' => 'stopped'
-          ) }
+          it { should_not contain_service('sensu-enterprise-dashboard') }
         end
       end
 


### PR DESCRIPTION
When using the current master with the Sensu (not enterprise), I'm getting :

```
Notice: /Stage[main]/Sensu::Api::Service/Service[sensu-api]: Triggered 'refresh' from 1 events
Notice: /Stage[main]/Sensu::Server::Service/Service[sensu-server]: Triggered 'refresh' from 1 events
Error: /Stage[main]/Sensu::Enterprise::Service/Service[sensu-enterprise]: Could not evaluate: Could not find init script or upstart conf file for 'sensu-enterprise'
Error: /Stage[main]/Sensu::Enterprise::Service/Service[sensu-enterprise]: Failed to call refresh: Could not find init script or upstart conf file for 'sensu-enterprise'
Error: /Stage[main]/Sensu::Enterprise::Service/Service[sensu-enterprise]: Could not find init script or upstart conf file for 'sensu-enterprise'
Notice: /Stage[main]/Sensu::Enterprise::Dashboard/Anchor[sensu::enterprise::dashboard::begin]: Dependency Service[sensu-enterprise] has failures: true
Warning: /Stage[main]/Sensu::Enterprise::Dashboard/Anchor[sensu::enterprise::dashboard::begin]: Skipping because of failed dependencies
Notice: /Package[sensu-enterprise-dashboard]: Dependency Service[sensu-enterprise] has failures: true
Warning: /Package[sensu-enterprise-dashboard]: Skipping because of failed dependencies
Notice: /Stage[main]/Sensu::Enterprise::Dashboard::Config/File[/etc/sensu/dashboard.json]: Dependency Service[sensu-enterprise] has failures: true
Warning: /Stage[main]/Sensu::Enterprise::Dashboard::Config/File[/etc/sensu/dashboard.json]: Skipping because of failed dependencies
...
Notice: /Stage[main]/Sensu::Enterprise::Dashboard::Service/Service[sensu-enterprise-dashboard]: Dependency Service[sensu-enterprise] has failures: true
Warning: /Stage[main]/Sensu::Enterprise::Dashboard::Service/Service[sensu-enterprise-dashboard]: Skipping because of failed dependencies
Error: /Stage[main]/Sensu::Enterprise::Dashboard::Service/Service[sensu-enterprise-dashboard]: Failed to call refresh: Could not find init script or upstart conf file for 'sensu-enterprise-dashboard'
Error: /Stage[main]/Sensu::Enterprise::Dashboard::Service/Service[sensu-enterprise-dashboard]: Could not find init script or upstart conf file for 'sensu-enterprise-dashboard'
```

This pull request fixes the issue by changing the if and the case in each service.pp for the Enterprise version. I also changed a little bit the rspec tests.