### PR TITLE
remove subdue property with 'absent'

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -217,7 +217,10 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def subdue=(value)
-    value = (value == :absent ? nil : value)
-    conf['checks'][resource[:name]]['subdue'] = value
+    if value == :absent
+      conf['checks'][resource[:name]].delete('subdue')
+    else
+      conf['checks'][resource[:name]]['subdue'] = value
+    end
   end
 end

--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -212,10 +212,12 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def subdue
-    conf['checks'][resource[:name]]['subdue']
+    value = conf['checks'][resource[:name]]['subdue']
+    value.nil? ? :absent : value
   end
 
   def subdue=(value)
+    value = (value == :absent ? nil : value)
     conf['checks'][resource[:name]]['subdue'] = value
   end
 end

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -147,6 +147,7 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:subdue) do
     desc "Check subdue"
+    newvalues(/.*/, :absent)
   end
 
   newproperty(:ttl) do

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -84,6 +84,7 @@
 #
 # [*subdue*]
 #   Hash.  Check subdue configuration
+#   Set this to 'absent' to remove it completely.
 #   Default: undef
 #
 define sensu::check(
@@ -133,7 +134,7 @@ define sensu::check(
   if $ttl and !is_integer($ttl) {
     fail("sensu::check{${name}}: ttl must be an integer (got: ${ttl})")
   }
-  if $subdue and !is_hash($subdue) {
+  if $subdue and !is_hash($subdue) and !($subdue == 'absent') {
     fail("sensu::check{${name}}: subdue must be a hash (got: ${subdue})")
   }
   if $aggregates and !is_array($aggregates) {

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -139,18 +139,42 @@ describe 'sensu::check', :type => :define do
     end
   end
 
-  context 'subdue' do
+  context 'with subdue' do
     let(:title) { 'mycheck' }
-    let(:params) {
-      {
-        :command => '/etc/sensu/somecommand.rb',
-        :subdue  => {
-          'begin' => '5PM PST',
-          'end'   => '9AM PST'
+
+    context 'defined' do
+      let(:params) {
+        {
+          :command => '/etc/sensu/somecommand.rb',
+          :subdue  => {
+            'begin' => '5PM PST',
+            'end'   => '9AM PST'
+          }
         }
       }
-    }
 
-    it { should contain_sensu_check('mycheck').with_subdue( {'begin' => '5PM PST', 'end' => '9AM PST'}) }
+      it { should contain_sensu_check('mycheck').with_subdue( {'begin' => '5PM PST', 'end' => '9AM PST'}) }
+    end
+
+    context '=> \'absent\'' do
+      let(:params) {
+        {
+          :command => '/etc/sensu/somecommand.rb',
+          :subdue  => 'absent'
+        }
+      }
+
+      it { should contain_sensu_check('mycheck').with_subdue(:absent) }
+    end
+
+    context '= undef' do
+      let(:params) {
+        {
+          :command => '/etc/sensu/somecommand.rb',
+        }
+      }
+
+      it { should contain_sensu_check('mycheck').without_subdue }
+    end
   end
 end


### PR DESCRIPTION
I've tried to implement removing of `subdue` property with:
```
subdue => `absent'
```

This follows the same logic as puppet type `yumrepo`:
* `subdue = undef` – no changes are made
* `subdue = 'absent'` – subdue property is removed from json file

I've based this on puppet type `yumrepo` implementation:
* https://github.com/puppetlabs/puppet/blob/4.7.0/lib/puppet/type/yumrepo.rb#L47-L53
* https://github.com/puppetlabs/puppet/blob/4.7.0/lib/puppet/provider/yumrepo/inifile.rb#L266-L279
* https://docs.puppet.com/puppet/latest/reference/types/yumrepo.html#yumrepo-attribute-descr