### PR TITLE
Add support for using the same source for  different sensu handlers

### DIFF
--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -123,13 +123,13 @@ define sensu::handler(
     $filename = inline_template('<%= scope.lookupvar(\'source\').split(\'/\').last %>')
     $handler = "${install_path}/${filename}"
 
-    file { $handler:
+    ensure_resource('file', $handler, {
       ensure => $file_ensure,
       owner  => 'sensu',
       group  => 'sensu',
       mode   => '0555',
       source => $source,
-    }
+    })
 
     $command_real = $command ? {
       undef   => $handler,

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -37,6 +37,38 @@ describe 'sensu', :type => :class do
     let(:params) { { :enterprise => true, :api => true } }
     it { expect { should create_class('sensu') }.to raise_error(Puppet::Error, /sensu-api/) }
   end
+
+  context 'with handlers attributes' do
+    let(:params) { {
+        :handlers => {
+          'hipchat_main_room' => {
+            'type'   => 'pipe',
+            'source' => 'puppet:///modules/sensu_module/community-plugins/handlers/notification/hipchat.rb',
+            'config' => {
+              'apikey' => 'my_long_api_key',
+              'room'   => 'Big Alerts'
+            }
+          },
+          'hipchat_other_room' => {
+            'type'   => 'pipe',
+            'source' => 'puppet:///modules/sensu_module/community-plugins/handlers/notification/hipchat.rb',
+            'config' => {
+              'apikey' => 'my_other_long_api_key',
+              'room'   => 'Small Alerts'
+            }
+          }
+        }
+    } }
+
+    it { should contain_file('/etc/sensu/handlers/hipchat.rb').with(
+        :ensure => 'file',
+        :owner  => 'sensu',
+        :group  => 'sensu',
+        :mode   => '0555',
+        :source => "puppet:///modules/sensu_module/community-plugins/handlers/notification/hipchat.rb"
+    )}
+
+  end
 end
 
 


### PR DESCRIPTION
Currently it's impossible to use the same source for different handlers. a duplicate file definition exception  is thrown. This PR fixes that. With this PR, you can now do:

```yaml
---
sensu::handlers:
  'hipchat_main_room':
    type: pipe
    source: "puppet:///modules/sensu_module/community-plugins/handlers/notification/hipchat.rb"
    config:
      apikey: my_long_key
      room: Big Alerts
  'hipchat_other_room':
    type: pipe
    source: "puppet:///modules/sensu_module/community-plugins/handlers/notification/hipchat.rb"
    config:
      apikey: my_other_long_key
      room: 'Small Alerts'
```

cc @jlambert121 
Thanks