### PR TITLE
Initital fix for sensu on windows

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -541,12 +541,13 @@ class sensu (
     'windows': {
       $etc_dir = 'C:/opt/sensu'
       $conf_dir = "${etc_dir}/conf.d"
-      $user = 'Sensu'
-      $group = 'Users'
+      $user = 'NT Authority\SYSTEM'
+      $group = 'Administrators'
       $home_dir = $etc_dir
       $shell = undef
       $dir_mode = undef
       $file_mode = undef
+      $manage_user = false
     }
 
     default: {}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -547,7 +547,6 @@ class sensu (
       $shell = undef
       $dir_mode = undef
       $file_mode = undef
-      $manage_user = false
     }
 
     default: {}


### PR DESCRIPTION
Initial fix for sensu on windows. This was tested minimally. Further support should be added to override user if needed. 

NOTE: you must set manage_user to false on windows