### PR TITLE
Install rake < 11.0.0 for ruby < 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
 end
 
 group :development, :unit_tests do
-  gem 'rake',                                             :require => false
+  gem 'rake',                                             '< 11.0.0'
   gem 'rspec-puppet',                                     :require => false
   gem 'puppetlabs_spec_helper',                           :require => false
   gem 'puppet-lint', "1.0.1",                             :require => false


### PR DESCRIPTION
Starting with version 11.0.0 rake requires ruby 1.9.3 or later, see ruby/rake@4ab6eba0d77c7e2d449e9292673099e2f10e193b. This is causing Travis tests to fail, see the [Ruby: 1.8.7](https://travis-ci.org/sensu/sensu-puppet/builds/115171590) builds for #486:
```
Gem::InstallError: rake requires Ruby version >= 1.9.3.
An error occurred while installing rake (11.0.1), and Bundler cannot continue.
```