### PR TITLE
Allow undef handlers and subscribers

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -45,7 +45,8 @@ Puppet::Type.newtype(:sensu_check) do
   newproperty(:handlers, :array_matching => :all) do
     desc "List of handlers that responds to this check"
     def insync?(is)
-      is.sort == should.sort
+      return is.sort == should.sort if is.is_a?(Array) && should.is_a?(Array)
+      is == should
     end
   end
 
@@ -81,7 +82,8 @@ Puppet::Type.newtype(:sensu_check) do
   newproperty(:subscribers, :array_matching => :all) do
     desc "Who is subscribed to this check"
     def insync?(is)
-      is.sort == should.sort
+      return is.sort == should.sort if is.is_a?(Array) && should.is_a?(Array)
+      is == should
     end
   end
 

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -3,22 +3,22 @@ require 'spec_helper'
 describe Puppet::Type.type(:sensu_check) do
   let(:resource_hash) do
     {
-      title: 'foo.example.com',
-      catalog: Puppet::Resource::Catalog.new
+      :title => 'foo.example.com',
+      :catalog => Puppet::Resource::Catalog.new
     }
   end
 
   describe 'handlers' do
     it 'should support a string as a value' do
       expect(
-        described_class.new(resource_hash.merge(handlers: 'default'))[:handlers]
+        described_class.new(resource_hash.merge(:handlers => 'default'))[:handlers]
       ).to eq ['default']
     end
 
     it 'should support an array as a value' do
       expect(
         described_class.new(
-          resource_hash.merge(handlers: %w(handler1 handler2))
+          resource_hash.merge(:handlers => %w(handler1 handler2))
         )[:handlers]
       ).to eq %w(handler1 handler2)
     end
@@ -26,7 +26,7 @@ describe Puppet::Type.type(:sensu_check) do
     # it 'should support nil as a value' do
     #   expect(
     #     described_class.new(
-    #       resource_hash.merge(handlers: nil)
+    #       resource_hash.merge(:handlers => nil)
     #     )[:handlers]
     #   ).to eq nil
     # end
@@ -35,14 +35,14 @@ describe Puppet::Type.type(:sensu_check) do
   describe 'subscribers' do
     it 'should support a string as a value' do
       expect(
-        described_class.new(resource_hash.merge(subscribers: 'default'))[:subscribers]
+        described_class.new(resource_hash.merge(:subscribers => 'default'))[:subscribers]
       ).to eq ['default']
     end
 
     it 'should support an array as a value' do
       expect(
         described_class.new(
-          resource_hash.merge(subscribers: %w(subscriber1 subscriber2))
+          resource_hash.merge(:subscribers => %w(subscriber1 subscriber2))
         )[:subscribers]
       ).to eq %w(subscriber1 subscriber2)
     end
@@ -50,7 +50,7 @@ describe Puppet::Type.type(:sensu_check) do
     # it 'should support nil as a value' do
     #   expect(
     #     described_class.new(
-    #       resource_hash.merge(subscribers: nil)
+    #       resource_hash.merge(:subscribers => nil)
     #     )[:subscribers]
     #   ).to eq nil
     # end

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_check) do
+  let(:resource_hash) do
+    {
+      title: 'foo.example.com',
+      catalog: Puppet::Resource::Catalog.new
+    }
+  end
+
+  describe 'handlers' do
+    it 'should support a string as a value' do
+      expect(
+        described_class.new(resource_hash.merge(handlers: 'default'))[:handlers]
+      ).to eq ['default']
+    end
+
+    it 'should support an array as a value' do
+      expect(
+        described_class.new(
+          resource_hash.merge(handlers: %w(handler1 handler2))
+        )[:handlers]
+      ).to eq %w(handler1 handler2)
+    end
+
+    # it 'should support nil as a value' do
+    #   expect(
+    #     described_class.new(
+    #       resource_hash.merge(handlers: nil)
+    #     )[:handlers]
+    #   ).to eq nil
+    # end
+  end
+
+  describe 'subscribers' do
+    it 'should support a string as a value' do
+      expect(
+        described_class.new(resource_hash.merge(subscribers: 'default'))[:subscribers]
+      ).to eq ['default']
+    end
+
+    it 'should support an array as a value' do
+      expect(
+        described_class.new(
+          resource_hash.merge(subscribers: %w(subscriber1 subscriber2))
+        )[:subscribers]
+      ).to eq %w(subscriber1 subscriber2)
+    end
+
+    # it 'should support nil as a value' do
+    #   expect(
+    #     described_class.new(
+    #       resource_hash.merge(subscribers: nil)
+    #     )[:subscribers]
+    #   ).to eq nil
+    # end
+  end
+end


### PR DESCRIPTION
This commit fixes the error message: `undefined method `sort' for
nil:NilClass`. This error message can be seen when either the handlers
or subscribers parameters are passed in as  `undef` in the check.pp
manifest.

The PRs that looks like they introduced this behavior are:
https://github.com/sensu/sensu-puppet/pull/285
https://github.com/sensu/sensu-puppet/pull/303