### PR TITLE
Drop support for Ruby 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ script: "bundle install && bundle exec rake validate && bundle exec rake test"
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.0
@@ -20,25 +19,11 @@ matrix:
   exclude:
   - rvm: 2.2.0
     env: PUPPET_GEM_VERSION="~> 3.8"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 4.2"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 4.2"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 4.4"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 4.3"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 4.3"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 4.4"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 4.4"
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 4.5"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 4.5"
-
-
-
-

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,5 @@
 source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-if RUBY_VERSION >= '1.8.7' and RUBY_VERSION < '1.9'
-  gem 'rspec', '~> 2.0'
-end
-
 group :development, :unit_tests do
   gem 'rake',                                             '< 11.0.0'
   gem 'rspec-puppet',                                     :require => false
@@ -25,12 +21,6 @@ group :development, :unit_tests do
   gem 'puppet-lint-undef_in_function-check',              :require => false
   gem 'puppet-lint-unquoted_string-check',                :require => false
   gem 'puppet-lint-version_comparison-check',             :require => false
-  # metadata-json-lint depends on semantic_puppet, version 0.1.4 of which
-  # is broken on ruby 1.8 due to use of `File.absolute_path`
-  if RUBY_VERSION < "1.9"
-    gem 'semantic_puppet', "< 0.1.4",                       :require => false
-    gem 'rdoc', "< 4.3.0",                                  :require => false
-  end
 end
 
 group :system_tests do

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'puppetlabs_spec_helper/rake_tasks'
 require 'puppet-lint/tasks/puppet-lint'
 require 'puppet-syntax/tasks/puppet-syntax'

--- a/lib/puppet/provider/sensu_api_config/json.rb
+++ b/lib/puppet/provider/sensu_api_config/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_check_config/json.rb
+++ b/lib/puppet/provider/sensu_check_config/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_client_config/json.rb
+++ b/lib/puppet/provider/sensu_client_config/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_client_subscription/json.rb
+++ b/lib/puppet/provider/sensu_client_subscription/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_enterprise_dashboard_api_config/json.rb
+++ b/lib/puppet/provider/sensu_enterprise_dashboard_api_config/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
+++ b/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_extension/json.rb
+++ b/lib/puppet/provider/sensu_extension/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_filter/json.rb
+++ b/lib/puppet/provider/sensu_filter/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_handler/json.rb
+++ b/lib/puppet/provider/sensu_handler/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_mutator/json.rb
+++ b/lib/puppet/provider/sensu_mutator/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -1,4 +1,3 @@
-require 'rubygems' if RUBY_VERSION < '1.9.0' && Puppet.version < '3'
 require 'json' if Puppet.features.json?
 require File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..',
                                    'puppet_x', 'sensu', 'provider_create.rb'))

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,3 @@
-require 'rubygems'
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 case ENV['COVERAGE']


### PR DESCRIPTION
This patch removes support for Ruby 1.9.3. This module maintains
compatibility with Puppet 3 which may run Ruby 2.0 and 2.1.

Support for Ruby 1.8 was already removed as TravisCI was not testing for
it. This patch also removes vestiges of that by no longer having the
'require rubygems' lines.