### PR TITLE
[WIP] Add support for multi-host Rabbitmq config

### DIFF
--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -34,7 +34,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def ssl_transport
-    if conf['rabbitmq'].class != Array 
+    if conf['rabbitmq'].class != Array
       if conf['rabbitmq'].has_key? 'ssl'
         :true
       else
@@ -62,8 +62,8 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
       else
         ''
       end
-    else 
-      '' 
+    else
+      ''
     end
   end
 
@@ -87,8 +87,8 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
       else
         ''
       end
-    else 
-      '' 
+    else
+      ''
     end
   end
 
@@ -165,7 +165,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   def prefetch=(value)
     if value != :absent then conf['rabbitmq']['prefetch'] = value.to_i end
   end
-  
+
   def cluster
     conf['rabbitmq']
   end

--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -151,6 +151,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def reconnect_on_error
+    return :absent if conf['rabbitmq'].is_a?(Array)
     conf['rabbitmq']['reconnect_on_error'] || :absent
   end
 

--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -110,12 +110,12 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def port
-    if conf['rabbitmq'].class == Array then pre_create end
-    if conf['rabbitmq']['port'] then conf['rabbitmq']['port'].to_s else :absent end
+    pre_create if conf['rabbitmq'].class == Array
+    conf['rabbitmq']['port'] ? conf['rabbitmq']['port'].to_s : :absent
   end
 
   def port=(value)
-    if value != :absent then conf['rabbitmq']['port'] = value.to_i end
+    conf['rabbitmq']['port'] = value.to_i unless value == :absent
   end
 
   def host
@@ -123,7 +123,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def host=(value)
-    if value != :absent then conf['rabbitmq']['host'] = value end
+    conf['rabbitmq']['host'] = value unless value == :absent
   end
 
   def user
@@ -131,7 +131,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def user=(value)
-    if value != :absent then conf['rabbitmq']['user'] = value end
+    conf['rabbitmq']['user'] = value unless value == :absent
   end
 
   def password
@@ -139,7 +139,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def password=(value)
-    if value != :absent then conf['rabbitmq']['password'] = value end
+    conf['rabbitmq']['password'] = value unless value == :absent
   end
 
   def vhost
@@ -147,7 +147,7 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def vhost=(value)
-    if value != :absent then conf['rabbitmq']['vhost'] = value end
+    conf['rabbitmq']['vhost'] = value unless value == :absent
   end
 
   def reconnect_on_error
@@ -155,15 +155,15 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def reconnect_on_error=(value)
-    if value != :absent then conf['rabbitmq']['reconnect_on_error'] = value end
+    conf['rabbitmq']['reconnect_on_error'] = value unless value == :absent
   end
 
   def prefetch
-    if conf['rabbitmq']['prefetch'] then conf['rabbitmq']['prefetch'].to_s else :absent end
+    conf['rabbitmq']['prefetch'] ? conf['rabbitmq']['prefetch'].to_s : :absent
   end
 
   def prefetch=(value)
-    if value != :absent then conf['rabbitmq']['prefetch'] = value.to_i end
+    conf['rabbitmq']['prefetch'] = value.to_i unless value == :absent
   end
 
   def cluster

--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -34,8 +34,12 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def ssl_transport
-    if conf['rabbitmq'].has_key? 'ssl'
-      :true
+    if conf['rabbitmq'].class != Array 
+      if conf['rabbitmq'].has_key? 'ssl'
+        :true
+      else
+        :false
+      end
     else
       :false
     end
@@ -52,10 +56,14 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def ssl_private_key
-    if conf['rabbitmq'].has_key? 'ssl'
-      conf['rabbitmq']['ssl']['private_key_file'] || ''
-    else
-      ''
+    if conf['rabbitmq'].class != Array
+      if conf['rabbitmq'].has_key? 'ssl'
+        conf['rabbitmq']['ssl']['private_key_file'] || ''
+      else
+        ''
+      end
+    else 
+      '' 
     end
   end
 
@@ -73,10 +81,14 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def ssl_cert_chain
-    if conf['rabbitmq'].has_key? 'ssl'
-      conf['rabbitmq']['ssl']['cert_chain_file'] || ''
-    else
-      ''
+    if conf['rabbitmq'].class != Array
+      if conf['rabbitmq'].has_key? 'ssl'
+        conf['rabbitmq']['ssl']['cert_chain_file'] || ''
+      else
+        ''
+      end
+    else 
+      '' 
     end
   end
 
@@ -98,58 +110,67 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def port
-    conf['rabbitmq']['port'].to_s
+    if conf['rabbitmq'].class == Array then pre_create end
+    if conf['rabbitmq']['port'] then conf['rabbitmq']['port'].to_s else :absent end
   end
 
   def port=(value)
-    conf['rabbitmq']['port'] = value.to_i
+    if value != :absent then conf['rabbitmq']['port'] = value.to_i end
   end
 
   def host
-    conf['rabbitmq']['host']
+    conf['rabbitmq']['host'] || :absent
   end
 
   def host=(value)
-    conf['rabbitmq']['host'] = value
+    if value != :absent then conf['rabbitmq']['host'] = value end
   end
 
   def user
-    conf['rabbitmq']['user']
+    conf['rabbitmq']['user'] || :absent
   end
 
   def user=(value)
-    conf['rabbitmq']['user'] = value
+    if value != :absent then conf['rabbitmq']['user'] = value end
   end
 
   def password
-    conf['rabbitmq']['password']
+    conf['rabbitmq']['password'] || :absent
   end
 
   def password=(value)
-    conf['rabbitmq']['password'] = value
+    if value != :absent then conf['rabbitmq']['password'] = value end
   end
 
   def vhost
-    conf['rabbitmq']['vhost']
+    conf['rabbitmq']['vhost'] || :absent
   end
 
   def vhost=(value)
-    conf['rabbitmq']['vhost'] = value
+    if value != :absent then conf['rabbitmq']['vhost'] = value end
   end
 
   def reconnect_on_error
-    conf['rabbitmq']['reconnect_on_error']
+    conf['rabbitmq']['reconnect_on_error'] || :absent
   end
 
   def reconnect_on_error=(value)
-     conf['rabbitmq']['reconnect_on_error'] = value
+    if value != :absent then conf['rabbitmq']['reconnect_on_error'] = value end
   end
 
   def prefetch
-    conf['rabbitmq']['prefetch'].to_s
+    if conf['rabbitmq']['prefetch'] then conf['rabbitmq']['prefetch'].to_s else :absent end
   end
 
   def prefetch=(value)
-     conf['rabbitmq']['prefetch'] = value.to_i
+    if value != :absent then conf['rabbitmq']['prefetch'] = value.to_i end
+  end
+  
+  def cluster
+    conf['rabbitmq']
+  end
+
+  def cluster=(value)
+    conf['rabbitmq'] = value
   end
 end

--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -23,7 +23,6 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
         conf['redis'].delete prop.to_s
       end
     end
-
     File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -1,3 +1,4 @@
+require 'set'
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
                                    'puppet_x', 'sensu', 'boolean_property.rb'))
 
@@ -12,6 +13,11 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
       "Service[sensu-client]",
       "Service[sensu-api]",
     ].select { |ref| catalog.resource(ref) }
+  end
+
+  def has_cluster?
+    cluster = self.should(:cluster)
+    return cluster && !cluster.empty?
   end
 
   ensurable do
@@ -56,19 +62,34 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   newproperty(:port) do
     desc "The port that RabbitMQ is listening on"
 
-    defaultto '5672'
+    defaultto {
+      if !@resource.has_cluster? then '5672' end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
   end
 
   newproperty(:host) do
     desc "The hostname that RabbitMQ is listening on"
 
-    defaultto '127.0.0.1'
+    defaultto {
+      if !@resource.has_cluster? then '127.0.0.1' end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
   end
 
   newproperty(:user) do
     desc "The username to use when connecting to RabbitMQ"
 
-    defaultto 'sensu'
+    defaultto {
+      if !@resource.has_cluster? then 'sensu' end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
   end
 
   newproperty(:password) do
@@ -78,19 +99,47 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   newproperty(:vhost) do
     desc "The vhost to use when connecting to RabbitMQ"
 
-    defaultto 'sensu'
+    defaultto {
+      if !@resource.has_cluster? then 'sensu' end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
   end
 
   newproperty(:reconnect_on_error) do
     desc "Attempt to reconnect to RabbitMQ on error"
 
-    defaultto :false
+    defaultto {
+      if !@resource.has_cluster? then :false end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
   end
 
   newproperty(:prefetch) do
     desc "The RabbitMQ AMQP consumer prefetch value"
 
-    defaultto '1'
+    defaultto {
+      if !@resource.has_cluster? then '1' end
+    }
+    def insync?(is)
+      if should.is_a?(Symbol) then should == is else super(is) end
+    end
+  end
+
+  newproperty(:cluster, :array_matching => :all) do
+    desc "Rabbitmq Cluster"
+    def insync?(is)
+      Set.new(is) == Set.new(should)
+    end
+
+    munge do |value|
+      Hash[value.map do |k, v|
+        [k,if k == "port" then v.to_i elsif k == "prefetch" then v.to_i else v.to_s end]
+      end]
+    end
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -11,7 +11,8 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
     self[:notify] = [
       'Service[sensu-server]',
       'Service[sensu-client]',
-      'Service[sensu-api]'
+      'Service[sensu-api]',
+      'Service[sensu-enterprise]'
     ].select { |ref| catalog.resource(ref) }
   end
 

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -93,7 +93,7 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
 
   newproperty(:vhost) do
     desc 'The vhost to use when connecting to RabbitMQ'
-    defaultto { 'sensu' unless @resource.has_cluster? }
+    defaultto { '/sensu' unless @resource.has_cluster? }
 
     def insync?(is)
       return should == is if should.is_a?(Symbol)
@@ -113,7 +113,7 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
 
   newproperty(:prefetch) do
     desc 'The RabbitMQ AMQP consumer prefetch value'
-    defaultto { '1' unless @resource.has_cluster? }
+    defaultto { 1 unless @resource.has_cluster? }
 
     def insync?(is)
       return should == is if should.is_a?(Symbol)

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -134,7 +134,7 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
       value.reduce({}) do |acc, (k, v)|
         acc[k] =
           case k
-          when 'port', 'prefetch', 'heartbeat' then v.to_i
+          when 'port', 'prefetch', 'heartbeat' then v.to_i unless v.is_a?(Symbol)
           else v end
         acc
       end

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -3,21 +3,21 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
                                    'puppet_x', 'sensu', 'boolean_property.rb'))
 
 Puppet::Type.newtype(:sensu_rabbitmq_config) do
-  @doc = ""
+  @doc = ''
 
   def initialize(*args)
-    super *args
+    super(*args)
 
     self[:notify] = [
-      "Service[sensu-server]",
-      "Service[sensu-client]",
-      "Service[sensu-api]",
+      'Service[sensu-server]',
+      'Service[sensu-client]',
+      'Service[sensu-api]'
     ].select { |ref| catalog.resource(ref) }
   end
 
   def has_cluster?
-    cluster = self.should(:cluster)
-    return cluster && !cluster.empty?
+    cluster = should(:cluster)
+    cluster && !cluster.empty?
   end
 
   ensurable do
@@ -33,99 +33,90 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   end
 
   newparam(:name) do
-    desc "This value has no effect, set it to what ever you want."
+    desc 'This value has no effect, set it to what ever you want.'
   end
 
   newparam(:base_path) do
-    desc "The base path to the client config file"
+    desc 'The base path to the client config file'
     defaultto '/etc/sensu/conf.d/'
   end
 
   newproperty(:ssl_transport, :parent => PuppetX::Sensu::BooleanProperty) do
-    desc "Enable SSL transport to connect to RabbitMQ"
-
+    desc 'Enable SSL transport to connect to RabbitMQ'
     defaultto :false
   end
 
   newproperty(:ssl_private_key) do
-    desc "The path on disk to the SSL private key needed to connect to RabbitMQ"
-
+    desc 'The path on disk to the SSL private key needed to connect to RabbitMQ'
     defaultto ''
   end
 
   newproperty(:ssl_cert_chain) do
-    desc "The path on disk to the SSL cert chain needed to connect to RabbitMQ"
-
+    desc 'The path on disk to the SSL cert chain needed to connect to RabbitMQ'
     defaultto ''
   end
 
   newproperty(:port) do
-    desc "The port that RabbitMQ is listening on"
+    desc 'The port that RabbitMQ is listening on'
+    defaultto { '5672' unless @resource.has_cluster? }
 
-    defaultto {
-      if !@resource.has_cluster? then '5672' end
-    }
     def insync?(is)
-      if should.is_a?(Symbol) then should == is else super(is) end
+      return should == is if should.is_a?(Symbol)
+      super(is)
     end
   end
 
   newproperty(:host) do
-    desc "The hostname that RabbitMQ is listening on"
+    desc 'The hostname that RabbitMQ is listening on'
+    defaultto { '127.0.0.1' unless @resource.has_cluster? }
 
-    defaultto {
-      if !@resource.has_cluster? then '127.0.0.1' end
-    }
     def insync?(is)
-      if should.is_a?(Symbol) then should == is else super(is) end
+      return should == is if should.is_a?(Symbol)
+      super(is)
     end
   end
 
   newproperty(:user) do
-    desc "The username to use when connecting to RabbitMQ"
+    desc 'The username to use when connecting to RabbitMQ'
+    defaultto { 'sensu' unless @resource.has_cluster? }
 
-    defaultto {
-      if !@resource.has_cluster? then 'sensu' end
-    }
     def insync?(is)
-      if should.is_a?(Symbol) then should == is else super(is) end
+      return should == is if should.is_a?(Symbol)
+      super(is)
     end
   end
 
   newproperty(:password) do
-    desc "The password to use when connecting to RabbitMQ"
+    desc 'The password to use when connecting to RabbitMQ'
   end
 
   newproperty(:vhost) do
-    desc "The vhost to use when connecting to RabbitMQ"
+    desc 'The vhost to use when connecting to RabbitMQ'
+    defaultto { 'sensu' unless @resource.has_cluster? }
 
-    defaultto {
-      if !@resource.has_cluster? then 'sensu' end
-    }
     def insync?(is)
-      if should.is_a?(Symbol) then should == is else super(is) end
+      return should == is if should.is_a?(Symbol)
+      super(is)
     end
   end
 
   newproperty(:reconnect_on_error) do
-    desc "Attempt to reconnect to RabbitMQ on error"
+    desc 'Attempt to reconnect to RabbitMQ on error'
+    defaultto { :false unless @resource.has_cluster? }
 
-    defaultto {
-      if !@resource.has_cluster? then :false end
-    }
     def insync?(is)
-      if should.is_a?(Symbol) then should == is else super(is) end
+      return should == is if should.is_a?(Symbol)
+      super(is)
     end
   end
 
   newproperty(:prefetch) do
-    desc "The RabbitMQ AMQP consumer prefetch value"
+    desc 'The RabbitMQ AMQP consumer prefetch value'
+    defaultto { '1' unless @resource.has_cluster? }
 
-    defaultto {
-      if !@resource.has_cluster? then '1' end
-    }
     def insync?(is)
-      if should.is_a?(Symbol) then should == is else super(is) end
+      return should == is if should.is_a?(Symbol)
+      super(is)
     end
   end
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -361,16 +361,16 @@ class sensu (
   $manage_plugins_dir             = true,
   $manage_handlers_dir            = true,
   $manage_mutators_dir            = true,
-  $rabbitmq_port                  = 5672,
-  $rabbitmq_host                  = '127.0.0.1',
-  $rabbitmq_user                  = 'sensu',
+  $rabbitmq_port                  = undef,
+  $rabbitmq_host                  = undef,
+  $rabbitmq_user                  = undef,
   $rabbitmq_password              = undef,
-  $rabbitmq_vhost                 = '/sensu',
-  $rabbitmq_ssl                   = false,
+  $rabbitmq_vhost                 = undef,
+  $rabbitmq_ssl                   = undef,
   $rabbitmq_ssl_private_key       = undef,
   $rabbitmq_ssl_cert_chain        = undef,
   $rabbitmq_reconnect_on_error    = false,
-  $rabbitmq_prefetch              = 1,
+  $rabbitmq_prefetch              = undef,
   $rabbitmq_cluster               = undef,
   $redis_host                     = '127.0.0.1',
   $redis_port                     = 6379,
@@ -442,7 +442,6 @@ class sensu (
   validate_re($enterprise_version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")
   validate_re($sensu_plugin_version, ['^absent$', '^installed$', '^latest$', '^present$', '^\d[\d\.\-\w]+$'], "Invalid sensu-plugin package version: ${sensu_plugin_version}")
   validate_re($log_level, ['^debug$', '^info$', '^warn$', '^error$', '^fatal$'] )
-  if !is_integer($rabbitmq_port) { fail('rabbitmq_port must be an integer') }
   if !is_integer($redis_port) { fail('redis_port must be an integer') }
   if !is_integer($api_port) { fail('api_port must be an integer') }
   if !is_integer($init_stop_max_wait) { fail('init_stop_max_wait must be an integer') }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -155,7 +155,7 @@
 #   Default: 1
 #
 # [*rabbitmq_cluster*]
-#   Array. Rabbitmq Cluster configuration and connection information for one or more Cluster
+#   Array of hashes. Rabbitmq Cluster configuration and connection information for one or more Cluster
 #   Default: Not configured
 #
 # [*redis_host*]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -377,7 +377,6 @@ class sensu (
   $redis_password                 = undef,
   $redis_reconnect_on_error       = false,
   $redis_db                       = 0,
-  $redis_sentinels                = undef,
   $redis_auto_reconnect           = true,
   $redis_sentinels                = undef,
   $redis_master                   = undef,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -154,6 +154,10 @@
 #   Integer.  The integer value for the RabbitMQ prefetch attribute
 #   Default: 1
 #
+# [*rabbitmq_cluster*]
+#   Array. Rabbitmq Cluster configuration and connection information for one or more Cluster
+#   Default: Not configured
+#
 # [*redis_host*]
 #   String.  Hostname of redis to be used by sensu
 #   Default: 127.0.0.1
@@ -367,11 +371,13 @@ class sensu (
   $rabbitmq_ssl_cert_chain        = undef,
   $rabbitmq_reconnect_on_error    = false,
   $rabbitmq_prefetch              = 1,
+  $rabbitmq_cluster               = undef,
   $redis_host                     = '127.0.0.1',
   $redis_port                     = 6379,
   $redis_password                 = undef,
   $redis_reconnect_on_error       = false,
   $redis_db                       = 0,
+  $redis_sentinels                = undef,
   $redis_auto_reconnect           = true,
   $redis_sentinels                = undef,
   $redis_master                   = undef,

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -108,6 +108,20 @@ class sensu::rabbitmq::config {
     before => Sensu_rabbitmq_config[$::fqdn],
   }
 
+  $has_cluster = !($sensu::rabbitmq_cluster == undef or $sensu::rabbitmq_cluster == [])
+  $host = $has_cluster ? { false => $sensu::rabbitmq_host, true => undef, }
+  $port = $has_cluster ? { false => $sensu::rabbitmq_port, true => undef, }
+  $user = $has_cluster ? { false => $sensu::rabbitmq_user, true => undef, }
+  $password = $has_cluster ? { false => $sensu::rabbitmq_password, true => undef, }
+  $vhost = $has_cluster ? { false => $sensu::rabbitmq_vhost, true => undef, }
+  $ssl_transport = $has_cluster ? { false => $enable_ssl, true => undef, }
+  $cert_chain = $has_cluster ? { false => $ssl_cert_chain, true => undef, }
+  $private_key = $has_cluster ? { false => $ssl_private_key, true => undef, }
+  $reconnect_on_error = $has_cluster ? { false => $sensu::rabbitmq_reconnect_on_error, true => undef, }
+  $prefetch = $has_cluster ? { false => $sensu::rabbitmq_prefetch, true => undef, }
+  $base_path = $has_cluster ? { false => $sensu::conf_dir, true => undef, }
+  $cluster = $has_cluster ? { true => $sensu::rabbitmq_cluster, false => undef, }
+
   sensu_rabbitmq_config { $::fqdn:
     ensure             => $ensure,
     base_path          => $sensu::conf_dir,
@@ -121,6 +135,7 @@ class sensu::rabbitmq::config {
     ssl_private_key    => $ssl_private_key,
     reconnect_on_error => $sensu::rabbitmq_reconnect_on_error,
     prefetch           => $sensu::rabbitmq_prefetch,
+    cluster            => $cluster,
   }
 
 }

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -158,6 +158,15 @@ describe 'sensu', :type => :class do
             'vhost'           => '/myvhost',
             'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
             'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+          },
+          {
+            'port'            => '1234',
+            'host'            => 'myhost',
+            'user'            => 'sensuuser',
+            'password'        => 'sensupass',
+            'vhost'           => '/myvhost',
+            'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+            'ssl_private_key' => '/etc/sensu/ssl/key.pem'
           }
         ]
       }

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -195,17 +195,6 @@ describe 'sensu', :type => :class do
       ) }
     end # when using prefetch attribute
 
-    context 'when not using prefetch attribute' do
-      let(:params) { {
-        :rabbitmq_host => 'myhost'
-      } }
-
-      it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
-        :host => 'myhost',
-        :prefetch  => '1'
-      ) }
-    end # when not using prefetch attribute
-
     context 'purge config' do
       let(:params) { {
         :purge  => { 'config' => true },

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -147,6 +147,33 @@ describe 'sensu', :type => :class do
       ) }
     end # when using key in variable
 
+    context 'when using rabbitmq cluster' do
+      let(:cluster_config) {
+        [
+          {
+            'port'            => '1234',
+            'host'            => 'myhost',
+            'user'            => 'sensuuser',
+            'password'        => 'sensupass',
+            'vhost'           => '/myvhost',
+            'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+            'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+          }
+        ]
+      }
+
+      let(:params) { {
+        :rabbitmq_ssl_cert_chain  => rabbitmq_ssl_cert_chain_test,
+        :rabbitmq_ssl_private_key => rabbitmq_ssl_private_key_test,
+        :rabbitmq_cluster => cluster_config
+      } }
+
+      it { should contain_file('/etc/sensu/ssl').with_ensure('directory') }
+      it { should contain_file('/etc/sensu/ssl/cert.pem').with_content(rabbitmq_ssl_cert_chain_test) }
+      it { should contain_file('/etc/sensu/ssl/key.pem').with_content(rabbitmq_ssl_private_key_test) }
+      it { should contain_sensu_rabbitmq_config('hostname.domain.com').with_cluster(cluster_config) }
+    end
+
     context 'when using prefetch attribute' do
       let(:params) { {
         :rabbitmq_host => 'myhost',

--- a/spec/unit/sensu_rabbitmq_config_spec.rb
+++ b/spec/unit/sensu_rabbitmq_config_spec.rb
@@ -33,6 +33,20 @@ describe Puppet::Type.type(:sensu_rabbitmq_config) do
     }
   end
 
+  let :wout_port do
+    {
+      :cluster => [{
+        'port' => :undef,
+        'host'            => 'myhost',
+        'user'            => 'sensuuser',
+        'password'        => 'sensupass',
+        'vhost'           => '/myvhost',
+        'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+        'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+      }]
+    }
+  end
+
   let :cluster_arrays do
     {
       :cluster => [
@@ -72,6 +86,14 @@ describe Puppet::Type.type(:sensu_rabbitmq_config) do
 
         it 'should raise an error' do
           expect {subject}.to raise_error(Puppet::ResourceError)
+        end
+      end
+
+      context 'and port is undef' do
+        let(:subject) { create_type_instance(resource_hash.merge(wout_port))}
+
+        it 'should not raise an error' do
+          expect { subject }.to_not raise_error
         end
       end
     end

--- a/spec/unit/sensu_rabbitmq_config_spec.rb
+++ b/spec/unit/sensu_rabbitmq_config_spec.rb
@@ -56,7 +56,7 @@ describe Puppet::Type.type(:sensu_rabbitmq_config) do
           cluster_val = subject.parameter(:cluster).value
           expect(cluster_val).to be_an(Array)
           expect(cluster_val).to eq([{
-            'port'            => '1234',
+            'port'            => 1234,
             'host'            => 'myhost',
             'user'            => 'sensuuser',
             'password'        => 'sensupass',
@@ -70,18 +70,8 @@ describe Puppet::Type.type(:sensu_rabbitmq_config) do
       context 'as an array of arrays' do
         let(:subject) { create_type_instance(resource_hash.merge(cluster_arrays)) }
 
-        it 'should be an array of hashes' do
-          cluster_val = subject.parameter(:cluster).value
-          expect(cluster_val).to be_an(Array)
-          expect(cluster_val).to eq([{
-            'port'            => '1234',
-            'host'            => 'myhost',
-            'user'            => 'sensuuser',
-            'password'        => 'sensupass',
-            'vhost'           => '/myvhost',
-            'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
-            'ssl_private_key' => '/etc/sensu/ssl/key.pem'
-          }])
+        it 'should raise an error' do
+          expect {subject}.to raise_error(Puppet::ResourceError)
         end
       end
     end

--- a/spec/unit/sensu_rabbitmq_config_spec.rb
+++ b/spec/unit/sensu_rabbitmq_config_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_rabbitmq_config) do
+  let :provider_class do
+    described_class.provider(:json)
+  end
+
+  def create_type_instance(resource_hash)
+    result = described_class.new(resource_hash)
+    provider_instance = provider_class.new(resource_hash)
+    result.provider = provider_instance
+    result
+  end
+
+  let :resource_hash do 
+    {
+      :title   => 'foo.example.com',
+      :catalog => Puppet::Resource::Catalog.new()
+    } 
+  end
+
+  let :cluster_proper do
+    {
+      :cluster => [{
+        'port'            => '1234',
+        'host'            => 'myhost',
+        'user'            => 'sensuuser',
+        'password'        => 'sensupass',
+        'vhost'           => '/myvhost',
+        'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+        'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+      }]
+    }
+  end
+
+  let :cluster_arrays do
+    {
+      :cluster => [
+        ['port'            , '1234'],
+        ['host'            , 'myhost'],
+        ['user'            , 'sensuuser'],
+        ['password'        , 'sensupass'],
+        ['vhost'           , '/myvhost'],
+        ['ssl_cert_chain'  , '/etc/sensu/ssl/cert.pem'],
+        ['ssl_private_key' , '/etc/sensu/ssl/key.pem']
+      ]
+    }
+  end
+
+  describe 'cluster' do
+    context 'when cluster is defined' do
+      context 'as an array of hashes' do
+        let(:subject) { create_type_instance(resource_hash.merge(cluster_proper)) }
+
+        it 'should be an array of hashes' do
+          cluster_val = subject.parameter(:cluster).value
+          expect(cluster_val).to be_an(Array)
+          expect(cluster_val).to eq([{
+            'port'            => '1234',
+            'host'            => 'myhost',
+            'user'            => 'sensuuser',
+            'password'        => 'sensupass',
+            'vhost'           => '/myvhost',
+            'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+            'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+          }])
+        end
+      end
+
+      context 'as an array of arrays' do
+        let(:subject) { create_type_instance(resource_hash.merge(cluster_arrays)) }
+
+        it 'should be an array of hashes' do
+          cluster_val = subject.parameter(:cluster).value
+          expect(cluster_val).to be_an(Array)
+          expect(cluster_val).to eq([{
+            'port'            => '1234',
+            'host'            => 'myhost',
+            'user'            => 'sensuuser',
+            'password'        => 'sensupass',
+            'vhost'           => '/myvhost',
+            'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+            'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+          }])
+        end
+      end
+    end
+  end
+end

--- a/tests/sensu-server-cluster.pp
+++ b/tests/sensu-server-cluster.pp
@@ -1,0 +1,42 @@
+node 'sensu-server' {
+  class { '::sensu':
+    install_repo      => true,
+    server            => true,
+    manage_services   => true,
+    manage_user       => true,
+    api               => true,
+    api_user          => 'admin',
+    api_password      => 'secret',
+    client_address    => $::ipaddress_eth1,
+    rabbitmq_cluster => [
+      {
+        'port'            => '1234',
+        'host'            => 'myhost',
+        'user'            => 'sensuuser',
+        'password'        => 'sensupass',
+        'vhost'           => '/myvhost',
+        'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+        'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+      },
+      {
+        'port'            => '1234',
+        'host'            => 'differenthost',
+        'user'            => 'sensuuser',
+        'password'        => 'sensupass',
+        'vhost'           => '/myvhost',
+        'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
+        'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+      }
+    ]
+  }
+
+  sensu::handler { 'default':
+    command => 'mail -s \'sensu alert\' ops@example.com',
+  }
+
+  sensu::check { 'check_ntp':
+    command     => 'PATH=$PATH:/usr/lib/nagios/plugins check_ntp_time -H pool.ntp.org -w 30 -c 60',
+    handlers    => 'default',
+    subscribers => 'sensu-test',
+  }
+}

--- a/tests/sensu-server-cluster.pp
+++ b/tests/sensu-server-cluster.pp
@@ -11,7 +11,7 @@ node 'sensu-server' {
     rabbitmq_cluster => [
       {
         'port'            => '1234',
-        'host'            => 'myhost',
+        'host'            => 'sensu-server.example.com',
         'user'            => 'sensuuser',
         'password'        => 'sensupass',
         'vhost'           => '/myvhost',
@@ -20,7 +20,7 @@ node 'sensu-server' {
       },
       {
         'port'            => '1234',
-        'host'            => 'differenthost',
+        'host'            => 'sensu-server.example.com',
         'user'            => 'sensuuser',
         'password'        => 'sensupass',
         'vhost'           => '/myvhost',


### PR DESCRIPTION
cluster config to be passed as array of hashes

puppet 3 doing something weird with passing the data around, improved munging may have fixed this or we may have found a weird edge case where an array that contains a single hash `[{:k => :v}]` gets converted in to an array of arrays `[[:k, :v]]`, but if it contains more than one hash `[{:k => :v}, {:k => :v}]`, it gets passed around correctly?