### PR TITLE
Use default redact

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -290,7 +290,7 @@
 #
 # [*redact*]
 #   Array of strings. Use to redact passwords from checks on the client side
-#   Default: []
+#   Default: undef
 #
 # [*deregister_on_stop*]
 #   Boolean. Whether the sensu client should deregister from the API on service stop
@@ -413,7 +413,7 @@ class sensu (
   $enterprise_dashboard_gitlab    = undef,
   $enterprise_dashboard_ldap      = undef,
   $path                           = undef,
-  $redact                         = [],
+  $redact                         = undef,
   $deregister_on_stop             = false,
   $deregister_handler             = undef,
 

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -15,10 +15,11 @@ describe 'sensu', :type => :class do
           :address       => '2.3.4.5',
           :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
           :subscriptions => [],
-          :redact        => [],
           :ensure        => 'present',
           :custom        => {}
         ) }
+
+        it { should contain_sensu_client_config('host.domain.com').without_redact }
       end # defaults
 
       context 'setting config params' do


### PR DESCRIPTION
Module should not use different default value than the service
is actually using. This patch changes to default redact value
according to [1]

[1] https://sensuapp.org/docs/0.24/reference/clients.html