### PR TITLE
Sort properties in sensu_check provider

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -21,6 +21,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def flush
+    sort_properties
     File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
@@ -29,6 +30,10 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   def pre_create
     conf['checks'] = {}
     conf['checks'][resource[:name]] = {}
+  end
+
+  def sort_properties
+    conf['checks'][resource[:name]] = Hash[conf['checks'][resource[:name]].sort]
   end
 
   def is_property?(prop)


### PR DESCRIPTION
Currently sensu_check properties are written to json file in unclear order (especially `custom` properties).
With this change we can have them always sorted alphabetically in json file.