### PR TITLE
Remove Puppet 3.8 from unit tests, update minimum Puppet version in metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ rvm:
   - 2.1.0
   - 2.2.0
 env:
-  - PUPPET_GEM_VERSION="~> 3.8"
   - PUPPET_GEM_VERSION="~> 4.2"
   - PUPPET_GEM_VERSION="~> 4.3"
   - PUPPET_GEM_VERSION="~> 4.4"
@@ -17,8 +16,6 @@ env:
 matrix:
   fast_finish: true
   exclude:
-  - rvm: 2.2.0
-    env: PUPPET_GEM_VERSION="~> 3.8"
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 4.2"
   - rvm: 2.0.0

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,7 @@
     { "operatingsystem": "Ubuntu", "operatingsystemrelease": [ "12.04", "14.04" ] }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">=3.3.0 <5.0.0" }
+    { "name": "puppet", "version_requirement": ">=4.0.0 <5.0.0" }
   ],
   "dependencies": [
     { "name": "lwf/remote_file", "version_requirement": ">= 1.0.0 <2.0.0" },


### PR DESCRIPTION
Closes #577