### PR TITLE
Windows package title

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -95,7 +95,7 @@ class sensu::package {
       owner   => '0',
       group   => '0',
       mode    => '0444',
-      require => Package['sensu'],
+      require => Package[$pkg_name],
     }
   }
 

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -44,7 +44,7 @@ class sensu::package {
 
       $pkg_version = inline_template("<%= scope.lookupvar('sensu::version').sub(/(.*)\\./, '\\1-') %>")
       $pkg_title = 'sensu'
-      $pkg_name = 'Sensu'
+      $pkg_name = 'sensu'
       $pkg_source = "C:\\Windows\\Temp\\sensu-${pkg_version}.msi"
       $pkg_require = "Remote_file[${pkg_source}]"
 


### PR DESCRIPTION
The capital "S" in pkg_name caused error

```
Error: Could not find dependency Package[sensu] for
File[C:/opt/sensu/conf.d] at
C:/ProgramData/PuppetLabs/code/modules/sensu/manifests/package.pp:102
```

I'm not sure what the difference with pkg_name and pkg_title is, so I didn't try combine those two.
