### PR TITLE
Fix for enabling strict_variables

### DIFF
--- a/manifests/mutator.pp
+++ b/manifests/mutator.pp
@@ -61,6 +61,8 @@ define sensu::mutator(
       mode   => '0555',
       source => $source,
     }
+  } else {
+    $file_ensure = undef
   }
 
   file { "/etc/sensu/conf.d/mutators/${name}.json":


### PR DESCRIPTION
This missing variable is causing failures in our spec tests, since we've recently enabled `strict_variables`  - https://docs.puppet.com/puppet/latest/lang_variables.html#unassigned-variables-and-strict-mode

The change ensures the variable is explicitly set to `undef` if the `source` parameter is not set.
This will have no negative affect on existing implementations.