### PR TITLE
transorm input with munge in type rather than in sensu_check/json.rb provider

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -10,6 +10,8 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   include PuppetX::Sensu::ToType
   include PuppetX::Sensu::ProviderCreate
 
+  SENSU_CHECK_PROPERTIES = Puppet::Type.type(:sensu_check).validproperties.reject { |p| p == :ensure }
+
   def conf
     begin
       @conf ||= JSON.parse(File.read(config_file))
@@ -29,16 +31,16 @@ Puppet::Type.type(:sensu_check).provide(:json) do
     conf['checks'][resource[:name]] = {}
   end
 
-  def check_args
-    ['handlers','command','interval','occurrences','refresh','source','subscribers','type','standalone','high_flap_threshold','low_flap_threshold','timeout','aggregate','handle','publish','dependencies','custom','ttl', 'subdue', 'aggregates']
+  def is_property?(prop)
+    SENSU_CHECK_PROPERTIES.map(&:to_s).include? prop
   end
 
   def custom
-    conf['checks'][resource[:name]].reject { |k,v| check_args.include?(k) }
+    conf['checks'][resource[:name]].reject { |k,v| is_property?(k) }
   end
 
   def custom=(value)
-    conf['checks'][resource[:name]].delete_if { |k,v| not check_args.include?(k) }
+    conf['checks'][resource[:name]].delete_if { |k,v| not is_property?(k) }
     conf['checks'][resource[:name]].merge!(to_type(value))
   end
 

--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -53,7 +53,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def interval
-    conf['checks'][resource[:name]]['interval'].to_s
+    conf['checks'][resource[:name]]['interval']
   end
 
   def config_file
@@ -61,7 +61,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def interval=(value)
-    conf['checks'][resource[:name]]['interval'] = value.to_i
+    conf['checks'][resource[:name]]['interval']
   end
 
   def handlers
@@ -73,19 +73,19 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def occurrences
-    conf['checks'][resource[:name]]['occurrences'].to_s
+    conf['checks'][resource[:name]]['occurrences']
   end
 
   def occurrences=(value)
-    conf['checks'][resource[:name]]['occurrences'] = value.to_i
+    conf['checks'][resource[:name]]['occurrences'] = value
   end
 
   def refresh
-    conf['checks'][resource[:name]]['refresh'].to_s
+    conf['checks'][resource[:name]]['refresh']
   end
 
   def refresh=(value)
-    conf['checks'][resource[:name]]['refresh'] = value.to_i
+    conf['checks'][resource[:name]]['refresh'] = value
   end
 
   def command
@@ -122,19 +122,19 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def low_flap_threshold
-    conf['checks'][resource[:name]]['low_flap_threshold'].to_s
+    conf['checks'][resource[:name]]['low_flap_threshold']
   end
 
   def low_flap_threshold=(value)
-    conf['checks'][resource[:name]]['low_flap_threshold'] = value.to_i
+    conf['checks'][resource[:name]]['low_flap_threshold'] = value
   end
 
   def high_flap_threshold
-    conf['checks'][resource[:name]]['high_flap_threshold'].to_s
+    conf['checks'][resource[:name]]['high_flap_threshold']
   end
 
   def high_flap_threshold=(value)
-    conf['checks'][resource[:name]]['high_flap_threshold'] = value.to_i
+    conf['checks'][resource[:name]]['high_flap_threshold'] = value
   end
 
   def source
@@ -146,16 +146,11 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def timeout
-    conf['checks'][resource[:name]]['timeout'].to_s
-  end
-
-  def trim num
-    i, f = num.to_i, num.to_f
-    i == f ? i : f
+    conf['checks'][resource[:name]]['timeout']
   end
 
   def timeout=(value)
-    conf['checks'][resource[:name]]['timeout'] = trim(value)
+    conf['checks'][resource[:name]]['timeout'] = value
   end
 
   def aggregate
@@ -163,14 +158,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def aggregate=(value)
-    case value
-    when true, 'true', 'True', :true, 1
-      conf['checks'][resource[:name]]['aggregate'] = true
-    when false, 'false', 'False', :false, 0
-      conf['checks'][resource[:name]]['aggregate'] = false
-    else
-      conf['checks'][resource[:name]]['aggregate'] = value
-    end
+    conf['checks'][resource[:name]]['aggregate'] = value
   end
 
   def aggregates
@@ -206,11 +194,11 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def ttl
-    conf['checks'][resource[:name]]['ttl'].to_s
+    conf['checks'][resource[:name]]['ttl']
   end
 
   def ttl=(value)
-    conf['checks'][resource[:name]]['ttl'] = value.to_i
+    conf['checks'][resource[:name]]['ttl'] = value
   end
 
   def subdue

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -52,18 +52,30 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:high_flap_threshold) do
     desc "A host is determined to be flapping when the percent change exceedes this threshold."
+    munge do |value|
+      value.to_i
+    end
   end
 
   newproperty(:interval) do
     desc "How frequently the check runs in seconds"
+    munge do |value|
+      value.to_i
+    end
   end
 
   newproperty(:occurrences) do
     desc "The number of event occurrences before the handler should take action."
+    munge do |value|
+      value.to_i
+    end
   end
 
   newproperty(:refresh) do
     desc "The number of seconds sensu-plugin-aware handlers should wait before taking second action."
+    munge do |value|
+      value.to_i
+    end
   end
 
   newparam(:base_path) do
@@ -73,6 +85,9 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:low_flap_threshold) do
     desc "A host is determined to be flapping when the percent change is below this threshold."
+    munge do |value|
+      value.to_i
+    end
   end
 
   newproperty(:source) do
@@ -124,10 +139,24 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:timeout) do
     desc "Check timeout in seconds, after it fails"
+    munge do |value|
+      i, f = value.to_i, value.to_f
+      i == f ? i : f
+    end
   end
 
   newproperty(:aggregate) do
     desc "Whether check is aggregate"
+    munge do |value|
+      case value
+      when true, 'true', 'True', :true, 1
+        true
+      when false, 'false', 'False', :false, 0
+        false
+      else
+        value
+      end
+    end
   end
 
   newproperty(:aggregates, :array_matching => :all) do
@@ -152,6 +181,9 @@ Puppet::Type.newtype(:sensu_check) do
 
   newproperty(:ttl) do
     desc "Check ttl in seconds"
+    munge do |value|
+      value.to_i
+    end
   end
 
   autorequire(:package) do


### PR DESCRIPTION
This change follows the discussion in #535

I don't know how to properly test the provider functionality.
I think that spec tests in this module don't cover the provider implementation (only the type is tested by verifying the resulting catalog). 