### PR TITLE
adding support for sentinel config

### DIFF
--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -77,6 +77,14 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
     conf['redis']['db'] = value.to_i
   end
 
+  def sentinels
+    conf['redis']['sentinels']
+  end
+
+  def sentinels=(value)
+    conf['redis']['sentinels'] = value
+  end
+
   def auto_reconnect
     conf['redis']['auto_reconnect']
   end

--- a/lib/puppet/provider/sensu_redis_sentinel_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_sentinel_config/json.rb
@@ -3,7 +3,7 @@ require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))
 
-Puppet::Type.type(:sensu_redis_config).provide(:json) do
+Puppet::Type.type(:sensu_redis_sentinel_config).provide(:json) do
   confine :feature => :json
   include PuppetX::Sensu::ProviderCreate
 
@@ -37,52 +37,12 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
     conf.has_key? 'redis'
   end
 
-  def port
-    conf['redis']['port'].to_s
-  end
-
-  def port=(value)
-    conf['redis']['port'] = value.to_i
-  end
-
-  def host
-    conf['redis']['host']
-  end
-
-  def host=(value)
-    conf['redis']['host'] = value
-  end
-
   def password
     conf['redis']['password']
   end
 
   def password=(value)
     conf['redis']['password'] = value
-  end
-
-  def reconnect_on_error
-    conf['redis']['reconnect_on_error']
-  end
-
-  def reconnect_on_error=(value)
-    conf['redis']['reconnect_on_error'] = value
-  end
-
-  def db
-    conf['redis']['db'].to_s
-  end
-
-  def db=(value)
-    conf['redis']['db'] = value.to_i
-  end
-
-  def sentinels_enabled
-    conf['redis']['sentinels_enabled']
-  end
-
-  def sentinels_enabled=(value)
-    conf['redis']['sentinels_enabled'] = value
   end
 
   def sentinels
@@ -109,11 +69,4 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
     end
   end
 
-  def auto_reconnect
-    conf['redis']['auto_reconnect']
-  end
-
-  def auto_reconnect=(value)
-    conf['redis']['auto_reconnect'] = value
-  end
 end

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -68,6 +68,10 @@ Puppet::Type.newtype(:sensu_redis_config) do
     defaultto :true
   end
 
+  newproperty(:sentinels) do
+    desc "Redis Sentinel configuration for HA clustering"
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/lib/puppet/type/sensu_redis_sentinel_config.rb
+++ b/lib/puppet/type/sensu_redis_sentinel_config.rb
@@ -2,7 +2,7 @@ require 'set'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
                                    'puppet_x', 'sensu', 'boolean_property.rb'))
 
-Puppet::Type.newtype(:sensu_redis_config) do
+Puppet::Type.newtype(:sensu_redis_sentinel_config) do
   @doc = ""
 
   def initialize(*args)
@@ -35,44 +35,8 @@ Puppet::Type.newtype(:sensu_redis_config) do
     defaultto '/etc/sensu/conf.d/'
   end
 
-  newproperty(:port) do
-    desc "The port that Redis is listening on"
-
-    defaultto '6379'
-  end
-
-  newproperty(:host) do
-    desc "The hostname that Redis is listening on"
-
-    defaultto 'localhost'
-  end
-
   newproperty(:password) do
     desc "The password used to connect to Redis"
-  end
-
-  newproperty(:reconnect_on_error, :parent => PuppetX::Sensu::BooleanProperty) do
-    desc "Attempt to reconnect to RabbitMQ on error"
-
-    defaultto :false
-  end
-
-  newproperty(:db) do
-    desc "The Redis instance DB to use/select"
-
-    defaultto '0'
-  end
-
-  newproperty(:auto_reconnect) do
-    desc "Reconnect to Redis in the event of a connection failure"
-
-    defaultto :true
-  end
-
-  newproperty(:sentinels_enabled, :parent => PuppetX::Sensu::BooleanProperty) do
-    desc "Will Sentinelconfig be used or standard config"
-
-    defaultto :false
   end
 
   newproperty(:sentinels, :array_matching => :all) do

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -85,7 +85,7 @@ define sensu::check(
   $ensure              = 'present',
   $type                = undef,
   $handlers            = undef,
-  $standalone          = true,
+  $standalone          = false,
   $interval            = 60,
   $occurrences         = undef,
   $refresh             = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,6 +173,10 @@
 #   Integer.  The Redis instance DB to use/select
 #   Default: 0
 #
+# [*redis_sentinels*]
+#   Array. Redis Sentinel configuration and connection information for one or more Sentinels
+#   Default: Not configured
+#
 # [*redis_auto_reconnect*]
 #   Boolean.  Reconnect to Redis in the event of a connection failure
 #   Default: true
@@ -354,6 +358,7 @@ class sensu (
   $redis_reconnect_on_error       = false,
   $redis_db                       = 0,
   $redis_auto_reconnect           = true,
+  $redis_sentinels                = [],
   $api_bind                       = '0.0.0.0',
   $api_host                       = 'localhost',
   $api_port                       = 4567,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,6 +172,20 @@
 # [*redis_db*]
 #   Integer.  The Redis instance DB to use/select
 #   Default: 0
+# 
+# [*sentinels_enabled*]
+#   Boolean. Defines if Sentinel config or standard config will be used
+#   Default: false
+#   Valid values: true, false
+#
+# [*redis_sentinels*]
+#   Array. Redis Sentinel configuration and connection information for one or more Sentinels
+#   Default: Not configured
+#
+# [*sentinels_enabled*]
+#   Boolean. Defines Sentinelsconfig be used or standard config
+#   Default: false
+#   Valid valuesL true, false
 #
 # [*redis_sentinels*]
 #   Array. Redis Sentinel configuration and connection information for one or more Sentinels
@@ -352,13 +366,14 @@ class sensu (
   $rabbitmq_ssl_cert_chain        = undef,
   $rabbitmq_reconnect_on_error    = false,
   $rabbitmq_prefetch              = 1,
-  $redis_host                     = 'localhost',
+  $redis_host                     = '127.0.0.1',
   $redis_port                     = 6379,
   $redis_password                 = undef,
-  $redis_reconnect_on_error       = false,
+  $redis_reconnect_on_error       = true,
   $redis_db                       = 0,
   $redis_auto_reconnect           = true,
   $redis_sentinels                = [],
+  $sentinels_enabled              = false,
   $api_bind                       = '0.0.0.0',
   $api_host                       = 'localhost',
   $api_port                       = 4567,
@@ -412,7 +427,7 @@ class sensu (
 
 ){
 
-  validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir)
+  validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $sentinels_enabled, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir)
 
   validate_re($repo, ['^main$', '^unstable$'], "Repo must be 'main' or 'unstable'.  Found: ${repo}")
   validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -32,6 +32,7 @@ class sensu::redis::config {
     reconnect_on_error => $sensu::redis_reconnect_on_error,
     db                 => $sensu::redis_db,
     auto_reconnect     => $sensu::redis_auto_reconnect,
+    sentinels          => $sensu::redis_sentinels,
   }
 
 }

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -1,4 +1,3 @@
-# = Class: sensu::redis::config
 #
 # Sets the Sensu redis config
 #
@@ -14,25 +13,41 @@ class sensu::redis::config {
     $ensure = 'present'
   }
 
-  # redis configuration may contain "secrets"
-  file { "${sensu::etc_dir}/conf.d/redis.json":
-    ensure => $ensure,
-    owner  => $sensu::user,
-    group  => $sensu::group,
-    mode   => $sensu::file_mode,
-    before => Sensu_redis_config[$::fqdn],
-  }
 
-  sensu_redis_config { $::fqdn:
-    ensure             => $ensure,
-    base_path          => "${sensu::etc_dir}/conf.d",
-    host               => $sensu::redis_host,
-    port               => $sensu::redis_port,
-    password           => $sensu::redis_password,
-    reconnect_on_error => $sensu::redis_reconnect_on_error,
-    db                 => $sensu::redis_db,
-    auto_reconnect     => $sensu::redis_auto_reconnect,
-    sentinels          => $sensu::redis_sentinels,
-  }
+  if $sensu::sentinels_enabled == false {
+    # redis configuration may contain "secrets"
+    file { "${sensu::etc_dir}/conf.d/redis.json":
+      ensure => $ensure,
+      owner  => $sensu::user,
+      group  => $sensu::group,
+      mode   => $sensu::file_mode,
+      before => Sensu_redis_config[$::fqdn],
+    }
 
+    sensu_redis_config { $::fqdn:
+      ensure             => $ensure,
+      base_path          => "${sensu::etc_dir}/conf.d",
+      host               => $sensu::redis_host,
+      port               => $sensu::redis_port,
+      password           => $sensu::redis_password,
+      reconnect_on_error => $sensu::redis_reconnect_on_error,
+      db                 => $sensu::redis_db,
+      auto_reconnect     => $sensu::redis_auto_reconnect,
+    }
+  } else {
+    # redis configuration may contain "secrets"
+    file { "${sensu::etc_dir}/conf.d/redis.json":
+      ensure => $ensure,
+      owner  => $sensu::user,
+      group  => $sensu::group,
+      mode   => $sensu::file_mode,
+      before => Sensu_redis_sentinel_config[$::fqdn],
+    }
+
+    sensu_redis_sentinel_config { $::fqdn:
+      ensure    => $ensure,
+      password  => $sensu::redis_password,
+      sentinels => $sensu::redis_sentinels,
+    }
+  }
 }

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -20,7 +20,8 @@ describe 'sensu' do
         :redis_port           => 1234,
         :redis_password       => 'password',
         :redis_db             => 1,
-        :redis_auto_reconnect => false
+        :redis_auto_reconnect => false,
+        :redis_sentinels      => [],
       } }
 
       it { should contain_sensu_redis_config('testhost.domain.com').with(


### PR DESCRIPTION
Support for redis sentinel configuration as documented on https://sensuapp.org/docs/latest/redis used for HA clustering and failover 