### PR TITLE
strict_variables bugfix for redhat ::osfamily

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -23,6 +23,8 @@ class sensu::package {
 
     'RedHat': {
       class { '::sensu::repo::yum': }
+
+      $pkg_require = undef
     }
 
     default: { fail("${::osfamily} not supported yet") }


### PR DESCRIPTION
set a value for $pkg_require to prevent run from failing on red hat based systems due to missing variable when strict_variables is enabled

