### PR TITLE
Added parameter sensu::install_repo as the first condition to manage …

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -38,6 +38,11 @@
 #   Default: false
 #   Valid values: true, false
 #
+# [*manage_repo*]
+#   String. Wether or not to manage apt/yum repositories
+#   Default: true
+#   Valid values: true, false
+#
 # [*repo*]
 #   String.  Which sensu repo to install
 #   Default: main
@@ -319,6 +324,7 @@ class sensu (
   $enterprise_pass                = undef,
   $enterprise_dashboard           = false,
   $enterprise_dashboard_version   = 'latest',
+  $manage_repo                    = true,
   $repo                           = 'main',
   $repo_source                    = undef,
   $repo_key_id                    = 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB',
@@ -398,7 +404,7 @@ class sensu (
 
 ){
 
-  validate_bool($client, $server, $api, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir)
+  validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir)
 
   validate_re($repo, ['^main$', '^unstable$'], "Repo must be 'main' or 'unstable'.  Found: ${repo}")
   validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")
@@ -419,10 +425,12 @@ class sensu (
     fail('Sensu Enterprise: sensu-enterprise replaces sensu-server and sensu-api')
   }
   # validate enterprise repo creds
-  if ( $enterprise or $enterprise_dashboard ) and $install_repo {
-    validate_string($enterprise_user, $enterprise_pass)
-    if $enterprise_user == undef or $enterprise_pass == undef {
-      fail('The Sensu Enterprise repos require both enterprise_user and enterprise_pass to be set')
+  if $manage_repo {
+    if ( $enterprise or $enterprise_dashboard ) and $install_repo {
+      validate_string($enterprise_user, $enterprise_pass)
+      if $enterprise_user == undef or $enterprise_pass == undef {
+        fail('The Sensu Enterprise repos require both enterprise_user and enterprise_pass to be set')
+      }
     }
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -15,8 +15,10 @@ class sensu::package {
       $pkg_name = 'sensu'
       $pkg_source = undef
 
-      class { '::sensu::repo::apt': }
-      if $sensu::install_repo {
+      if $sensu::manage_repo {
+        class { '::sensu::repo::apt': }
+      }
+      if $sensu::manage_repo and $sensu::install_repo {
         include ::apt
         $pkg_require = Class['apt::update']
       }
@@ -30,7 +32,9 @@ class sensu::package {
       $pkg_name = 'sensu'
       $pkg_source = undef
 
-      class { '::sensu::repo::yum': }
+      if $sensu::manage_repo {
+        class { '::sensu::repo::yum': }
+      }
 
       $pkg_require = undef
     }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -81,6 +81,16 @@ describe 'sensu' do
             ) }
           end
 
+          context 'manage_repo => false' do
+            let(:params) { { :manage_repo => false, :install_repo => false } }
+            it { should_not contain_apt__source('sensu') }
+          end
+
+          context 'manage_repo => false independent from install_repo ' do
+            let(:params) { { :manage_repo => false , :install_repo => true } }
+            it { should_not contain_apt__source('sensu') }
+          end
+
           context 'unstable repo' do
             let(:params) { { :repo => 'unstable' } }
             it { should contain_apt__source('sensu').with_repos('unstable') }
@@ -131,6 +141,16 @@ describe 'sensu' do
             :gpgcheck  => 0,
             :before    => 'Package[sensu]'
           ) }
+        end
+
+        context 'manage_repo => false' do
+          let(:params) { { :manage_repo => false, :install_repo => false } }
+          it { should_not contain_yumrepo('sensu') }
+        end
+
+        context 'manage_repo => false independent from install_repo ' do
+          let(:params) { { :manage_repo => false , :install_repo => true } }
+          it { should_not contain_yumrepo('sensu') }
         end
 
         context 'unstable repo' do


### PR DESCRIPTION
Currently, if a user does not want to install the repositories by setting the parameter class install_repo to false, and this is declared in hiera, there is an error about duplicated resources apt::source (resource declared in manifests/repo/apt.pp file).

This PR changes the checks of the if statement to avoid this error about duplicated resources.

