### PR TITLE
Add the ability to add ::apt module from external source

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -15,7 +15,7 @@
 #   Default: sensu-plugin
 #
 # [*sensu_plugin_provider*]
-#   String.  Provider used to install the sensu-plugin package. Refers to the 
+#   String.  Provider used to install the sensu-plugin package. Refers to the
 #   sensu-plugin rubygem, not the sensu-plugins community scripts
 #   Default: undef
 #   Valid values: sensu_gem, apt, aptitude, yum
@@ -76,6 +76,11 @@
 # [*api*]
 #   Boolean.  Include the sensu api service
 #   Default: false
+#   Valid values: true, false
+#
+# [*manage_apt*]
+#   Boolean.  Include the apt external puppet module
+#   Default: true
 #   Valid values: true, false
 #
 # [*manage_services*]
@@ -352,6 +357,7 @@ class sensu (
   $client                         = true,
   $server                         = false,
   $api                            = false,
+  $manage_apt                     = true,
   $manage_services                = true,
   $manage_user                    = true,
   $manage_plugins_dir             = true,
@@ -430,7 +436,7 @@ class sensu (
 
 ){
 
-  validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir, $deregister_on_stop)
+  validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_apt, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir, $deregister_on_stop)
 
   validate_re($repo, ['^main$', '^unstable$'], "Repo must be 'main' or 'unstable'.  Found: ${repo}")
   validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -18,7 +18,7 @@ class sensu::package {
       if $sensu::manage_repo {
         class { '::sensu::repo::apt': }
       }
-      if $sensu::manage_repo and $sensu::install_repo {
+      if $sensu::manage_repo and $sensu::install_repo and $sensu::manage_apt {
         include ::apt
         $pkg_require = Class['apt::update']
       }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -60,10 +60,11 @@ class sensu::package {
   }
 
   package { $pkg_title:
-    ensure  => $sensu::version,
-    name    => $pkg_name,
-    source  => $pkg_source,
-    require => $pkg_require,
+    ensure          => $sensu::version,
+    name            => $pkg_name,
+    source          => $pkg_source,
+    install_options => ['--allow-unauthenticated'],
+    require         => $pkg_require,
   }
 
   if $::sensu::sensu_plugin_provider {


### PR DESCRIPTION
Hi !

I need to import ::apt class from my own custom modules, because of special parameters. So your way to manage this was a problem for me.
Now, the module is able to use apt functionnalities without  import the module.

This can be inconsistency, but far more flexible.
