### PR TITLE
Updated config.pp to add base_path

### DIFF
--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -120,6 +120,7 @@ class sensu::rabbitmq::config {
     ssl_private_key    => $ssl_private_key,
     reconnect_on_error => $sensu::rabbitmq_reconnect_on_error,
     prefetch           => $sensu::rabbitmq_prefetch,
+    base_path          => $sensu::conf_dir,
   }
 
 }


### PR DESCRIPTION
sensu_rabbitmq_config resource type does not a base_path param being passed to it. This causes it default to /etc/sensu/conf.d which breaks Windows support. Added base_path to resource using $sensu::conf_dir, used on the above file resource to ensure the directory.