### PR TITLE
Remove subdue from handler

### DIFF
--- a/lib/puppet/provider/sensu_handler/json.rb
+++ b/lib/puppet/provider/sensu_handler/json.rb
@@ -127,12 +127,4 @@ Puppet::Type.type(:sensu_handler).provide(:json) do
   def type=(value)
     conf['handlers'][resource[:name]]['type'] = value
   end
-
-  def subdue
-    conf['handlers'][resource[:name]]['subdue']
-  end
-
-  def subdue=(value)
-    conf['handlers'][resource[:name]]['subdue'] = value
-  end
 end

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -93,10 +93,6 @@ Puppet::Type.newtype(:sensu_handler) do
     desc "Handler specific config"
   end
 
-  newproperty(:subdue) do
-    desc "Handler subdue"
-  end
-
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -58,10 +58,6 @@
 #   Hash.  Handler specific config
 #   Default: undef
 #
-# [*subdue*]
-#   Hash.  Handler subdue configuration
-#   Default: undef
-#
 define sensu::handler(
   $ensure       = 'present',
   $type         = 'pipe',
@@ -88,6 +84,8 @@ define sensu::handler(
   if $socket { validate_hash($socket) }
   validate_array($severities, $filters)
   if $source { validate_re($source, ['^puppet://'] ) }
+  if $subdue{ fail('Subdue at handler is deprecated since sensu 0.26. See https://sensuapp.org/docs/0.26/overview/changelog.html#core-v0-26-0')}
+
 
   if $type == 'pipe' and $ensure != 'absent' and !$command and !$source and !$mutator {
     fail('command must be set with type pipe')
@@ -160,7 +158,6 @@ define sensu::handler(
     mutator    => $mutator,
     filters    => $filters,
     config     => $config,
-    subdue     => $subdue,
     notify     => $notify_services,
     require    => File['/etc/sensu/conf.d/handlers'],
   }

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -152,7 +152,7 @@ describe 'sensu::handler', :type => :define do
       }
     }
 
-    it { should contain_sensu_handler('myhandler').with_subdue( {'begin' => '09PM CEST', 'end'   => '10PM CEST'} ) }
+    it { should raise_error(Puppet::Error, /Subdue at handler is deprecated since sensu 0.26/) }
   end
 
 end


### PR DESCRIPTION
Sensu 0.26 deprecates subdue at handler (#553).
I've removed it from handler configuration and added deprecation error message.
More details: [Sensu Core 0.26.0 Release Notes](https://sensuapp.org/docs/0.26/overview/changelog.html#core-v0-26-0)