### PR TITLE
Pin listen to a working pre-ruby2.2 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,8 +35,9 @@ group :system_tests do
 end
 
 group :development do
-  gem 'simplecov',   :require => false
-  gem 'guard-rake',  :require => false
+  gem 'simplecov',          :require => false
+  gem 'guard-rake',         :require => false
+  gem 'listen', '~> 3.0.0', :require => false
 end
 
 if facterversion = ENV['FACTER_GEM_VERSION']


### PR DESCRIPTION
It looks like guard requires listen. Listen has been updated to only
support ruby >= 2.2.x. The last version of listen to work on ruby >=
1.9.3 was 3.0.x. This pins the version of listen so development
dependencies can be installed on ruby 2.1.x.