### PR TITLE
Windows Support Fixes

### DIFF
--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -97,7 +97,7 @@ class sensu::package {
       owner   => '0',
       group   => '0',
       mode    => '0444',
-      require => Package['sensu'],
+      require => Package[$pkg_title],
     }
   }
 
@@ -109,7 +109,7 @@ class sensu::package {
     purge   => $sensu::_purge_config,
     recurse => true,
     force   => true,
-    require => Package[$pkg_name],
+    require => Package[$pkg_title],
   }
 
   if $sensu::manage_handlers_dir {
@@ -121,7 +121,7 @@ class sensu::package {
       purge   => $sensu::_purge_handlers,
       recurse => true,
       force   => true,
-      require => Package[$pkg_name],
+      require => Package[$pkg_title],
     }
   }
 
@@ -133,7 +133,7 @@ class sensu::package {
     purge   => $sensu::_purge_extensions,
     recurse => true,
     force   => true,
-    require => Package[$pkg_name],
+    require => Package[$pkg_title],
   }
 
   if $sensu::manage_mutators_dir {
@@ -145,7 +145,7 @@ class sensu::package {
       purge   => $sensu::_purge_mutators,
       recurse => true,
       force   => true,
-      require => Package[$pkg_name],
+      require => Package[$pkg_title],
     }
   }
 
@@ -158,7 +158,7 @@ class sensu::package {
       purge   => $sensu::_purge_plugins,
       recurse => true,
       force   => true,
-      require => Package[$pkg_name],
+      require => Package[$pkg_title],
     }
   }
 

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -118,7 +118,7 @@ define sensu::plugin(
         recurse => $recurse,
         purge   => $purge,
         force   => $force,
-        require => Package['sensu'],
+        require => Package[$sensu::package::pkg_title],
       }
     }
     'package':    {

--- a/manifests/plugins_dir.pp
+++ b/manifests/plugins_dir.pp
@@ -14,7 +14,7 @@ define sensu::plugins_dir (
       recurse => $recurse,
       purge   => $purge,
       force   => $force,
-      require => Package['sensu'],
+      require => Package[$sensu::package::pkg_title],
     }
   }
 }

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -21,7 +21,7 @@ class sensu::rabbitmq::config {
       ensure  => directory,
       owner   => $sensu::user,
       group   => $sensu::group,
-      mode    => '0755',
+      mode    => $sensu::dir_mode,
       require => Package['sensu'],
     }
 

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -22,7 +22,7 @@ class sensu::rabbitmq::config {
       owner   => $sensu::user,
       group   => $sensu::group,
       mode    => $sensu::dir_mode,
-      require => Package['sensu'],
+      require => Package[$sensu::package::pkg_title],
     }
 
     # if provided a cert chain, and its a puppet:// URI, source file form the

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -35,7 +35,7 @@ class sensu::repo::apt {
         'id'     => $sensu::repo_key_id,
         'source' => $sensu::repo_key_source,
       },
-      before   => Package['sensu'],
+      before   => Package[$sensu::package::pkg_title],
       notify   => Exec['apt-update'],
     }
 

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -24,7 +24,7 @@ class sensu::repo::yum {
       gpgcheck => 0,
       name     => 'sensu',
       descr    => 'sensu',
-      before   => Package['sensu'],
+      before   => Package[$sensu::package::pkg_title],
     }
 
     # prep for Enterprise repos


### PR DESCRIPTION
This PR provides fixes for two issues when using this module in a Windows environment:

1. The package title in `Class[sensu::package]` is "Sensu" instead of "sensu" which causes a compilation failure due to resource references to `Package[sensu]`. Commit 69b01e7 unifies the use of `$sensu::package::pkg_title` across the module.
2. The RabbitMQ configuration class manages a directory for storing SSL certificates, but hard-codes the permissions on that directory to `0755` on all platforms which results in unusable folder permissions and a catalog application failure. Commit c1c6ef5 switches the hard-coded permissions to use `$sensu::dir_mode` instead.

With these two fixes applied this module works perfectly on my Windows server deployments.

Let me know if there's anything else that needs to change.