### PR TITLE
feat: update apt/yum repos

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -61,7 +61,7 @@
 #
 # [*repo_key_source*]
 #   String.  URL of the apt GPG key
-#   Default: http://repositories.sensuapp.org/apt/pubkey.gpg
+#   Default: http://sensu.global.ssl.fastly.net/apt/pubkey.gpg
 #
 # [*client*]
 #   Boolean.  Include the sensu client
@@ -366,7 +366,7 @@ class sensu (
   $repo                           = 'main',
   $repo_source                    = undef,
   $repo_key_id                    = 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB',
-  $repo_key_source                = 'http://repositories.sensuapp.org/apt/pubkey.gpg',
+  $repo_key_source                = 'http://sensu.global.ssl.fastly.net/apt/pubkey.gpg',
   $enterprise_repo_key_id         = '910442FF8781AFD0995D14B311AB27E8C3FE3269',
   $client                         = true,
   $server                         = false,

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -20,7 +20,7 @@ class sensu::repo::apt {
     if $::sensu::repo_source {
       $url = $::sensu::repo_source
     } else {
-      $url = 'http://repositories.sensuapp.org/apt'
+      $url = 'http://sensu.global.ssl.fastly.net/apt'
     }
 
     apt::source { 'sensu':

--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -13,8 +13,8 @@ class sensu::repo::yum {
       $url = $::sensu::repo_source
     } else {
       $url = $::sensu::repo ? {
-        'unstable'  => "http://repositories.sensuapp.org/yum-unstable/\$releasever/\$basearch/",
-        default     => "http://repositories.sensuapp.org/yum/\$releasever/\$basearch/"
+        'unstable'  => "http://sensu.global.ssl.fastly.net/yum-unstable/\$releasever/\$basearch/",
+        default     => "http://sensu.global.ssl.fastly.net/yum/\$releasever/\$basearch/"
       }
     }
 

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -174,7 +174,7 @@ describe 'sensu' do
         context 'default' do
           it { should contain_yumrepo('sensu').with(
             :enabled   => 1,
-            :baseurl   => 'http://repositories.sensuapp.org/yum/$releasever/$basearch/',
+            :baseurl   => 'http://sensu.global.ssl.fastly.net/yum/$releasever/$basearch/',
             :gpgcheck  => 0,
             :before    => 'Package[sensu]'
           ) }
@@ -192,7 +192,7 @@ describe 'sensu' do
 
         context 'unstable repo' do
           let(:params) { { :repo => 'unstable' } }
-          it { should contain_yumrepo('sensu').with(:baseurl => 'http://repositories.sensuapp.org/yum-unstable/$releasever/$basearch/' )}
+          it { should contain_yumrepo('sensu').with(:baseurl => 'http://sensu.global.ssl.fastly.net/yum-unstable/$releasever/$basearch/' )}
         end
 
         context 'override repo url' do

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -92,11 +92,11 @@ describe 'sensu' do
           context 'default' do
             it { should contain_apt__source('sensu').with(
               :ensure      => 'present',
-              :location    => 'http://repositories.sensuapp.org/apt',
+              :location    => 'http://sensu.global.ssl.fastly.net/apt',
               :release     => 'trusty',
               :repos       => 'main',
               :include     => { 'src' => false },
-              :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },
+              :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://sensu.global.ssl.fastly.net/apt/pubkey.gpg' },
               :before      => 'Package[sensu]'
             ) }
           end
@@ -157,11 +157,11 @@ describe 'sensu' do
           context 'repo release' do
             it { should contain_apt__source('sensu').with(
               :ensure      => 'present',
-              :location    => 'http://repositories.sensuapp.org/apt',
+              :location    => 'http://sensu.global.ssl.fastly.net/apt',
               :release     => 'jessie',
               :repos       => 'main',
               :include     => { 'src' => false },
-              :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://repositories.sensuapp.org/apt/pubkey.gpg' },
+              :key         => { 'id' => 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB', 'source' => 'http://sensu.global.ssl.fastly.net/apt/pubkey.gpg' },
               :before      => 'Package[sensu]'
             ) }
           end


### PR DESCRIPTION
Hi,

I've updated yum/apt repository location, according documentation.

This also permit to get latest sensu version, v0.29

https://sensuapp.org/docs/0.29/platforms/sensu-on-ubuntu-debian.html#install-sensu-core-repository

Next step: ensure apt/yum https transport package is installed then use the HTTPS endpoint by default.

Thank you