### PR TITLE
Move file_ensure out of conditional

### DIFF
--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -114,15 +114,14 @@ define sensu::handler(
     $notify_services = []
   }
 
-  if $source {
+  $file_ensure = $ensure ? {
+    'absent' => 'absent',
+    default  => 'file'
+  }
 
+  if $source {
     $filename = inline_template('<%= scope.lookupvar(\'source\').split(\'/\').last %>')
     $handler = "${install_path}/${filename}"
-
-    $file_ensure = $ensure ? {
-      'absent' => 'absent',
-      default  => 'file'
-    }
 
     file { $handler:
       ensure => $file_ensure,


### PR DESCRIPTION
The file_ensure variable is referenced outside of this conditional, which fails under strict_variables.