### PR TITLE
Support redis sentinels and add master property

### DIFF
--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -16,6 +16,14 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
   end
 
   def flush
+    # Clean nil valued properties, esp. sentinel related
+    # Related to https://github.com/sensu/sensu-puppet/issues/394.
+    self.class.resource_type.validproperties.each do |prop|
+      if resource.should(prop).nil?
+        conf['redis'].delete prop.to_s
+      end
+    end
+
     File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
@@ -38,19 +46,27 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
   end
 
   def port
-    conf['redis']['port'].to_s
+    if conf['redis']['port'] then conf['redis']['port'].to_s else :absent end
   end
 
   def port=(value)
-    conf['redis']['port'] = value.to_i
+    if value == :absent
+      conf['redis'].delete 'port'
+    else
+      conf['redis']['port'] = value.to_i
+    end
   end
 
   def host
-    conf['redis']['host']
+    conf['redis']['host'] || :absent
   end
 
   def host=(value)
-    conf['redis']['host'] = value
+    if value == :absent
+      conf['redis'].delete 'host'
+    else
+      conf['redis']['host'] = value
+    end
   end
 
   def password
@@ -75,6 +91,18 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
 
   def db=(value)
     conf['redis']['db'] = value.to_i
+  end
+
+  def sentinels
+    conf['redis']['sentinels'] || []
+  end
+
+  def sentinels=(value)
+    if value == []
+      conf['redis'].delete 'sentinels'
+    else
+      conf['redis']['sentinels'] = value
+    end
   end
 
   def auto_reconnect

--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -105,6 +105,18 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
     end
   end
 
+  def master
+    conf['redis']['master'] || :absent
+  end
+
+  def master=(value)
+    if value == :absent
+      conf['redis'].delete 'master'
+    else
+      conf['redis']['master'] = value.to_s
+    end
+  end
+
   def auto_reconnect
     conf['redis']['auto_reconnect']
   end

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -1,3 +1,4 @@
+require 'set'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
                                    'puppet_x', 'sensu', 'boolean_property.rb'))
 
@@ -11,6 +12,22 @@ Puppet::Type.newtype(:sensu_redis_config) do
       "Service[sensu-api]",
       "Service[sensu-server]",
     ].select { |ref| catalog.resource(ref) }
+  end
+
+  def has_sentinels?
+    sentinels = self.should(:sentinels)
+    return sentinels && !sentinels.empty?
+  end
+
+  def pre_run_check
+    if self.has_sentinels? then
+      if self.should(:host) && self.should(:host) != :absent then
+        raise Puppet::Error, "Redis 'host' (#{self.should(:host)}) must not be specified when sentinels are specified"
+      end
+      if self.should(:port) && self.should(:port) != :absent then
+        raise Puppet::Error, "Redis 'port' (#{self.should(:port)}) must not be specified when sentinels are specified"
+      end
+    end
   end
 
   ensurable do
@@ -37,13 +54,25 @@ Puppet::Type.newtype(:sensu_redis_config) do
   newproperty(:port) do
     desc "The port that Redis is listening on"
 
-    defaultto '6379'
+    defaultto {
+      if !@resource.has_sentinels? then '6379' else :absent end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
   end
 
   newproperty(:host) do
     desc "The hostname that Redis is listening on"
 
-    defaultto '127.0.0.1'
+    defaultto {
+      # Use absent to ensure that config is flushed
+      # when property gets unset
+      if !@resource.has_sentinels? then '127.0.0.1' else :absent end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
   end
 
   newproperty(:password) do
@@ -66,6 +95,23 @@ Puppet::Type.newtype(:sensu_redis_config) do
     desc "Reconnect to Redis in the event of a connection failure"
 
     defaultto :true
+  end
+
+  newproperty(:sentinels, :array_matching => :all) do
+    desc "Redis Sentinel configuration for HA clustering"
+    defaultto []
+
+    def insync?(is)
+      # this probably needs more checks, for duplicate values, etc
+      # but for now it works fine
+      Set.new(is) == Set.new(should)
+    end
+
+    munge do |value|
+      Hash[value.map do |k, v|
+        [k, if k == "port" then v.to_i else v.to_s end]
+      end]
+    end
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -114,6 +114,16 @@ Puppet::Type.newtype(:sensu_redis_config) do
     end
   end
 
+  newproperty(:master) do
+    desc "Redis master name in the sentinel configuration"
+    # Use absent to ensure that config is flushed
+    # when property gets unset
+    defaultto :absent
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -173,6 +173,10 @@
 #   Integer.  The Redis instance DB to use/select
 #   Default: 0
 #
+# [*redis_sentinels*]
+#   Array. Redis Sentinel configuration and connection information for one or more Sentinels
+#   Default: Not configured
+#
 # [*redis_auto_reconnect*]
 #   Boolean.  Reconnect to Redis in the event of a connection failure
 #   Default: true
@@ -354,6 +358,7 @@ class sensu (
   $redis_reconnect_on_error       = false,
   $redis_db                       = 0,
   $redis_auto_reconnect           = true,
+  $redis_sentinels                = undef,
   $api_bind                       = '0.0.0.0',
   $api_host                       = '127.0.0.1',
   $api_port                       = 4567,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,10 @@
 #   Array. Redis Sentinel configuration and connection information for one or more Sentinels
 #   Default: Not configured
 #
+# [*redis_master*]
+#   String. Redis master name in the sentinel configuration
+#   Default: undef. In the end whatever sensu defaults to, which is "mymaster" currently.
+#
 # [*redis_auto_reconnect*]
 #   Boolean.  Reconnect to Redis in the event of a connection failure
 #   Default: true
@@ -359,6 +363,7 @@ class sensu (
   $redis_db                       = 0,
   $redis_auto_reconnect           = true,
   $redis_sentinels                = undef,
+  $redis_master                   = undef,
   $api_bind                       = '0.0.0.0',
   $api_host                       = '127.0.0.1',
   $api_port                       = 4567,

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -23,15 +23,21 @@ class sensu::redis::config {
     before => Sensu_redis_config[$::fqdn],
   }
 
+  $has_sentinels = !($sensu::redis_sentinels == undef or $sensu::redis_sentinels == [])
+  $host = $has_sentinels ? { false => $sensu::redis_host, true  => undef, }
+  $port = $has_sentinels ? { false => $sensu::redis_port, true  => undef, }
+  $sentinels = $has_sentinels ? { true  => $sensu::redis_sentinels, false => undef, }
+
   sensu_redis_config { $::fqdn:
     ensure             => $ensure,
     base_path          => "${sensu::etc_dir}/conf.d",
-    host               => $sensu::redis_host,
-    port               => $sensu::redis_port,
+    host               => $host,
+    port               => $port,
     password           => $sensu::redis_password,
     reconnect_on_error => $sensu::redis_reconnect_on_error,
     db                 => $sensu::redis_db,
     auto_reconnect     => $sensu::redis_auto_reconnect,
+    sentinels          => $sentinels,
   }
 
 }

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -27,6 +27,7 @@ class sensu::redis::config {
   $host = $has_sentinels ? { false => $sensu::redis_host, true  => undef, }
   $port = $has_sentinels ? { false => $sensu::redis_port, true  => undef, }
   $sentinels = $has_sentinels ? { true  => $sensu::redis_sentinels, false => undef, }
+  $master = $has_sentinels ? { true => $sensu::redis_master, false => undef, }
 
   sensu_redis_config { $::fqdn:
     ensure             => $ensure,
@@ -38,6 +39,7 @@ class sensu::redis::config {
     db                 => $sensu::redis_db,
     auto_reconnect     => $sensu::redis_auto_reconnect,
     sentinels          => $sentinels,
+    master             => $master,
   }
 
 }

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -14,7 +14,7 @@ describe 'sensu' do
       )}
     end # default settings
 
-    context 'be configurable' do
+    context 'be configurable without sentinels' do
       let(:params) { {
         :redis_host           => 'redis.domain.com',
         :redis_port           => 1234,
@@ -28,9 +28,40 @@ describe 'sensu' do
         :port           => 1234,
         :password       => 'password',
         :db             => 1,
-        :auto_reconnect => false        
+        :auto_reconnect => false,
+        :sentinels      => nil,
       )}
-    end # be configurable
+    end # be configurable without sentinels
+
+    context 'be configurable with sentinels' do
+      let(:params) { {
+        :redis_password       => 'password',
+        :redis_db             => 1,
+        :redis_auto_reconnect => false,
+        :redis_sentinels      => [{
+            'host' => 'redis1.domain.com',
+            'port' => 1234
+        }, {
+            'host' => 'redis2.domain.com',
+            'port' => '5678'
+        }]
+      } }
+
+      it { should contain_sensu_redis_config('testhost.domain.com').with(
+        :host           => nil,
+        :port           => nil,
+        :password       => 'password',
+        :db             => 1,
+        :auto_reconnect => false,
+        :sentinels      => [{
+            'host' => 'redis1.domain.com',
+            'port' => 1234
+        }, {
+            'host'  => 'redis2.domain.com',
+            'port'  => 5678
+        }]
+      )}
+    end # be configurable with sentinels
 
     context 'with server' do
       let(:params) { { :server => true } }

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -30,6 +30,7 @@ describe 'sensu' do
         :db             => 1,
         :auto_reconnect => false,
         :sentinels      => nil,
+        :master         => nil
       )}
     end # be configurable without sentinels
 
@@ -44,7 +45,8 @@ describe 'sensu' do
         }, {
             'host' => 'redis2.domain.com',
             'port' => '5678'
-        }]
+        }],
+        :redis_master         => 'master-name'
       } }
 
       it { should contain_sensu_redis_config('testhost.domain.com').with(
@@ -59,7 +61,8 @@ describe 'sensu' do
         }, {
             'host'  => 'redis2.domain.com',
             'port'  => 5678
-        }]
+        }],
+        :master         => "master-name"
       )}
     end # be configurable with sentinels
 

--- a/spec/unit/sensu_redis_config_spec.rb
+++ b/spec/unit/sensu_redis_config_spec.rb
@@ -1,7 +1,16 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_redis_config) do
-  provider_class = described_class.provider(:json)
+  let :provider_class do
+    described_class.provider(:json)
+  end
+
+  def create_type_instance(resource_hash)
+    result = described_class.new(resource_hash)
+    provider_instance = provider_class.new(resource_hash)
+    result.provider = provider_instance
+    result
+  end
 
   let :resource_hash do
     {
@@ -11,10 +20,7 @@ describe Puppet::Type.type(:sensu_redis_config) do
   end
 
   let :type_instance do
-    result = described_class.new(resource_hash)
-    provider_instance = provider_class.new(resource_hash)
-    result.provider = provider_instance
-    result
+    create_type_instance(resource_hash)
   end
 
   describe 'reconnect_on_error property' do
@@ -44,5 +50,92 @@ describe Puppet::Type.type(:sensu_redis_config) do
 
   end
 
+  describe "sentinels" do
+    it "defaults (no sentinels)" do
+      expect(type_instance.parameter(:sentinels).value).to eq([])
+    end
+
+    context "single value" do
+      let :inst do
+        create_type_instance(resource_hash.merge({
+          :sentinels => {
+            'host' => 'redis.sentinel.1',
+            'port' => '12345',
+          }
+        }))
+      end
+
+      it "munges it (to array with port as int)" do
+        expect(inst.parameter(:sentinels).value).to eq([{
+          'host' => 'redis.sentinel.1',
+          'port' => 12345
+        }])
+      end
+
+      it "assumes insync? for the same values" do
+        expect(inst.parameter(:sentinels).safe_insync?([
+            'host' => 'redis.sentinel.1',
+            'port' => 12345
+        ])).to be true
+      end
+
+      [nil, []].each do |v|
+        it "assumes not insync? for empty value #{v.inspect}" do
+          expect(inst.parameter(:sentinels).safe_insync?([])).to be false
+        end
+      end
+
+      it "assumes not insync? for different value" do
+        expect(inst.parameter(:sentinels).safe_insync?([
+            'host' => 'redis.sentinel.1.foo',
+            'port' => 12345
+        ])).to be false
+      end
+    end
+
+    context "multiple values" do
+      let :inst do
+        create_type_instance(resource_hash.merge({
+          :sentinels => [{
+            'host' => 'redis.sentinel.1',
+            'port' => '12345',
+          }, {
+            'host' => 'redis.sentinel.2',
+            'port' => 6789,
+          }]
+        }))
+      end
+
+      it "can munge them" do
+        expect(inst.parameter(:sentinels).value).to eq([{
+          'host' => 'redis.sentinel.1',
+          'port' => 12345
+        }, {
+          'host' => 'redis.sentinel.2',
+          'port' => 6789,
+        }])
+      end
+
+      it "assumes insync? for the same values" do
+        expect(inst.parameter(:sentinels).safe_insync?([{
+          'host' => 'redis.sentinel.1',
+          'port' => 12345
+        }, {
+          'host' => 'redis.sentinel.2',
+          'port' => 6789,
+        }])).to be true
+      end
+
+      it "assumes insync? for the same values in different order" do
+        expect(inst.parameter(:sentinels).safe_insync?([{
+          'host' => 'redis.sentinel.2',
+          'port' => 6789,
+        }, {
+          'host' => 'redis.sentinel.1',
+          'port' => 12345
+        }])).to be true
+     end
+    end
+  end
 
 end


### PR DESCRIPTION
Hello,

this PR adds support for redis sentinels (since sensu 0.23) and adds master property for redis sentinels config (undocumented sensu 0.23 feature). It is somewhat inspired on PR https://github.com/sensu/sensu-puppet/pull/496 but:

1. No sentinel unrelated changes in the code.
2. Code should be cleaner (I have kept the same type / provider for redis config with sentinels)
3. host, port, master, sentinels properties are properly removed from redis.json once they are removed from puppet config or when "connection type" changes.
4. New tests for sentinels.
5. Support for 'master' property https://github.com/sensu/sensu-docs/issues/380

It would be great if you could release a new version with this PR. Thank you.