### PR TITLE
Update package repository URLs

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@
 #
 # [*repo_key_source*]
 #   String.  URL of the apt GPG key
-#   Default: http://repos.sensuapp.org/apt/pubkey.gpg
+#   Default: http://repositories.sensuapp.org/apt/pubkey.gpg
 #
 # [*client*]
 #   Boolean.  Include the sensu client
@@ -277,7 +277,7 @@ class sensu (
   $repo                           = 'main',
   $repo_source                    = undef,
   $repo_key_id                    = '8911D8FF37778F24B4E726A218609E3D7580C77F',
-  $repo_key_source                = 'http://repos.sensuapp.org/apt/pubkey.gpg',
+  $repo_key_source                = 'http://repositories.sensuapp.org/apt/pubkey.gpg',
   $enterprise_repo_key_id         = '910442FF8781AFD0995D14B311AB27E8C3FE3269',
   $client                         = true,
   $server                         = false,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@
 
 # [*repo_key_id*]
 #   String.  The apt GPG key id
-#   Default: 8911D8FF37778F24B4E726A218609E3D7580C77F
+#   Default: EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB
 #
 # [*repo_key_source*]
 #   String.  URL of the apt GPG key
@@ -276,7 +276,7 @@ class sensu (
   $enterprise_dashboard_version   = 'latest',
   $repo                           = 'main',
   $repo_source                    = undef,
-  $repo_key_id                    = '8911D8FF37778F24B4E726A218609E3D7580C77F',
+  $repo_key_id                    = 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB',
   $repo_key_source                = 'http://repositories.sensuapp.org/apt/pubkey.gpg',
   $enterprise_repo_key_id         = '910442FF8781AFD0995D14B311AB27E8C3FE3269',
   $client                         = true,

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -20,7 +20,7 @@ class sensu::repo::apt {
     if $sensu::repo_source {
       $url = $sensu::repo_source
     } else {
-      $url = 'http://repos.sensuapp.org/apt'
+      $url = 'http://repositories.sensuapp.org/apt'
     }
 
     apt::source { 'sensu':

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -13,8 +13,8 @@ class sensu::repo::yum {
       $url = $sensu::repo_source
     } else {
       $url = $sensu::repo ? {
-        'unstable'  => "http://repos.sensuapp.org/yum-unstable/el/\$basearch/",
-        default     => "http://repos.sensuapp.org/yum/el/\$basearch/"
+        'unstable'  => "http://repositories.sensuapp.org/yum-unstable/\$basearch/",
+        default     => "http://repositories.sensuapp.org/yum/\$basearch/"
       }
     }
 

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -72,11 +72,11 @@ describe 'sensu' do
           context 'default' do
             it { should contain_apt__source('sensu').with(
               :ensure      => 'present',
-              :location    => 'http://repos.sensuapp.org/apt',
+              :location    => 'http://repositories.sensuapp.org/apt',
               :release     => 'sensu',
               :repos       => 'main',
               :include     => { 'src' => false },
-              :key         => { 'id' => '8911D8FF37778F24B4E726A218609E3D7580C77F', 'source' => 'http://repos.sensuapp.org/apt/pubkey.gpg' },
+              :key         => { 'id' => '8911D8FF37778F24B4E726A218609E3D7580C77F', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },
               :before      => 'Package[sensu]'
             ) }
           end
@@ -109,7 +109,7 @@ describe 'sensu' do
 
             it { should_not contain_apt__key('sensu').with(
               :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
-              :key_source  => 'http://repos.sensuapp.org/apt/pubkey.gpg'
+              :key_source  => 'http://repositories.sensuapp.org/apt/pubkey.gpg'
             ) }
 
             it { should contain_package('sensu').with( :require => nil ) }
@@ -127,7 +127,7 @@ describe 'sensu' do
         context 'default' do
           it { should contain_yumrepo('sensu').with(
             :enabled   => 1,
-            :baseurl   => 'http://repos.sensuapp.org/yum/el/$basearch/',
+            :baseurl   => 'http://repositories.sensuapp.org/yum/$basearch/',
             :gpgcheck  => 0,
             :before    => 'Package[sensu]'
           ) }
@@ -135,7 +135,7 @@ describe 'sensu' do
 
         context 'unstable repo' do
           let(:params) { { :repo => 'unstable' } }
-          it { should contain_yumrepo('sensu').with(:baseurl => 'http://repos.sensuapp.org/yum-unstable/el/$basearch/' )}
+          it { should contain_yumrepo('sensu').with(:baseurl => 'http://repositories.sensuapp.org/yum-unstable/$basearch/' )}
         end
 
         context 'override repo url' do

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -76,7 +76,7 @@ describe 'sensu' do
               :release     => 'sensu',
               :repos       => 'main',
               :include     => { 'src' => false },
-              :key         => { 'id' => '8911D8FF37778F24B4E726A218609E3D7580C77F', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },
+              :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },
               :before      => 'Package[sensu]'
             ) }
           end
@@ -91,7 +91,7 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with( :location => 'http://repo.mydomain.com/apt') }
 
             it { should_not contain_apt__key('sensu').with(
-              :key         => { 'id' => '8911D8FF37778F24B4E726A218609E3D7580C77F', 'source'  => 'http://repo.mydomain.com/apt/pubkey.gpg' }
+              :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source'  => 'http://repo.mydomain.com/apt/pubkey.gpg' }
             ) }
           end
 
@@ -108,7 +108,7 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with_ensure('absent') }
 
             it { should_not contain_apt__key('sensu').with(
-              :key         => '8911D8FF37778F24B4E726A218609E3D7580C77F',
+              :key         => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB',
               :key_source  => 'http://repositories.sensuapp.org/apt/pubkey.gpg'
             ) }
 


### PR DESCRIPTION
Updated the module to use the new Sensu package repository URLs, for example:

http://repositories.sensuapp.org/apt/

http://repositories.sensuapp.org/yum/

The new repositories contain the latest Sensu builds, >= 0.20.0 only. The repositories are part of the new Sensu Core build pipeline.

![tumblr_mvrc0evts81swhepeo1_250_zps371b1695](https://cloud.githubusercontent.com/assets/149630/10555165/b90894ca-741f-11e5-94b0-25f0e3e9b4e8.GIF)
