### PR TITLE
skip ssl config if rabbitmq_ssl = false

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -127,7 +127,9 @@
 #   Boolean.  Use SSL transport to connect to RabbitMQ.  If rabbitmq_ssl_private_key and/or
 #     rabbitmq_ssl_cert_chain are set, then this is enabled automatically.  Set rabbitmq_ssl => true
 #     without specifying a private key or cert chain to use SSL transport, but not cert auth.
-#   Defaul: false
+#     Setting rabbitmq_ssl => false will disable rabbitmq_ssl_cert_chain or rabbitmq_ssl_private_key
+#     from being created
+#   Default: undef
 #   Valid values: true, false
 #
 # [*rabbitmq_ssl_private_key*]
@@ -362,7 +364,7 @@ class sensu (
   $rabbitmq_user                  = 'sensu',
   $rabbitmq_password              = undef,
   $rabbitmq_vhost                 = '/sensu',
-  $rabbitmq_ssl                   = false,
+  $rabbitmq_ssl                   = undef,
   $rabbitmq_ssl_private_key       = undef,
   $rabbitmq_ssl_cert_chain        = undef,
   $rabbitmq_reconnect_on_error    = false,

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -16,88 +16,92 @@ class sensu::rabbitmq::config {
 
   $ssl_dir = "${sensu::etc_dir}/ssl"
 
-  if $sensu::rabbitmq_ssl_cert_chain or $sensu::rabbitmq_ssl_private_key {
-    file { $ssl_dir:
-      ensure  => directory,
-      owner   => $sensu::user,
-      group   => $sensu::group,
-      mode    => '0755',
-      require => Package['sensu'],
-    }
-
-    # if provided a cert chain, and its a puppet:// URI, source file form the
-    # the URI provided
-    if $sensu::rabbitmq_ssl_cert_chain and $sensu::rabbitmq_ssl_cert_chain =~ /^puppet:\/\// {
-      file { "${ssl_dir}/cert.pem":
-        ensure  => file,
-        source  => $sensu::rabbitmq_ssl_cert_chain,
-        owner   => $sensu::user,
-        group   => $sensu::group,
-        mode    => $sensu::file_mode,
-        require => File[$ssl_dir],
-        before  => Sensu_rabbitmq_config[$::fqdn],
-      }
-
-      $ssl_cert_chain = '/etc/sensu/ssl/cert.pem'
-    # else provided a cert chain, and the variable actually contains the cert,
-    # create the file with conents of the variable
-    } elsif $sensu::rabbitmq_ssl_cert_chain and  $sensu::rabbitmq_ssl_cert_chain =~ /BEGIN CERTIFICATE/ {
-      file { "${ssl_dir}/cert.pem":
-        ensure  => file,
-        content => $sensu::rabbitmq_ssl_cert_chain,
-        owner   => $sensu::user,
-        group   => $sensu::group,
-        mode    => $sensu::file_mode,
-        require => File[$ssl_dir],
-        before  => Sensu_rabbitmq_config[$::fqdn],
-      }
-
-      $ssl_cert_chain = '/etc/sensu/ssl/cert.pem'
-    # else set the cert to value passed in wholesale, usually this is
-    # a raw file path
-    } else {
-      $ssl_cert_chain = $sensu::rabbitmq_ssl_cert_chain
-    }
-
-    # if provided private key, and its a puppet:// URI, source file from the
-    # URI provided
-    if $sensu::rabbitmq_ssl_private_key and $sensu::rabbitmq_ssl_private_key =~ /^puppet:\/\// {
-      file { "${ssl_dir}/key.pem":
-        ensure  => file,
-        source  => $sensu::rabbitmq_ssl_private_key,
-        owner   => $sensu::user,
-        group   => $sensu::group,
-        mode    => $sensu::file_mode,
-        require => File[$ssl_dir],
-        before  => Sensu_rabbitmq_config[$::fqdn],
-      }
-
-      $ssl_private_key = '/etc/sensu/ssl/key.pem'
-    # else provided private key, and the variable actually contains the key,
-    # create file with contents of the variable
-    } elsif $sensu::rabbitmq_ssl_private_key and $sensu::rabbitmq_ssl_private_key =~ /BEGIN RSA PRIVATE KEY/ {
-      file { "${ssl_dir}/key.pem":
-        ensure  => file,
-        content => $sensu::rabbitmq_ssl_private_key,
-        owner   => $sensu::user,
-        group   => $sensu::group,
-        mode    => $sensu::file_mode,
-        require => File[$ssl_dir],
-        before  => Sensu_rabbitmq_config[$::fqdn],
-      }
-
-      $ssl_private_key = '/etc/sensu/ssl/key.pem'
-    # else set the private key to value passed in wholesale, usually this is
-    # a raw file path
-    } else {
-      $ssl_private_key = $sensu::rabbitmq_ssl_private_key
-    }
-
-    $enable_ssl = true
+  if $sensu::rabbitmq_ssl == false {
+    # do nothing
   } else {
-    $ssl_cert_chain = undef
-    $ssl_private_key = undef
-    $enable_ssl = $sensu::rabbitmq_ssl
+    if $sensu::rabbitmq_ssl_cert_chain or $sensu::rabbitmq_ssl_private_key {
+      file { $ssl_dir:
+        ensure  => directory,
+        owner   => $sensu::user,
+        group   => $sensu::group,
+        mode    => '0755',
+        require => Package['sensu'],
+      }
+
+      # if provided a cert chain, and its a puppet:// URI, source file form the
+      # the URI provided
+      if $sensu::rabbitmq_ssl_cert_chain and $sensu::rabbitmq_ssl_cert_chain =~ /^puppet:\/\// {
+        file { "${ssl_dir}/cert.pem":
+          ensure  => file,
+          source  => $sensu::rabbitmq_ssl_cert_chain,
+          owner   => $sensu::user,
+          group   => $sensu::group,
+          mode    => $sensu::file_mode,
+          require => File[$ssl_dir],
+          before  => Sensu_rabbitmq_config[$::fqdn],
+        }
+
+        $ssl_cert_chain = '/etc/sensu/ssl/cert.pem'
+      # else provided a cert chain, and the variable actually contains the cert,
+      # create the file with conents of the variable
+      } elsif $sensu::rabbitmq_ssl_cert_chain and  $sensu::rabbitmq_ssl_cert_chain =~ /BEGIN CERTIFICATE/ {
+        file { "${ssl_dir}/cert.pem":
+          ensure  => file,
+          content => $sensu::rabbitmq_ssl_cert_chain,
+          owner   => $sensu::user,
+          group   => $sensu::group,
+          mode    => $sensu::file_mode,
+          require => File[$ssl_dir],
+          before  => Sensu_rabbitmq_config[$::fqdn],
+        }
+
+        $ssl_cert_chain = '/etc/sensu/ssl/cert.pem'
+      # else set the cert to value passed in wholesale, usually this is
+      # a raw file path
+      } else {
+        $ssl_cert_chain = $sensu::rabbitmq_ssl_cert_chain
+      }
+
+      # if provided private key, and its a puppet:// URI, source file from the
+      # URI provided
+      if $sensu::rabbitmq_ssl_private_key and $sensu::rabbitmq_ssl_private_key =~ /^puppet:\/\// {
+        file { "${ssl_dir}/key.pem":
+          ensure  => file,
+          source  => $sensu::rabbitmq_ssl_private_key,
+          owner   => $sensu::user,
+          group   => $sensu::group,
+          mode    => $sensu::file_mode,
+          require => File[$ssl_dir],
+          before  => Sensu_rabbitmq_config[$::fqdn],
+        }
+
+        $ssl_private_key = '/etc/sensu/ssl/key.pem'
+      # else provided private key, and the variable actually contains the key,
+      # create file with contents of the variable
+      } elsif $sensu::rabbitmq_ssl_private_key and $sensu::rabbitmq_ssl_private_key =~ /BEGIN RSA PRIVATE KEY/ {
+        file { "${ssl_dir}/key.pem":
+          ensure  => file,
+          content => $sensu::rabbitmq_ssl_private_key,
+          owner   => $sensu::user,
+          group   => $sensu::group,
+          mode    => $sensu::file_mode,
+          require => File[$ssl_dir],
+          before  => Sensu_rabbitmq_config[$::fqdn],
+        }
+
+        $ssl_private_key = '/etc/sensu/ssl/key.pem'
+      # else set the private key to value passed in wholesale, usually this is
+      # a raw file path
+      } else {
+        $ssl_private_key = $sensu::rabbitmq_ssl_private_key
+      }
+
+      $enable_ssl = true
+    } else {
+      $ssl_cert_chain = undef
+      $ssl_private_key = undef
+      $enable_ssl = $sensu::rabbitmq_ssl
+    }
   }
 
   file { "${sensu::conf_dir}/rabbitmq.json":


### PR DESCRIPTION
Allow rabbitmq_ssl to be explicitly defined as false. The modules default behavior is that if ssl cert/keys are defined anywhere in hiera, then ssl is reconfigured, regardless if desired or not.