### PR TITLE
redhat version fix

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -36,7 +36,7 @@ class sensu::package {
         'installed' => $sensu::version,
         'present'   => $sensu::version,
         'absent'    => $sensu::version,
-        default     => "${sensu::version}.el${::os_maj_version}"
+        default     => "${sensu::version}.el${::operatingsystemmajrelease}"
       }
 
       $pkg_source = undef

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -31,7 +31,14 @@ class sensu::package {
     'RedHat': {
       $pkg_title = 'sensu'
       $pkg_name = 'sensu'
-      $pkg_version = $sensu::version
+      $pkg_version = $sensu::version ? {
+        'latest'    => $sensu::version,
+        'installed' => $sensu::version,
+        'present'   => $sensu::version,
+        'absent'    => $sensu::version,
+        default     => "${sensu::version}.el${::os_maj_version}"
+      }
+
       $pkg_source = undef
 
       if $sensu::manage_repo {

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'sensu' do
-  let(:facts) { { :fqdn => 'testhost.domain.com', :osfamily => 'RedHat', :os_maj_version => 7 } }
+  let(:facts) { { :fqdn => 'testhost.domain.com', :osfamily => 'RedHat', :operatingsystemmajrelease => 7 } }
   directories = [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks',
         '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
         '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ]

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'sensu' do
-  let(:facts) { { :fqdn => 'testhost.domain.com', :osfamily => 'RedHat' } }
+  let(:facts) { { :fqdn => 'testhost.domain.com', :osfamily => 'RedHat', :os_maj_version => 7 } }
   directories = [ '/etc/sensu/conf.d', '/etc/sensu/conf.d/handlers', '/etc/sensu/conf.d/checks',
         '/etc/sensu/handlers', '/etc/sensu/extensions', '/etc/sensu/mutators',
         '/etc/sensu/extensions/handlers', '/etc/sensu/plugins' ]
@@ -35,7 +35,7 @@ describe 'sensu' do
         } }
 
         it { should contain_package('sensu').with(
-          :ensure => '0.9.10'
+          :ensure => '0.9.10.el7'
         ) }
 
         it { should contain_package('sensu-plugin').with(
@@ -78,7 +78,7 @@ describe 'sensu' do
       it { should contain_file('/etc/default/sensu').with(:content => /RUBYOPT="a"/) }
       it { should contain_file('/etc/default/sensu').with(:content => /GEM_PATH="\/foo"/) }
       it { should contain_file('/etc/default/sensu').with(:content => /CLIENT_DEREGISTER_ON_STOP=true/) }
-      it { should contain_file('/etc/default/sensu').with(:content => /CLIENT_DEREGISTER_HANDLER="example"/) } 
+      it { should contain_file('/etc/default/sensu').with(:content => /CLIENT_DEREGISTER_HANDLER="example"/) }
     end
 
     context 'repos' do


### PR DESCRIPTION
The redhat version numbers now have the os version appended, which when combined with this [version number validation](https://github.com/sensu/sensu-puppet/blob/master/manifests/init.pp#L446) means that `0.28.0-1.el7` is rejected by the module, but `0.28.0-1` won't select the package correctly from the yum repo.

The options are: either remove the version number validation in init.pp, or transform the centos version number to include the `.el5`, `.el6` or `.el7` suffix.

In the interests of making it easier to have one version that applies to all environments (debian, redhat, windows, etc) I've opted for the latter.

I'm not sure what side-effects this might have, so let me know if you think this is a terrible idea.