### PR TITLE
add dist to windows msi url

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -52,7 +52,7 @@ class sensu::package {
 
       remote_file { $pkg_source:
         ensure   => present,
-        source   => "http://repositories.sensuapp.org/msi/2012r2/sensu-${sensu::version}.msi",
+        source   => "http://repositories.sensuapp.org/msi/2012r2/sensu-${sensu::version}-x64.msi",
         checksum => $::sensu::package_checksum,
       }
     }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -52,7 +52,7 @@ class sensu::package {
 
       remote_file { $pkg_source:
         ensure   => present,
-        source   => "http://repositories.sensuapp.org/msi/sensu-${sensu::version}.msi",
+        source   => "http://repositories.sensuapp.org/msi/2012r2/sensu-${sensu::version}.msi",
         checksum => $::sensu::package_checksum,
       }
     }

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -52,7 +52,7 @@ class sensu::package {
 
       remote_file { $pkg_source:
         ensure   => present,
-        source   => "http://repositories.sensuapp.org/msi/2012r2/sensu-${sensu::version}-x64.msi",
+        source   => "http://repositories.sensuapp.org/msi/2012r2/sensu-${sensu::version}-${::architecture}.msi",
         checksum => $::sensu::package_checksum,
       }
     }


### PR DESCRIPTION
Similarly to #611 the windows install url also now has the dist codename in it.

Unfortunately only 2012r2 is supported, so it's simplest (for now) to hard-code the url

🏖 