### PR TITLE
Add support for slack channel configuration / check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,61 @@ This will create the following check definition for Sensu:
       }
     }
 
+
+## Slack multi channel configuration
+It enables to send alert to specific channel per check.
+Please see for the reference the multi channel handler script.
+https://github.com/sensu-plugins/sensu-plugins-slack/blob/master/bin/handler-slack-multichannel.rb
+
+For example:
+Check from hieradata:
+
+
+sensu.yaml:
+```
+::sensu_checks:
+    check-gmail-conn:
+      command: "/opt/sensu-plugins-omnibus/checks/check-ports.rb -H smtp.gmail.com -p 25"
+      handlers:
+        - "slack"
+      interval: "30"
+      occurrences: "3"
+      standalone: true
+      'slack':
+        channels:
+          - "#channel-A"
+          - "#channel-B"
+```
+
+check.pp:
+```
+create_resources('::sensu::check', $sensu_checks)
+```
+
+check-gmail-conn.json:
+```
+{
+  "checks": {
+    "check-gmail-conn": {
+      "command": "/opt/sensu-plugins-omnibus/checks/check-ports.rb -H smtp.gmail.com -p 25",
+      "handlers": [
+        "slack"
+      ],
+      "interval": 30,
+      "occurrences": 3,
+      "standalone": true,
+      "slack": {
+        "channels": [
+          "#channel-A",
+          "#channel-B"
+        ]
+      }
+    }
+  }
+}
+```
+
+
 ## Handler configuration
 
     sensu::handler {

--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -30,7 +30,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def check_args
-    ['handlers','command','interval','occurrences','refresh','source','subscribers','type','standalone','high_flap_threshold','low_flap_threshold','timeout','aggregate','handle','publish','dependencies','custom','ttl']
+    ['handlers','command','interval','occurrences','refresh','source','subscribers','type','standalone','high_flap_threshold','low_flap_threshold','timeout','aggregate','handle','publish','dependencies','custom','ttl','slack']
   end
 
   def custom
@@ -208,5 +208,13 @@ Puppet::Type.type(:sensu_check).provide(:json) do
 
   def subdue=(value)
     conf['checks'][resource[:name]]['subdue'] = value
+  end
+  
+  def slack
+    conf['checks'][resource[:name]]['slack']
+  end
+
+  def slack=(value)
+    conf['checks'][resource[:name]]['slack'] = value
   end
 end

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -147,4 +147,9 @@ Puppet::Type.newtype(:sensu_check) do
   autorequire(:package) do
     ['sensu']
   end
+  
+  newproperty(:slack) do
+    desc "Check Slack Channel"
+  end
+  
 end

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -80,6 +80,11 @@
 #   Hash.  Check subdue configuration
 #   Default: undef
 #
+# [*slack*]
+#   Hash.  Check slack Channel
+#   Default: undef
+#
+
 define sensu::check(
   $command,
   $ensure              = 'present',
@@ -101,6 +106,7 @@ define sensu::check(
   $custom              = undef,
   $ttl                 = undef,
   $subdue              = undef,
+  $slack               = undef
 ) {
 
   validate_re($ensure, ['^present$', '^absent$'] )
@@ -160,6 +166,7 @@ define sensu::check(
     require             => File['/etc/sensu/conf.d/checks'],
     notify              => $::sensu::check_notify,
     ttl                 => $ttl,
+    slack               => $slack,
   }
 
 }


### PR DESCRIPTION
Hi there,

I've added support to the sensu_check provider to support custom channel configuration pre check   
It enables one or more channel to be specified per check.

Please see the multi channel handler script for the reference.
https://github.com/sensu-plugins/sensu-plugins-slack/blob/master/bin/handler-slack-multichannel.rb

Regards,
Oszkar 