### PR TITLE
Add filters and filter_defaults to init with create_resources, missing puppetdoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,12 @@ site.pp
         command: '/usr/local/bin/check_file_test.sh'
       'chef_client':
         command: 'check-chef-client.rb'
+    sensu::filters:
+      'recurrences-30':
+        attributes:
+          occurrences: "eval: value == 1 || value % 30 == 0"
+    sensu::filter_defaults:
+      negate: true
     sensu::check_defaults:
       handlers: 'mail'
     sensu::mutators:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -355,6 +355,8 @@ class sensu (
   $handler_defaults            = {},
   $checks                      = {},
   $check_defaults              = {},
+  $filters                     = {},
+  $filter_defaults             = {},
   $mutators                    = {},
   ### END Hiera Lookups ###
 
@@ -447,6 +449,7 @@ class sensu (
   create_resources('::sensu::extension', $extensions)
   create_resources('::sensu::handler', $handlers, $handler_defaults)
   create_resources('::sensu::check', $checks, $check_defaults)
+  create_resources('::sensu::filter', $filters, $filter_defaults)
   create_resources('::sensu::mutator', $mutators)
 
   # Include everything and let each module determine its state.  This allows

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -272,6 +272,37 @@
 #   Array of strings. Use to redact passwords from checks on the client side
 #   Default: []
 
+# [*handlers*]
+#   Hash of handlers for use with create_sources(sensu::handler).
+#   Example value: { 'email': { 'type' => 'pipe', 'command' => 'mail' } }
+#   Default: {}
+#
+# [*handler_defaults*]
+#   Handler defaults when not provided explicitely in $handlers.
+#   Example value: { 'filters' => ['production'] }
+#   Default: {}
+#
+# [*checks*]
+#   Hash of checks for use with create_sources(sensu::check).
+#   Example value: { 'check-cpu': { 'command' => 'check-cpu.rb' } }
+#   Default: {}
+#
+# [*check_defaults*]
+#   Check defaults when not provided explicitely in $checks.
+#   Example value: { 'occurences' => 3 }
+#   Default: {}
+#
+# [*filters*]
+#   Hash of filters for use with create_sources(sensu::filter).
+#   Example value: { 'occurrence': { 'attributes' => { 'occurrences' => '1' } } }
+#   Default: {}
+#
+# [*filter_defaults*]
+#   Filter defaults when not provided explicitely in $filters.
+#   Example value: { 'negate' => true }
+#   Default: {}
+
+
 class sensu (
   $version                        = 'latest',
   $sensu_plugin_name              = 'sensu-plugin',

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -38,6 +38,47 @@ describe 'sensu', :type => :class do
     it { expect { should create_class('sensu') }.to raise_error(Puppet::Error, /sensu-api/) }
   end
 
+  context 'with filters attributes' do
+    let(:params) { {
+      :filters => {
+        'recurrences-30' => {
+          'attributes' => {
+            'occurrences' => "eval: value == 1 || value % 30 == 0"
+          }
+        },
+        'production' => {
+          'attributes' => {
+            'client' => {
+              'environment' => 'production'
+            }
+          },
+          'negate' => true
+        }
+      },
+      :filter_defaults => {
+        'negate' => false
+      }
+    } }
+
+    it { should contain_sensu_filter('recurrences-30').with(
+      :attributes => {
+        'occurrences' => "eval: value == 1 || value % 30 == 0"
+      },
+      :negate => false
+    ) }
+    it { should contain_file('/etc/sensu/conf.d/filters/recurrences-30.json') }
+
+    it { should contain_sensu_filter('production').with(
+      :attributes => {
+        'client' => {
+          'environment' => 'production'
+        }
+      },
+      :negate => true
+    ) }
+    it { should contain_file('/etc/sensu/conf.d/filters/production.json') }
+  end
+
   context 'with handlers attributes' do
     let(:params) { {
         :handlers => {
@@ -70,6 +111,3 @@ describe 'sensu', :type => :class do
 
   end
 end
-
-
-


### PR DESCRIPTION
This allows to create a batch of filters just like we have support
for doing so with checks and handlers.