### PR TITLE
Bump puppetlabs/apt dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": [
     { "name": "lwf/remote_file", "version_requirement": ">= 1.0.0 <2.0.0" },
-    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 <3.0.0" },
+    { "name": "puppetlabs/apt", "version_requirement": ">= 2.0.0 <4.0.0" },
     { "name": "puppetlabs/stdlib", "version_requirement": ">=3.2.0 <5.0.0" }
   ]
 }


### PR DESCRIPTION
From puppetlabs/apt:
> "This release is fully backwards compatible to existing Puppet 4 configurations and provides you with deprecation warnings for every argument that will not work as expected with the final 4.0.0 release."