### PR TITLE
Add transport type support for redis/rabbitmq

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,6 +192,11 @@
 #   Boolean.  Reconnect to Redis in the event of a connection failure
 #   Default: true
 #
+# [*transport_type*]
+#   String. Transport type to be used by Sensu
+#   Default: rabbitmq
+#   Valid values: rabbitmq, redis
+#
 # [*api_bind*]
 #   String.  IP to bind api service
 #   Default: 0.0.0.0
@@ -380,6 +385,7 @@ class sensu (
   $redis_auto_reconnect           = true,
   $redis_sentinels                = undef,
   $redis_master                   = undef,
+  $transport_type                 = 'rabbitmq',
   $api_bind                       = '0.0.0.0',
   $api_host                       = '127.0.0.1',
   $api_port                       = 4567,
@@ -442,6 +448,7 @@ class sensu (
   validate_re($enterprise_version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")
   validate_re($sensu_plugin_version, ['^absent$', '^installed$', '^latest$', '^present$', '^\d[\d\.\-\w]+$'], "Invalid sensu-plugin package version: ${sensu_plugin_version}")
   validate_re($log_level, ['^debug$', '^info$', '^warn$', '^error$', '^fatal$'] )
+  validate_re($transport_type, ['^rabbitmq$', '^redis$'], "Invalid transport type '${transport_type}'. Expected either rabbitmq or redis" )
   if !is_integer($redis_port) { fail('redis_port must be an integer') }
   if !is_integer($api_port) { fail('api_port must be an integer') }
   if !is_integer($init_stop_max_wait) { fail('init_stop_max_wait must be an integer') }
@@ -557,6 +564,7 @@ class sensu (
   anchor { 'sensu::begin': } ->
   class { '::sensu::package': } ->
   class { '::sensu::enterprise::package': } ->
+  class { '::sensu::transport': } ->
   class { '::sensu::rabbitmq::config': } ->
   class { '::sensu::api::config': } ->
   class { '::sensu::redis::config': } ->

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -1,0 +1,43 @@
+# Class: sensu::transport
+#
+# Configure Sensu Transport
+#
+class sensu::transport {
+
+  if $caller_module_name != $module_name {
+    fail("Use of private function ${name} by ${caller_module_name}")
+  }
+
+  if $sensu::_purge_config and !$sensu::server and !$sensu::api {
+    $ensure = 'absent'
+  } else {
+    $ensure = 'present'
+  }
+
+  if $sensu::version =~ /^[\d\.\-]+$/ {
+    if versioncmp($sensu::version, '0.19.0') >= 0 {
+      $_transport_type = $sensu::transport_type
+    } else {
+      warning("${::sensu::version} is below 0.19.0, defaulting to rabbitmq")
+      $_transport_type = 'rabbitmq'
+    }
+  } else {
+    $_transport_type = $sensu::transport_type
+  }
+
+  $transport_type_hash = {
+    'transport' => {
+      'name'               => $_transport_type,
+      'reconnect_on_error' => true,
+    },
+  }
+
+  file { "${sensu::conf_dir}/transport.json":
+    ensure  => $ensure,
+    owner   => 'sensu',
+    group   => 'sensu',
+    mode    => '0440',
+    content => inline_template("<%= JSON.pretty_generate(@transport_type_hash) %>"),
+    notify  => $sensu::check_notify,
+  }
+}

--- a/spec/classes/sensu_transport_spec.rb
+++ b/spec/classes/sensu_transport_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'json'
+
+describe 'sensu' do
+  let(:facts) {{
+    :fqdn     => 'testhost.example.com',
+    :osfamily => 'RedHat',
+  }}
+
+  context 'transports' do
+    context 'defaults' do
+      it { should create_class('sensu::transport') }
+      it { should contain_file('/etc/sensu/conf.d/transport.json') }
+    end
+
+    context 'setting version < 0.19.0' do
+      let(:params) {{
+        :version        => '0.9.10',
+        :transport_type => 'redis',
+      }}
+
+      it { should contain_file('/etc/sensu/conf.d/transport.json').with_content(
+        JSON.pretty_generate({'transport' => {'name' => 'rabbitmq'}})
+      )}
+    end
+
+    context 'setting version >= 0.19.0' do
+      let(:params) {{
+        :version        => '0.20.3',
+        :transport_type => 'redis',
+      }}
+
+      it { should contain_file('/etc/sensu/conf.d/transport.json').with_content(
+        JSON.pretty_generate({'transport' => {'name' => 'redis'}})
+      )}
+    end
+  end
+end


### PR DESCRIPTION
Allows the selection of either Redis or RabbitMQ as the backend for
Sensu.

Fixes #556
Taken the code from #405 and merged in to a single commit