### PR TITLE
Adding parameters and manifest to support transport.json

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -192,6 +192,16 @@
 #   Boolean.  Reconnect to Redis in the event of a connection failure
 #   Default: true
 #
+# [*transport_type*]
+#   String. Transport type to be used by Sensu
+#   Default: rabbitmq
+#   Valid values: rabbitmq, redis
+#
+# [*transport_reconnect_on_error*]
+#   Boolean. If the transport connection is closed, attempt to recommect automatically when possible.
+#   Default: true
+#   Valid values: true, false
+#
 # [*api_bind*]
 #   String.  IP to bind api service
 #   Default: 0.0.0.0
@@ -380,6 +390,8 @@ class sensu (
   $redis_auto_reconnect           = true,
   $redis_sentinels                = undef,
   $redis_master                   = undef,
+  $transport_type                 = 'rabbitmq',
+  $transport_reconnect_on_error   = true,
   $api_bind                       = '0.0.0.0',
   $api_host                       = '127.0.0.1',
   $api_port                       = 4567,
@@ -442,6 +454,7 @@ class sensu (
   validate_re($enterprise_version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")
   validate_re($sensu_plugin_version, ['^absent$', '^installed$', '^latest$', '^present$', '^\d[\d\.\-\w]+$'], "Invalid sensu-plugin package version: ${sensu_plugin_version}")
   validate_re($log_level, ['^debug$', '^info$', '^warn$', '^error$', '^fatal$'] )
+  validate_re($transport_type, ['^rabbitmq$', '^redis$'], "Invalid transport type '${transport_type}'. Expected either rabbitmq or redis" )
   if !is_integer($redis_port) { fail('redis_port must be an integer') }
   if !is_integer($api_port) { fail('api_port must be an integer') }
   if !is_integer($init_stop_max_wait) { fail('init_stop_max_wait must be an integer') }
@@ -557,6 +570,7 @@ class sensu (
   anchor { 'sensu::begin': } ->
   class { '::sensu::package': } ->
   class { '::sensu::enterprise::package': } ->
+  class { '::sensu::transport': } ->
   class { '::sensu::rabbitmq::config': } ->
   class { '::sensu::api::config': } ->
   class { '::sensu::redis::config': } ->

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -8,7 +8,7 @@ class sensu::redis::config {
     fail("Use of private class ${name} by ${caller_module_name}")
   }
 
-  if $sensu::_purge_config and !$sensu::server and !$sensu::api and !$sensu::enterprise {
+  if $sensu::_purge_config and !$sensu::server and !$sensu::api and !$sensu::enterprise and $sensu::transport_type != 'redis' {
     $ensure = 'absent'
   } else {
     $ensure = 'present'

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -1,0 +1,23 @@
+# Class: sensu::transport
+#
+# Configure Sensu Transport
+#
+class sensu::transport {
+
+  $transport_type_hash = {
+    'transport' => {
+      'name'               => $sensu::transport_type,
+      'reconnect_on_error' => $sensu::transport_reconnect_on_error,
+    },
+  }
+
+  file { "${sensu::conf_dir}/transport.json":
+    ensure  => $ensure,
+    owner   => 'sensu',
+    group   => 'sensu',
+    mode    => '0440',
+    content => inline_template("<%= JSON.pretty_generate(@transport_type_hash) %>"),
+    notify  => $sensu::check_notify,
+  }
+}
+

--- a/spec/classes/sensu_transport_spec.rb
+++ b/spec/classes/sensu_transport_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'json'
+
+describe 'sensu' do
+  let(:facts) {{
+    :fqdn     => 'testhost.example.com',
+    :osfamily => 'RedHat',
+  }}
+
+  context 'transports' do
+    context 'defaults' do
+      it { should create_class('sensu::transport') }
+      it { should contain_file('/etc/sensu/conf.d/transport.json') }
+    end
+
+    context 'setting transport_type to redis' do
+      let(:params) {{
+        :transport_type => 'redis',
+      }}
+
+      it { should contain_file('/etc/sensu/conf.d/transport.json').with_content(
+        JSON.pretty_generate({'transport' => {'name' => 'redis', 'reconnect_on_error' => true}})
+      )}
+    end
+  end
+end
+


### PR DESCRIPTION
- Safe defaults: transport_type = 'rabbitmq', reconnect_on_error = true
- Redis config will be deployed to all hosts if the transport_type is 'redis'

I have deployed this in my own test environment, as I have a pressing need to deploy. I can come back to this and work on whatever it's missing (tests etc)