### PR TITLE
Make the sensu enterprise dashboard not show up unbidden

### DIFF
--- a/manifests/enterprise/dashboard/config.pp
+++ b/manifests/enterprise/dashboard/config.pp
@@ -3,38 +3,44 @@ class sensu::enterprise::dashboard::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $sensu::purge and !$sensu::enterprise_dashboard {
-    if is_hash($sensu::purge) and $::sensu::purge['config'] {
+  if $::sensu::enterprise_dashboard {
+    $ensure = 'present'
+  } elsif is_hash($::sensu::purge) {
+    if $::sensu::purge['config'] {
       $ensure = 'absent'
     } else {
-      $ensure = 'present'
+      $ensure = undef
     }
+  } elsif $::sensu::purge {
+    $ensure = 'absent'
   } else {
-    $ensure = 'present'
+    $ensure = undef
   }
 
-  if $ensure == 'present' {
-    $_ensure = 'file'
-  } else {
-    $_ensure = $ensure
-  }
+  if $ensure != undef {
+    if $ensure == 'present' {
+      $_ensure = 'file'
+    } else {
+      $_ensure = $ensure
+    }
 
-  file { '/etc/sensu/dashboard.json':
-    ensure => $_ensure,
-    owner  => 'sensu',
-    group  => 'sensu',
-    mode   => '0440',
-  }
+    file { '/etc/sensu/dashboard.json':
+      ensure => $_ensure,
+      owner  => 'sensu',
+      group  => 'sensu',
+      mode   => '0440',
+    }
 
-  sensu_enterprise_dashboard_config { $::fqdn:
-    ensure    => $ensure,
-    base_path => $::sensu::enterprise_dashboard_base_path,
-    host      => $::sensu::enterprise_dashboard_host,
-    port      => $::sensu::enterprise_dashboard_port,
-    refresh   => $::sensu::enterprise_dashboard_refresh,
-    user      => $::sensu::enterprise_dashboard_user,
-    pass      => $::sensu::enterprise_dashboard_pass,
-    github    => $::sensu::enterprise_dashboard_github,
-    ldap      => $::sensu::enterprise_dashboard_ldap,
+    sensu_enterprise_dashboard_config { $::fqdn:
+      ensure    => $ensure,
+      base_path => $::sensu::enterprise_dashboard_base_path,
+      host      => $::sensu::enterprise_dashboard_host,
+      port      => $::sensu::enterprise_dashboard_port,
+      refresh   => $::sensu::enterprise_dashboard_refresh,
+      user      => $::sensu::enterprise_dashboard_user,
+      pass      => $::sensu::enterprise_dashboard_pass,
+      github    => $::sensu::enterprise_dashboard_github,
+      ldap      => $::sensu::enterprise_dashboard_ldap,
+    }
   }
 }


### PR DESCRIPTION
The logic on line 10 would drop the dashboard in place with ensure=>present even when dashboard was explicitly disabled.  I believe I've modified it to more closely follow the expectations around the $purge parameter.