### PR TITLE
fix redis_db type def

### DIFF
--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -70,7 +70,7 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
   end
 
   def db
-    conf['redis']['db'].to_i
+    conf['redis']['db'].to_s
   end
 
   def db=(value)


### PR DESCRIPTION
Every puppet run was causing a re-write of the /etc/sensu/conf.d/redis.json file, causing a refresh os sensu-api and sensu-server. Simple type fix, I matched it with redis_port (which is an integer, since I have no clue what this does, I do know that it stops the file rewrite and refreshes from happening :)

==> sensu_server: Notice: /Stage[main]/Sensu::Redis::Config/Sensu_redis_config[sensu-server.campus.wm.edu]/db: db changed '0' to '0'
==> sensu_server: Notice: /Stage[main]/Sensu::Api::Service/Service[sensu-api]: Triggered 'refresh' from 1 events
==> sensu_server: Notice: /Stage[main]/Sensu::Server::Service/Service[sensu-server]: Triggered 'refresh' from 1 events