### PR TITLE
transform default client_port into an integer

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -314,7 +314,7 @@ class sensu (
   $api_password                   = undef,
   $subscriptions                  = [],
   $client_bind                    = '127.0.0.1',
-  $client_port                    = '3030',
+  $client_port                    = 3030,
   $client_address                 = $::ipaddress,
   $client_name                    = $::fqdn,
   $client_custom                  = {},
@@ -360,6 +360,7 @@ class sensu (
   validate_re($log_level, ['^debug$', '^info$', '^warn$', '^error$', '^fatal$'] )
   if !is_integer($rabbitmq_port) { fail('rabbitmq_port must be an integer') }
   if !is_integer($redis_port) { fail('redis_port must be an integer') }
+  if !is_integer($client_port) { fail('client_port must be an integer') }
   if !is_integer($api_port) { fail('api_port must be an integer') }
   if !is_integer($init_stop_max_wait) { fail('init_stop_max_wait must be an integer') }
   if $dashboard { fail('Sensu-dashboard is deprecated, use a dashboard module. See https://github.com/sensu/sensu-puppet#dashboards')}


### PR DESCRIPTION
By using the old default value which was a string and not an integer,
sensu-client would never start and you would got this message:

{"timestamp":"2015-12-06T21:18:52.299496+0000","level":"fatal","message":"client socket port must be an integer","object":{"name":"instack","address":"192.0.2.1","subscriptions":["undercloud_basic"],"socket":{"bind":"127.0.0.1","port":"3030"},"safe_mode":false,"keepalive":{}}}

The port value (defined by sensu::client_port here) must be an integer
and not a string.
This patch transforms the default value from a string to an integer so
we can run sensu-client out-of-the-box.