### PR TITLE
Support `ensure` property on sensu::enterprise::dashboard::api

### DIFF
--- a/manifests/enterprise/dashboard/api.pp
+++ b/manifests/enterprise/dashboard/api.pp
@@ -1,4 +1,5 @@
 define sensu::enterprise::dashboard::api (
+  $ensure    = present,
   $base_path = undef,
   $host      = undef,
   $port      = undef,
@@ -7,12 +8,13 @@ define sensu::enterprise::dashboard::api (
   $path      = undef,
   $timeout   = undef,
   $user      = undef,
-  $pass      = undef
+  $pass      = undef,
 ) {
 
   require sensu::enterprise::dashboard::config
 
   sensu_enterprise_dashboard_api_config { $title:
+    ensure    => $ensure,
     base_path => $base_path,
     host      => $host,
     port      => $port,

--- a/spec/unit/sensu_enterprise_dashboard_api_spec.rb
+++ b/spec/unit/sensu_enterprise_dashboard_api_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_enterprise_dashboard_api_config) do
+  provider_class = described_class.provider(:json)
+
+  let :resource_hash do
+    {
+      :title   => 'foo.example.com',
+      :catalog => Puppet::Resource::Catalog.new()
+    }
+  end
+
+  let :type_instance do
+    result            = described_class.new(resource_hash)
+    provider_instance = provider_class.new(resource_hash)
+    result.provider   = provider_instance
+    result
+  end
+
+  describe "defaults ensure to 'present'" do
+    it do
+      expect(type_instance[:ensure]).to eq(:present)
+    end
+  end
+
+  context 'accepts String values for :ensure' do
+    describe "accepts value 'present' for :ensure" do
+      it do
+        type_instance[:ensure] = 'present'
+        expect(type_instance[:ensure]).to eq(:present)
+      end
+      describe "accepts String value 'absent' for :ensure" do
+        it do
+          type_instance[:ensure] = 'absent'
+          expect(type_instance[:ensure]).to eq(:absent)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This change adds an `ensure` parameter to sensu::enterprise::dashboard::api defined type, making it possible to specify that particular instances should be absent.

Perhaps I am thinking about this the wrong way, but adding the ability explicitly setting ensure to `absent` with these changes is the only way I've found to remove the 'Site 1' and 'Site 2' examples from the default dashboard.json.