### PR TITLE
Fixing regression bug.

### DIFF
--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -53,14 +53,6 @@ Puppet::Type.newtype(:sensu_client_config) do
       value.each { |k, v| value[k] = to_type(v) }
     end
 
-    def is_to_s(hash = @is)
-      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
-    end
-
-    def should_to_s(hash = @should)
-      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
-    end
-
     def insync?(is)
       if defined? @should[0]
         if is == @should[0].each { |k, v| value[k] = to_type(v) }


### PR DESCRIPTION
When people are updating from old puppet module the socket is '',
which crashes puppet when it tries to #keys method in the is_to_s
method.  Additionally, I think the default change message is good
enough.

Here is how it looks now when upgrading from old puppet module:
`Notice: /Stage[main]/Sensu::Client::Config/Sensu_client_config[fqdn]/socket: socket changed '' to '{"bind"=>"128.0.0.1", "port"=>3030}'`

Here is how it will look when changing:
`Notice: /Stage[main]/Sensu::Client::Config/Sensu_client_config[fqdn]/socket:
 socket changed {"bind"=>"1.1.1.1", "port"=3030} to '{"bind"=>"128.0.0.1", "port"=>3030}'`