### PR TITLE
Fix dependencies for ruby 2.2.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ group :development, :unit_tests do
   gem 'metadata-json-lint',                               :require => false
   gem 'puppet-blacksmith',                                :require => false
   gem 'rest-client', "1.6.8",                             :require => false
+  gem 'syck',                                             :require => false
+  gem 'safe_yaml',                                        :require => false
   gem 'puppet-lint-absolute_classname-check',             :require => false
   gem 'puppet-lint-appends-check',                        :require => false
   gem 'puppet-lint-empty_string-check',                   :require => false


### PR DESCRIPTION
Without these changes, running specs fails when using:
ruby 2.2.3p173 (2015-08-18 revision 51636) [x86_64-linux]