### PR TITLE
update apt repository url

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -26,7 +26,7 @@ class sensu::repo::apt {
     apt::source { 'sensu':
       ensure   => $ensure,
       location => $url,
-      release  => 'sensu',
+      release  => $::lsbdistcodename,
       repos    => $sensu::repo,
       include  => {
         'src' => false,

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -75,7 +75,7 @@ describe 'sensu' do
             it { should contain_apt__source('sensu').with(
               :ensure      => 'present',
               :location    => 'http://repositories.sensuapp.org/apt',
-              :release     => 'sensu',
+              :release     => 'trusty',
               :repos       => 'main',
               :include     => { 'src' => false },
               :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },


### PR DESCRIPTION
relase is no longer sensu, but the codename (precise, trusty, ...)