### PR TITLE
Fix some lint issues and test spec warnings

### DIFF
--- a/manifests/enterprise/dashboard/api.pp
+++ b/manifests/enterprise/dashboard/api.pp
@@ -1,3 +1,50 @@
+# = Class: sensu::enterprise::dashboard::api
+#
+# Manages the Sensu Enterprise API configuration
+#
+# == Parameters
+#
+# [*ensure*]
+#   String. Whether the dashboard API should be configured or not
+#   Default: present
+#   Valid values: present, absent
+#
+# [*base_path*]
+#   String. The base path to the client config file.
+#   Default: undef
+#
+# [*host*]
+#   String. The hostname or IP address of the Sensu API.
+#   Default: undef
+#
+# [*port*]
+#   Integer. The port of the Sensu API.
+#   Default: unset
+#
+# [*ssl*]
+#   Boolean. Whether or not to use the HTTPS protocol.
+#   Default: undef
+#
+# [*insecure*]
+#   Boolean. Whether or not to accept an insecure SSL certificate.
+#   Default: undef
+#
+# [*path*]
+#   String. The path of the Sensu API. Leave empty unless your Sensu API is not mounted to /.
+#   Default: undef
+#
+# [*timeout*]
+#   Integer. The timeout for the Sensu API, in seconds.
+#   Default: undef
+#
+# [*user*]
+#   String. The username of the Sensu API. Leave empty for no authentication.
+#   Default: undef
+#
+# [*pass*]
+#   String. The password of the Sensu API. Leave empty for no authentication.
+#   Default: undef
+
 define sensu::enterprise::dashboard::api (
   $ensure    = present,
   $base_path = undef,
@@ -11,7 +58,7 @@ define sensu::enterprise::dashboard::api (
   $pass      = undef,
 ) {
 
-  require sensu::enterprise::dashboard::config
+  require ::sensu::enterprise::dashboard::config
 
   sensu_enterprise_dashboard_api_config { $title:
     ensure    => $ensure,

--- a/manifests/enterprise/dashboard/config.pp
+++ b/manifests/enterprise/dashboard/config.pp
@@ -1,3 +1,7 @@
+# = Class: sensu::enterprise::dashboard::config
+#
+# Manages the Sensu Enterprise Dashboard configuration
+#
 class sensu::enterprise::dashboard::config {
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")

--- a/manifests/enterprise/service.pp
+++ b/manifests/enterprise/service.pp
@@ -1,3 +1,13 @@
+# = Class: sensu::enterprise::service
+#
+# Manages the Sensu Enterprise server service
+#
+# == Parameters
+#
+# [*hasrestart*]
+#   Boolean. Value of hasrestart attribute for this service.
+#   Default: true
+
 class sensu::enterprise::service (
   $hasrestart = true,
 ) {

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -162,7 +162,7 @@ class sensu::package {
     }
   }
 
-  if $sensu::manage_user and $osfamily != 'windows' {
+  if $sensu::manage_user and $::osfamily != 'windows' {
     user { $sensu::user:
       ensure  => 'present',
       system  => true,
@@ -176,7 +176,7 @@ class sensu::package {
       ensure => 'present',
       system => true,
     }
-  } elsif $sensu::manage_user and $osfamily == 'windows' {
+  } elsif $sensu::manage_user and $::osfamily == 'windows' {
     warning('Managing a local windows user is not supported')
   }
 

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -15,7 +15,6 @@ describe 'sensu', :type => :class do
           :address       => '2.3.4.5',
           :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
           :subscriptions => [],
-          :ensure        => 'present',
           :custom        => {}
         ) }
 
@@ -40,7 +39,6 @@ describe 'sensu', :type => :class do
           :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
           :subscriptions => ['all'],
           :redact        => ['password'],
-          :ensure        => 'present',
           :safe_mode     => true,
           :custom        => { 'bool' => true, 'foo' => 'bar' }
         } ) }

--- a/tests/sensu-server-cluster.pp
+++ b/tests/sensu-server-cluster.pp
@@ -1,13 +1,13 @@
 node 'sensu-server' {
   class { '::sensu':
-    install_repo      => true,
-    server            => true,
-    manage_services   => true,
-    manage_user       => true,
-    api               => true,
-    api_user          => 'admin',
-    api_password      => 'secret',
-    client_address    => $::ipaddress_eth1,
+    install_repo     => true,
+    server           => true,
+    manage_services  => true,
+    manage_user      => true,
+    api              => true,
+    api_user         => 'admin',
+    api_password     => 'secret',
+    client_address   => $::ipaddress_eth1,
     rabbitmq_cluster => [
       {
         'port'            => '1234',
@@ -26,8 +26,8 @@ node 'sensu-server' {
         'vhost'           => '/myvhost',
         'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
         'ssl_private_key' => '/etc/sensu/ssl/key.pem'
-      }
-    ]
+      },
+    ],
   }
 
   sensu::handler { 'default':


### PR DESCRIPTION
EDIT: It's a slow day for me today... I went ahead and added documentation to the enterprise modules that were missing it. There should be no lint issues with this PR, squashed it down into the original commit.

Our automated test system was not happy about some of the lint issues (which were also detected by your lint tests as well) so I fixed those up.

While running the test suite I also noticed a couple of warnings about ensure being redefined in the sensu_client_spec.rb file so I cleaned that up as well.

For clarity, here are the lint issues that this fixes:
```
manifests/enterprise/dashboard/api.pp:1:documentation:WARNING:defined type not documented
manifests/enterprise/dashboard/api.pp:14:relative_classname_inclusion:WARNING:class included by relative name
manifests/enterprise/dashboard/config.pp:1:documentation:WARNING:class not documented
manifests/enterprise/service.pp:1:documentation:WARNING:class not documented
manifests/package.pp:165:variable_scope:WARNING:top-scope variable being used without an explicit namespace
manifests/package.pp:179:variable_scope:WARNING:top-scope variable being used without an explicit namespace
tests/sensu-server-cluster.pp:3:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:4:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:5:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:6:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:7:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:8:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:9:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:10:arrow_alignment:WARNING:indentation of => is not properly aligned
tests/sensu-server-cluster.pp:31:trailing_comma:WARNING:missing trailing comma after last element
tests/sensu-server-cluster.pp:30:trailing_comma:WARNING:missing trailing comma after last element
```

And here are the two test warnings:
```
/home/cryptk/Documents/sourcecode/sensu/spec/classes/sensu_client_spec.rb:13: warning: key :ensure is duplicated and overwritten on line 18
/home/cryptk/Documents/sourcecode/sensu/spec/classes/sensu_client_spec.rb:37: warning: key :ensure is duplicated and overwritten on line 43
```