### PR TITLE
Feature prefetch attribute

### DIFF
--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -144,4 +144,12 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   def reconnect_on_error=(value)
      conf['rabbitmq']['reconnect_on_error'] = value
   end
+
+  def prefetch
+    conf['rabbitmq']['prefetch'].to_s
+  end
+
+  def prefetch=(value)
+     conf['rabbitmq']['prefetch'] = value.to_i
+  end
 end

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -87,6 +87,12 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
     defaultto :false
   end
 
+  newproperty(:prefetch) do
+    desc "The RabbitMQ AMQP consumer prefetch value"
+
+    defaultto '1'
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -142,6 +142,10 @@
 #   Default: false
 #   Valid values: true, false
 #
+# [*rabbitmq_prefetch*]
+#   Integer.  The integer value for the RabbitMQ prefetch attribute
+#   Default: 1
+#
 # [*redis_host*]
 #   String.  Hostname of redis to be used by sensu
 #   Default: localhost
@@ -306,6 +310,7 @@ class sensu (
   $rabbitmq_ssl_private_key       = undef,
   $rabbitmq_ssl_cert_chain        = undef,
   $rabbitmq_reconnect_on_error    = false,
+  $rabbitmq_prefetch              = 1,
   $redis_host                     = 'localhost',
   $redis_port                     = 6379,
   $redis_password                 = undef,

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -117,6 +117,7 @@ class sensu::rabbitmq::config {
     ssl_cert_chain     => $ssl_cert_chain,
     ssl_private_key    => $ssl_private_key,
     reconnect_on_error => $sensu::rabbitmq_reconnect_on_error,
+    prefetch           => $sensu::rabbitmq_prefetch,
   }
 
 }

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -147,6 +147,29 @@ describe 'sensu', :type => :class do
       ) }
     end # when using key in variable
 
+    context 'when using prefetch attribute' do
+      let(:params) { {
+        :rabbitmq_host => 'myhost',
+        :rabbitmq_prefetch => '10'
+      } }
+
+      it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
+        :host => 'myhost',
+        :prefetch  => '10'
+      ) }
+    end # when using prefetch attribute
+
+    context 'when not using prefetch attribute' do
+      let(:params) { {
+        :rabbitmq_host => 'myhost'
+      } }
+
+      it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
+        :host => 'myhost',
+        :prefetch  => '1'
+      ) }
+    end # when not using prefetch attribute
+
     context 'purge config' do
       let(:params) { {
         :purge  => { 'config' => true },


### PR DESCRIPTION
I was getting an error trying to set the [Rabbitmq prefetch attribute](https://sensuapp.org/docs/latest/rabbitmq#anatomy-of-a-rabbitmq-definition) in the ::sensu class.
Added the [Rabbitmq prefetch attribute](https://sensuapp.org/docs/latest/rabbitmq#anatomy-of-a-rabbitmq-definition), following the same format as the other attributes (such as rabbitmq_port), and got it to update the /etc/sensu/conf.d/rabbitmq.json with prefetch successfully when running on this branch.  
Set the default to 1 since that's what it is in the Sensu docs.
Added rspec tests and verified they're passing.