### PR TITLE
small puppet-lint fixes

### DIFF
--- a/manifests/client/service.pp
+++ b/manifests/client/service.pp
@@ -34,7 +34,7 @@ class sensu::client::service (
     if $::osfamily == 'windows' {
 
       file { 'C:/opt/sensu/bin/sensu-client.xml':
-        ensure  => present,
+        ensure  => file,
         content => template("${module_name}/sensu-client.erb"),
       }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -540,6 +540,8 @@ class sensu (
       $dir_mode = undef
       $file_mode = undef
     }
+
+    default: {}
   }
 
   # Include everything and let each module determine its state.  This allows


### PR DESCRIPTION
This is to obey style guide recommendations:
* [Defaults for Case Statements and Selectors](https://docs.puppet.com/guides/style_guide.html#defaults-for-case-statements-and-selectors)
* [File modes](https://docs.puppet.com/guides/style_guide.html#file-modes) / [Ensure present on file resource](https://github.com/voxpupuli/puppet-lint-file_ensure-check#ensure-present-on-file-resource)