### PR TITLE
Redaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,6 +437,47 @@ by using the `sensu_gem` package provider:
       provider => sensu_gem,
     }
 
+## Sensitive String Redaction
+
+Redaction of passwords is supported by this module. To enable it, pass a value to `sensu::redact`
+and set some password values with `sensu::client_custom`
+
+```
+  class { 'sensu':
+    redact  => 'password',
+    client_custom => {
+      github => {
+        password => 'correct-horse-battery-staple',
+      },
+    },
+  }
+```
+
+Or with hiera:
+
+```
+sensu::redact
+  - :password"
+sensu::client_custom:
+  - sensu::client_custom:
+  nexus:
+    password: "correct-horse-battery-staple'
+```
+
+This ends up like this in the uchiwa console:
+
+![Sensu Redaction](http://i.imgur.com/K4noGoN.png)
+
+You can make use of the password now when defining a check by using command substitution:
+
+```
+sensu::check{ 'check_password_test':
+  command      => '/usr/local/bin/check_password_test --password :::github.password::: ',
+}
+```
+
+
+
 ## Dashboards
 
 The following puppet modules exist for managing dashboards

--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -41,7 +41,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
   end
 
   def check_args
-    ['name', 'address', 'subscriptions', 'safe_mode', 'socket', 'keepalive']
+    ['name', 'address', 'subscriptions', 'safe_mode', 'socket', 'keepalive', 'redact']
   end
 
   def client_name
@@ -74,6 +74,14 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
 
   def subscriptions=(value)
     conf['client']['subscriptions'] = value
+  end
+
+  def redact
+    conf['client']['redact'] || []
+  end
+
+  def redact=(value)
+    conf['client']['redact'] = value
   end
 
   def custom

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -45,6 +45,13 @@ Puppet::Type.newtype(:sensu_client_config) do
     end
   end
 
+  newproperty(:redact, :array_matching => :all) do
+    desc "An array of strings that should be redacted in the sensu client config"
+    def insync?(is)
+      is.sort == should.sort
+    end
+  end
+
   newproperty(:socket) do
     desc "A set of attributes that configure the Sensu client socket."
     include PuppetX::Sensu::ToType

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -33,6 +33,7 @@ class sensu::client::config {
     safe_mode     => $sensu::safe_mode,
     custom        => $sensu::client_custom,
     keepalive     => $sensu::client_keepalive,
+    redact        => $sensu::redact,
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -270,7 +270,7 @@
 #
 # [*redact*]
 #   Array of strings. Use to redact passwords from checks on the client side
-#   Default: undef
+#   Default: []
 
 class sensu (
   $version                        = 'latest',
@@ -347,7 +347,7 @@ class sensu (
   $enterprise_dashboard_github    = undef,
   $enterprise_dashboard_ldap      = undef,
   $path                           = undef,
-  $redact                         = undef,
+  $redact                         = [],
 
   ### START Hiera Lookups ###
   $extensions                  = {},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,6 +267,11 @@
 #
 # [*path*]
 #   String. used to set PATH in /etc/default/sensu
+#
+# [*redact*]
+#   Array of strings. Use to redact passwords from checks on the client side
+#   Default: undef
+
 class sensu (
   $version                        = 'latest',
   $sensu_plugin_name              = 'sensu-plugin',
@@ -342,6 +347,7 @@ class sensu (
   $enterprise_dashboard_github    = undef,
   $enterprise_dashboard_ldap      = undef,
   $path                           = undef,
+  $redact                         = undef,
 
   ### START Hiera Lookups ###
   $extensions                  = {},

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -15,6 +15,7 @@ describe 'sensu', :type => :class do
           :address       => '2.3.4.5',
           :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
           :subscriptions => [],
+          :redact        => [],
           :ensure        => 'present',
           :custom        => {}
         ) }
@@ -25,6 +26,7 @@ describe 'sensu', :type => :class do
           :client                   => true,
           :client_address           => '1.2.3.4',
           :subscriptions            => ['all'],
+          :redact                   => ['password'],
           :client_name              => 'myclient',
           :safe_mode                => true,
           :client_custom            => { 'bool' => true, 'foo' => 'bar' }
@@ -36,6 +38,7 @@ describe 'sensu', :type => :class do
           :address       => '1.2.3.4',
           :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
           :subscriptions => ['all'],
+          :redact        => ['password'],
           :ensure        => 'present',
           :safe_mode     => true,
           :custom        => { 'bool' => true, 'foo' => 'bar' }


### PR DESCRIPTION
This PR adds support for password redaction which is part of the sensu-core and has been since the early days.

I've also added a README to make use of it, as this isn't well documented.

I've set the value to undef for the time being but I think it could be debated that we should set "password" as the default value.

Any thoughts or feedback is very welcome.