### PR TITLE
updating package provider to upgrade gems

### DIFF
--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -18,6 +18,12 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
       "/opt/sensu/embedded/bin/gem"
     end
 
+  def update
+    command = [command(:gemcmd), "update"]
+    command << resource[:name]
+    output = execute(command)
+  end
+
   def uninstall
     command = [command(:gemcmd), "uninstall"]
     command << "-x" << "-a" << resource[:name]

--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -18,6 +18,12 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
       "/opt/sensu/embedded/bin/gem"
     end
 
+  def install
+    command = [command(:gemcmd), "install"]
+    command << resource[:name]
+    output = execute(command)
+  end
+
   def update
     command = [command(:gemcmd), "update"]
     command << resource[:name]


### PR DESCRIPTION
Currently the sensu_gems package provider doesn't allow gems to be updated, this fixes that.  So if you are bold you can ensure 'latest' on packages or set a newer version.