### PR TITLE
add support for configuring sensu-enterprise-dashboard ssl listener

### DIFF
--- a/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
+++ b/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
@@ -120,6 +120,20 @@ Puppet::Type.type(:sensu_enterprise_dashboard_config).provide(:json) do
     conf['dashboard']['pass'] = value
   end
 
+  # Public: Set the ssl listener config
+  #
+  # Returns nothing.
+  def ssl=(value)
+    conf['dashboard']['ssl'] = value
+  end
+
+  # Public: Get the Dashboard ssl
+  #
+  # Returns the ssl listener config
+  def ssl
+    conf['dashboard']['ssl']
+  end
+
   # Public: Retrieve the Github config
   #
   # Returns the Github auth config

--- a/lib/puppet/type/sensu_enterprise_dashboard_config.rb
+++ b/lib/puppet/type/sensu_enterprise_dashboard_config.rb
@@ -56,6 +56,16 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_config) do
     desc "A password to enable simple authentication and restrict access to the dashboard. Leave blank along with user to disable simple authentication."
   end
 
+  newproperty(:ssl) do
+    desc "A hash of SSL attributes to enable native SSL"
+
+    validate do |value|
+      unless value.respond_to?(:to_hash)
+        raise ArgumentError, "Sensu Enterprise Dashboard ssl config must be a Hash"
+      end
+    end
+  end
+
   newproperty(:github) do
     desc "A hash of GitHub authentication attributes to enable GitHub authentication via OAuth. Overrides simple authentication."
 

--- a/manifests/enterprise/dashboard/config.pp
+++ b/manifests/enterprise/dashboard/config.pp
@@ -39,6 +39,7 @@ class sensu::enterprise::dashboard::config {
       refresh   => $::sensu::enterprise_dashboard_refresh,
       user      => $::sensu::enterprise_dashboard_user,
       pass      => $::sensu::enterprise_dashboard_pass,
+      ssl       => $::sensu::enterprise_dashboard_ssl,
       github    => $::sensu::enterprise_dashboard_github,
       ldap      => $::sensu::enterprise_dashboard_ldap,
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -380,6 +380,7 @@ class sensu (
   $enterprise_dashboard_refresh   = undef,
   $enterprise_dashboard_user      = undef,
   $enterprise_dashboard_pass      = undef,
+  $enterprise_dashboard_ssl       = undef,
   $enterprise_dashboard_github    = undef,
   $enterprise_dashboard_ldap      = undef,
   $path                           = undef,


### PR DESCRIPTION
Uchiwa 0.14.2 and Sensu Enterprise Dashboard support a native SSL listener. This change adds support for specifying ssl configuration in sensu_enterprise_dashboard_config as a Hash.