### PR TITLE
Update version string validation to allow for redhat platform suffix

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 # [*version*]
 #   String.  Version of sensu to install
 #   Default: latest
-#   Valid values: absent, installed, latest, present, [\d\.\-]+
+#   Valid values: absent, installed, latest, present, [\d\.\-el]+
 #
 # [*sensu_plugin_name*]
 #   String.  Name of the sensu-plugin package. Refers to the sensu-plugin rubygem

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -453,7 +453,7 @@ class sensu (
   validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir, $deregister_on_stop)
 
   validate_re($repo, ['^main$', '^unstable$'], "Repo must be 'main' or 'unstable'.  Found: ${repo}")
-  validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")
+  validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-el]+$'], "Invalid package version: ${version}")
   validate_re($enterprise_version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-]+$'], "Invalid package version: ${version}")
   validate_re($sensu_plugin_version, ['^absent$', '^installed$', '^latest$', '^present$', '^\d[\d\.\-\w]+$'], "Invalid sensu-plugin package version: ${sensu_plugin_version}")
   validate_re($log_level, ['^debug$', '^info$', '^warn$', '^error$', '^fatal$'] )

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -28,19 +28,37 @@ describe 'sensu' do
     end
 
     context 'setting version' do
-      let(:params) { {
-        :version              => '0.9.10',
-        :sensu_plugin_version => 'installed',
-      } }
+      context 'without platform version suffix' do
+        let(:params) { {
+          :version              => '0.9.10',
+          :sensu_plugin_version => 'installed',
+        } }
 
-      it { should contain_package('sensu').with(
-        :ensure => '0.9.10'
-      ) }
+        it { should contain_package('sensu').with(
+          :ensure => '0.9.10'
+        ) }
 
-      it { should contain_package('sensu-plugin').with(
-        :ensure   => 'installed',
-        :provider => 'gem'
-      ) }
+        it { should contain_package('sensu-plugin').with(
+          :ensure   => 'installed',
+          :provider => 'gem'
+        ) }
+      end
+
+      context 'with redhat platform version suffix' do
+        let(:params) { {
+          :version              => '0.29.0-1.el7',
+          :sensu_plugin_version => 'installed',
+        } }
+
+        it { should contain_package('sensu').with(
+          :ensure => '0.29.0-1.el7'
+        ) }
+
+        it { should contain_package('sensu-plugin').with(
+          :ensure   => 'installed',
+          :provider => 'gem'
+        ) }
+      end
     end
 
     context 'embeded_ruby' do


### PR DESCRIPTION
On RHEL-like platforms, version strings for Sensu 0.27 and later include a `.elX` suffix (where `X` represents the OS major version), which the current validation regex will not permit. This change seeks to loosen the validation regex to allow for this version string suffix.

Closes #641 