### PR TITLE
added source in remote_file for plugin install

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -100,6 +100,7 @@ define sensu::plugin(
           ensure   => present,
           path     => "${install_path}/${filename}",
           checksum => $pkg_checksum,
+          source   => $name,
           require  => File[$install_path],
         } ->
         file { "${install_path}/${filename}":


### PR DESCRIPTION
Without the source parameter, the remote_file definition is failing....
Error: Could not set 'present' on ensure: bad URI(is not URI?):  at 104: sensu/manifests/plugin.pp
Wrapped exception: bad URI(is not URI?)