### PR TITLE
Add require on apt::update for puppetlabs-apt 2.x

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -14,6 +14,10 @@ class sensu::package {
       class { '::sensu::repo::apt': }
       if $sensu::install_repo {
         include ::apt
+        $pkg_require = Class['apt::update']
+      }
+      else {
+        $pkg_require = undef
       }
     }
 
@@ -27,6 +31,7 @@ class sensu::package {
 
   package { 'sensu':
     ensure  => $sensu::version,
+    require => $pkg_require,
   }
 
   if $::sensu::sensu_plugin_provider {


### PR DESCRIPTION
This problem doesn't always happen.  I'm unable to reproduce when
just declaring class {'sensu':} by itself.  However, it does seem
to happen when declared in a profile with other classes that use
puppetlabs-apt.  My best guess is that once one of the other
classes triggers an apt-get update, another one doesn't happen
within the same run.  In any case, the official puppetlabs-apt
docs now state that one's package resource must have an explicit
dependency on class apt::update if you expect things to work in one
run:
https://github.com/puppetlabs/puppetlabs-apt#adding-new-sources-or-ppas
