### PR TITLE
Select debian/ubuntu release for apt repo

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -26,7 +26,7 @@ class sensu::repo::apt {
     apt::source { 'sensu':
       ensure   => $ensure,
       location => $url,
-      release  => 'sensu',
+      release  => $::lsbdistcodename,
       repos    => $sensu::repo,
       include  => {
         'src' => false,

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -75,7 +75,7 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with(
               :ensure      => 'present',
               :location    => 'http://repositories.sensuapp.org/apt',
-              :release     => 'sensu',
+              :release     => 'trusty',
               :repos       => 'main',
               :include     => { 'src' => false },
               :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },
@@ -131,6 +131,23 @@ describe 'sensu' do
         context 'without puppet-apt installed' do
           it { expect { should raise_error(Puppet::Error) } }
         end
+      end
+
+      context 'debian' do
+        let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistrelease => '8.6', :lsbdistcodename => 'jessie', } }
+
+          context 'repo release' do
+            it { should contain_apt__source('sensu').with(
+              :ensure      => 'present',
+              :location    => 'http://repositories.sensuapp.org/apt',
+              :release     => 'jessie',
+              :repos       => 'main',
+              :include     => { 'src' => false },
+              :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },
+              :before      => 'Package[sensu]'
+            ) }
+          end
+
       end
 
       context 'redhat' do


### PR DESCRIPTION
It appears that sensu packages are no longer created in the `sensu` apt release on repositories.sensuapp.org - the latest there is 0.2.6-5.

Newer builds are being created for each of the releases ala. trusty, xenial, jessie etc.

Update the apt repo config to support this, and update relevant tests.