### PR TITLE
Added the log_dir variable to the init.pp and sensu.erb

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,6 +267,12 @@
 #   Default: 'info'
 #   Valid values: debug, info, warn, error, fatal
 #
+#
+# [*log_dir*]
+#   String.  Sensu log directory to be used
+#   Default: '/var/log/sensu'
+#   Valid values: Any valid log directory path, accessible by the sensu user
+#
 # [*init_stop_max_wait*]
 #   Integer.  Number of seconds to wait for the init stop script to run
 #   Default: 10
@@ -397,6 +403,7 @@ class sensu (
   $rubyopt                        = undef,
   $gem_path                       = undef,
   $log_level                      = 'info',
+  $log_dir                        = '/var/log/sensu',
   $dashboard                      = false,
   $init_stop_max_wait             = 10,
   $gem_install_options            = undef,

--- a/templates/sensu.erb
+++ b/templates/sensu.erb
@@ -1,5 +1,6 @@
 EMBEDDED_RUBY=<%= scope.lookupvar("sensu::use_embedded_ruby") %>
 LOG_LEVEL=<%= scope.lookupvar("sensu::log_level") %>
+LOG_DIR=<%= scope.lookupvar("sensu::log_dir") %>
 <% if ![:undef, nil].include?(scope.lookupvar("sensu::rubyopt")) -%>
 RUBYOPT="<%= scope.lookupvar("sensu::rubyopt") %>"
 <% end -%>


### PR DESCRIPTION
Created a log_dir variable so that users can specify a custom log directory. This is important for users who want to put all application data in a specific app folder
