### PR TITLE
Pin the package provider for RedHat osfamily

### DIFF
--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe 'sensu' do
   let(:facts) { { :fqdn => 'testhost.domain.com', :osfamily => 'RedHat' } }
+  let(:pre_condition) { 'Package{ provider => "yum"}' }
 
   context 'redis config' do
 


### PR DESCRIPTION
Local tests fail when run on a Mac. This commit forces the package
provider to use yum. Since we're already assuming the osfamily is RedHat
and the default package provider for RedHat is yum, side effects from
this change should be minimal. And local tests will pass on a Mac.

Original error:
`Parameter ensure failed on Package[sensu]: Provider must have features
'upgradeable' to set 'ensure' to 'latest'`