### PR TITLE
Add fix to resolve rabbitmq cluster heartbeat config failure.

### DIFF
--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -150,11 +150,11 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
   end
 
   def heartbeat
-    conf['rabbitmq']['heartbeat'].to_s
+    conf['rabbitmq']['heartbeat'] ? conf['rabbitmq']['heartbeat'].to_s : :absent
   end
 
   def heartbeat=(value)
-    conf['rabbitmq']['heartbeat'] = value.to_i
+    conf['rabbitmq']['heartbeat'] = value.to_i unless value == :absent
   end
 
   def reconnect_on_error

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -103,8 +103,12 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
 
   newproperty(:heartbeat) do
     desc "The RabbitMQ heartbeat value"
-
-    defaultto '30'
+    defaultto {30 unless @resource.has_cluster? }
+    
+    def insync?(is)
+      return should == is if should.is_a?(Symbol)
+      super(is)
+    end
   end
 
   newproperty(:reconnect_on_error) do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -376,7 +376,7 @@ class sensu (
   $rabbitmq_reconnect_on_error    = false,
   $rabbitmq_prefetch              = undef,
   $rabbitmq_cluster               = undef,
-  $rabbitmq_heartbeat             = 30,
+  $rabbitmq_heartbeat             = undef,
   $redis_host                     = '127.0.0.1',
   $redis_port                     = 6379,
   $redis_password                 = undef,

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -121,6 +121,7 @@ class sensu::rabbitmq::config {
   $prefetch = $has_cluster ? { false => $sensu::rabbitmq_prefetch, true => undef, }
   $base_path = $has_cluster ? { false => $sensu::conf_dir, true => undef, }
   $cluster = $has_cluster ? { true => $sensu::rabbitmq_cluster, false => undef, }
+  $heartbeat = $has_cluster ? { false => $sensu::rabbitmq_heartbeat, true => undef, }
 
   sensu_rabbitmq_config { $::fqdn:
     ensure             => $ensure,

--- a/metadata.json
+++ b/metadata.json
@@ -15,8 +15,7 @@
     { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">=3.3.0 <5.0.0" },
-    { "name": "pe", "version_requirement": ">=3.7.0 < 2015.3.0" }
+    { "name": "puppet", "version_requirement": ">=3.3.0 <5.0.0" }
   ],
   "dependencies": [
     { "name": "lwf/remote_file", "version_requirement": ">= 1.0.0 <2.0.0" },

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -207,17 +207,6 @@ describe 'sensu', :type => :class do
       ) }
     end # when using heartbeat attribute
 
-    context 'when not using heartbeat attribute' do
-      let(:params) { {
-        :rabbitmq_host => 'myhost'
-      } }
-
-      it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
-        :host => 'myhost',
-        :heartbeat  => '30'
-      ) }
-    end # when not using heartbeat attribute
-
     context 'purge config' do
       let(:params) { {
         :purge  => { 'config' => true },


### PR DESCRIPTION
This PR fixes a bug introduced by this change: https://github.com/sensu/sensu-puppet/pull/596

When a cluster is used the single node heartbeat var was conflicting with the cluster setting. This PR fixes that issue by mimicking what was done with the prefetch var. 

The default is set to undef as I believe it should not be set by default. Sensu's documentation states that its default is to not be set which disables heartbeats and I would say we should follow that. The config example in the docs shows how to set it if needed: https://sensuapp.org/docs/latest/reference/rabbitmq.html#rabbitmq-attributes