### PR TITLE
[enterprise dashboard] move package resource inside conditional

### DIFF
--- a/manifests/enterprise/dashboard/package.pp
+++ b/manifests/enterprise/dashboard/package.pp
@@ -9,13 +9,8 @@ class sensu::enterprise::dashboard::package {
   }
 
   if $::sensu::enterprise_dashboard {
-    $ensure = $::sensu::enterprise_dashboard_version
-  } else {
-    $ensure = 'absent'
+    package { 'sensu-enterprise-dashboard':
+      ensure => $::sensu::enterprise_dashboard_version,
+    }
   }
-
-  package { 'sensu-enterprise-dashboard':
-    ensure => $ensure,
-  }
-
 }


### PR DESCRIPTION
This change avoids defining the package resource when the enterprise_dashboard parameter is false.

I believe this is desirable because it mirrors the behavior of the enterprise package manifest, making it possible to include this module in another module which manages the sensu-enterprise-dashboard package itself.

cc @dhgwilliam as he committed the original implementation
