### PR TITLE
sensu fails to start as client_port is a string.

### DIFF
--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -49,6 +49,10 @@ Puppet::Type.newtype(:sensu_client_config) do
     desc "A set of attributes that configure the Sensu client socket."
     include PuppetX::Sensu::ToType
 
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
+
     def is_to_s(hash = @is)
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
     end
@@ -88,6 +92,10 @@ Puppet::Type.newtype(:sensu_client_config) do
 
     include PuppetX::Sensu::ToType
 
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
+
     def is_to_s(hash = @is)
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
     end
@@ -115,6 +123,10 @@ Puppet::Type.newtype(:sensu_client_config) do
     desc "Keepalive config"
 
     include PuppetX::Sensu::ToType
+
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
 
     def is_to_s(hash = @is)
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")


### PR DESCRIPTION
Related to #454 and to #453 

No matter what you put as a value for $client_port the first run of
sensu fails because the rendered /etc/sensu/conf.d/client.json has a
string for port value.  It works at the second run.

The reason is that the value returned by puppet for the hash in socket
is always a string whatever you put in $client_port (string or int).  It
works the second time because is get munged by in the insync?  method in
the type definition.

This is why also it can work at the first run depending of the
distribution.  If the distribution install a valid
/etc/sensu/conf.d/client.json by default, then this problem will get
unnoticed (munged by insync?).  Unfortunately this is not the case for
centos where no such file is installed.

I added the munge at every place this could be a problem.  I ran the
beaker tests on centos and got:

Finished in 6 minutes 20 seconds (files took 1 minute 40.05 seconds to load)
16 examples, 0 failures

real    8m3.775s
user    0m15.046s
sys     0m1.130s

puppet --version -> 3.8.4, centos7