### PR TITLE
Add ruby-dev to be installed whilst provisioning process.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To quickly try out Sensu, spin up a test virtual machine with Vagrant that alrea
 
 You can then access the API.
 
-    $ curl http://admin:secret@localhost:4567/info
+    $ curl http://admin:secret@192.168.56.10:4567/info
 
 Navigate to `192.168.56.10:3000` to use the uchiwa dashboard
 

--- a/tests/provision_client.sh
+++ b/tests/provision_client.sh
@@ -5,7 +5,7 @@
 # apt-get install -y python-software-properties
 wget --quiet http://apt.puppetlabs.com/puppetlabs-release-precise.deb -O /tmp/puppetlabs-release-precise.deb
 dpkg -i /tmp/puppetlabs-release-precise.deb
-apt-get update 
-apt-get install -y ruby-json puppet-common #masterless puppet
+apt-get update
+apt-get install -y ruby-json puppet-common ruby-dev #masterless puppet
 sed -i '/templatedir/d' /etc/puppet/puppet.conf
 puppet module install sensu/sensu

--- a/tests/provision_server.sh
+++ b/tests/provision_server.sh
@@ -5,8 +5,8 @@
 # apt-get install -y python-software-properties
 wget --quiet http://apt.puppetlabs.com/puppetlabs-release-precise.deb -O /tmp/puppetlabs-release-precise.deb
 dpkg -i /tmp/puppetlabs-release-precise.deb
-apt-get update 
-apt-get install -y ruby-json redis-server puppet-common #masterless puppet
+apt-get update
+apt-get install -y ruby-json redis-server puppet-common ruby-dev #masterless puppet
 sed -i '/templatedir/d' /etc/puppet/puppet.conf
 puppet module install sensu/sensu
 puppet module install puppetlabs/rabbitmq


### PR DESCRIPTION
At the moment puppet is failing while trying to install `sensu-plugin' gem on both server and client with the following error:

```
==> sensu-client: Error: Execution of '/usr/bin/gem install --no-rdoc --no-ri sensu-plugin' returned 1: Building native extensions.  This could take a while...
==> sensu-client: ERROR:  Error installing sensu-plugin:
==> sensu-client: 	ERROR: Failed to build gem native extension.
==> sensu-client:
==> sensu-client:         /usr/bin/ruby1.9.1 extconf.rb
==> sensu-client: /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require': cannot load such file -- mkmf (LoadError)
==> sensu-client: 	from /usr/lib/ruby/1.9.1/rubygems/custom_require.rb:36:in `require'
==> sensu-client: 	from extconf.rb:1:in `<main>'
==> sensu-client:
==> sensu-client:
==> sensu-client: Gem files will remain installed in /var/lib/gems/1.9.1/gems/json-1.8.3 for inspection.
==> sensu-client: Results logged to /var/lib/gems/1.9.1/gems/json-1.8.3/ext/json/ext/generator/gem_make.out
==> sensu-client: Error: /Stage[main]/Sensu::Package/Package[sensu-plugin]/ensure: change from absent to present failed: Execution of '/usr/bin/gem install --no-rdoc --no-ri sensu-plugin' returned 1: Building native extensions.  This could take a while...
```

This PR should solve it.