### PR TITLE
use gem.cmd instead of gem.bat

### DIFF
--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -13,7 +13,7 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
 
   commands :gemcmd =>
     if RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|winse|emx/
-      "#{ENV['SYSTEMDRIVE']}\\opt\\sensu\\embedded\\bin\\gem.bat"
+      "#{ENV['SYSTEMDRIVE']}\\opt\\sensu\\embedded\\bin\\gem.cmd"
     else
       "/opt/sensu/embedded/bin/gem"
     end


### PR DESCRIPTION
yet more fun and games from the 0.27 update for windows

I've yet to find exactly out why using `gem.bat` fails but using `gem.cmd`, but it's *something* to do with the gems environment.

It's worth noting that `gem.cmd` seems to have been added in 0.27, but it's not clear if it's supposed to replace `gem.bat` or not