### PR TITLE
Add support to rotate windows logs

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -15,8 +15,7 @@
     { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">=3.3.0 <5.0.0" },
-    { "name": "pe", "version_requirement": ">=3.7.0 < 2015.3.0" }
+    { "name": "puppet", "version_requirement": ">=3.3.0 <5.0.0" }
   ],
   "dependencies": [
     { "name": "lwf/remote_file", "version_requirement": ">= 1.0.0 <2.0.0" },

--- a/templates/sensu-client.erb
+++ b/templates/sensu-client.erb
@@ -4,5 +4,10 @@
   <name>Sensu Client</name>
   <description>This service runs a Sensu Client</description>
   <executable>C:\opt\sensu\embedded\bin\ruby</executable>
-  <arguments>C:\opt\sensu\embedded\bin\sensu-client -l C:\opt\sensu\sensu-client.log -d C:\opt\sensu\conf.d -L <%= scope.lookupvar("sensu::log_level") -%></arguments>
+  <arguments>C:\opt\sensu\embedded\bin\sensu-client -d C:\opt\sensu\conf.d -L <%= scope.lookupvar("sensu::log_level") -%></arguments>
+  <logpath>C:\opt\sensu\</logpath>
+  <log mode="roll-by-size">
+        <sizeThreshold>10240</sizeThreshold>
+        <keepFiles>10</keepFiles>
+  </log>
 </service>


### PR DESCRIPTION
The windows agent was not rotating logs correctly. I added support for that here, some changes to how logging is done was altered to add this support. Im open to discussion if we think we need to adjust it briefly but there are now separate log files for each type of output.

https://github.com/sensu/sensu-puppet/issues/618

https://github.com/sensu/sensu/issues/1617

