### PR TITLE
Tests for subdue 2.0

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -133,8 +133,14 @@ define sensu::check(
   if $ttl and !is_integer($ttl) {
     fail("sensu::check{${name}}: ttl must be an integer (got: ${ttl})")
   }
-  if $subdue and !is_hash($subdue) {
-    fail("sensu::check{${name}}: subdue must be a hash (got: ${subdue})")
+  if $subdue {
+    if is_hash($subdue) {
+      if !( has_key($subdue, 'days') and is_hash($subdue['days']) ){
+        fail("sensu::check{${name}}: subdue hash should have a proper format. (got: ${subdue}) See https://sensuapp.org/docs/latest/reference/checks.html#subdue-attributes")
+      }
+    } else {
+      fail("sensu::check{${name}}: subdue must be a hash (got: ${subdue})")
+    }
   }
   if $aggregates and !is_array($aggregates) {
     fail("sensu::check{${name}}: aggregates must be an array (got: ${aggregates})")

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -141,16 +141,42 @@ describe 'sensu::check', :type => :define do
 
   context 'subdue' do
     let(:title) { 'mycheck' }
-    let(:params) {
-      {
-        :command => '/etc/sensu/somecommand.rb',
-        :subdue  => {
-          'begin' => '5PM PST',
-          'end'   => '9AM PST'
+    context 'valid subdue hash' do
+      let(:params) {
+        {
+          :command => '/etc/sensu/somecommand.rb',
+          :subdue  => {
+            'days' => {
+              'monday' => [
+                {
+                  'begin' => '12:00:00 AM PST',
+                  'end'   => '9:00:00 AM PST'
+                },
+                {
+                  'begin' => '5:00:00 PM PST',
+                  'end'   => '11:59:59 PM PST'
+                }
+              ]
+            }
+          }
         }
       }
-    }
 
-    it { should contain_sensu_check('mycheck').with_subdue( {'begin' => '5PM PST', 'end' => '9AM PST'}) }
+      it { should contain_sensu_check('mycheck').with_subdue( {'days'=>{'monday'=>[{'begin'=>'12:00:00 AM PST', 'end'=>'9:00:00 AM PST'}, {'begin'=>'5:00:00 PM PST', 'end'=>'11:59:59 PM PST'}]}} ) }
+    end
+
+    context 'invalid subdue hash' do
+      let(:params) {
+        {
+          :command => '/etc/sensu/somecommand.rb',
+          :subdue  => {
+            'begin' => '5PM PST',
+            'end'   => '9AM PST'
+          }
+        }
+      }
+
+      it { should raise_error(Puppet::Error, /subdue hash should have a proper format/) }
+    end
   end
 end


### PR DESCRIPTION
Sensu 0.26 changes subdue hash format (#553).
More details: [Sensu Core 0.26.0 Release Notes](https://sensuapp.org/docs/0.26/overview/changelog.html#core-v0-26-0)
- updated subdue hash validation in sensu::check
- added test for invalid subdue hash format
