### PR TITLE
plugins should be hash and use create_resources

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -549,7 +549,7 @@ class sensu (
   if $plugins_dir {
     sensu::plugin { $plugins_dir: type => 'directory' }
   } else {
-    create_resources('::sensu::plugin', $plugins, $plugins_default)
+    create_resources('::sensu::plugin', $plugins, $plugins_defaults)
   }
 
 }

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -120,6 +120,7 @@ class sensu::rabbitmq::config {
     ssl_private_key    => $ssl_private_key,
     reconnect_on_error => $sensu::rabbitmq_reconnect_on_error,
     prefetch           => $sensu::rabbitmq_prefetch,
+    base_path          => $sensu::conf_dir,
   }
 
 }


### PR DESCRIPTION
The current use of plugins param is an array for files only. This isn't necessarily a problem but the install_path is not dynamic so you can't use it on windows. In general, a better solution is for plugins to be like checks and be a hash. This allow multiple plugin types and allows the install_path to be overwritten on per plugin basis or using plugins_defaults.
