### PR TITLE
Correcting issue #318 

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -20,7 +20,7 @@
 #
 # [*sensu_plugin_version*]
 #   String.  Version of the sensu-plugin gem to install
-#   Default: absent
+#   Default: installed
 #   Valid values: absent, installed, latest, present, [\d\.\-]+
 #
 # [*install_repo*]
@@ -259,7 +259,7 @@ class sensu (
   $version                        = 'latest',
   $sensu_plugin_name              = 'sensu-plugin',
   $sensu_plugin_provider          = undef,
-  $sensu_plugin_version           = 'absent',
+  $sensu_plugin_version           = 'installed',
   $install_repo                   = true,
   $enterprise                     = false,
   $enterprise_version             = 'latest',


### PR DESCRIPTION
The default value of sensu_plugin_version was set to "absent" causing failures such as those seen in #318 and #410. 

The example parameters at the head of the file were changed, as well as the actual implementation. 

