### PR TITLE
[WIP] rename 'name' to 'datacenter', use 'host' as namevar

### DIFF
--- a/lib/puppet/provider/sensu_enterprise_dashboard_api_config/json.rb
+++ b/lib/puppet/provider/sensu_enterprise_dashboard_api_config/json.rb
@@ -15,11 +15,9 @@ Puppet::Type.type(:sensu_enterprise_dashboard_api_config).provide(:json) do
   # Returns a Hash representation of the JSON structure in
   # /etc/sensu/dashboard.json or an empty Hash if the file can not be read.
   def conf
-    begin
-      @conf ||= JSON.parse(File.read(config_file))
-    rescue
-      @conf ||= {}
-    end
+    @conf ||= JSON.parse(File.read(config_file))
+  rescue
+    @conf ||= {}
   end
 
   # Internal: Retrieve the sensu config block from conf
@@ -119,7 +117,7 @@ Puppet::Type.type(:sensu_enterprise_dashboard_api_config).provide(:json) do
     api['ssl'] = value
   end
 
-  # Public: Retrieve the Boolean value which determines whether to accept 
+  # Public: Retrieve the Boolean value which determines whether to accept
   # an insecure SSL certificate
   #
   # Returns the Boolean insecure.

--- a/lib/puppet/provider/sensu_enterprise_dashboard_api_config/json.rb
+++ b/lib/puppet/provider/sensu_enterprise_dashboard_api_config/json.rb
@@ -31,8 +31,8 @@ Puppet::Type.type(:sensu_enterprise_dashboard_api_config).provide(:json) do
   end
 
   # Internal: Returns the name of the resource
-  def name
-    resource[:name]
+  def host
+    resource[:host]
   end
 
   # Internal: Returns the API endpoint config Hash
@@ -40,7 +40,7 @@ Puppet::Type.type(:sensu_enterprise_dashboard_api_config).provide(:json) do
   # Returns an empty Hash if the config block doesn't exist yet
   def api
     return @api if @api
-    api_hash = sensu.find { |endpoint| endpoint['name'] == name }
+    api_hash = sensu.find { |endpoint| endpoint['host'] == host }
     @api = api_hash ? api_hash : {}
   end
 
@@ -57,14 +57,14 @@ Puppet::Type.type(:sensu_enterprise_dashboard_api_config).provide(:json) do
 
   def pre_create
     conf['sensu'] ||= []
-    sensu << { 'name' => name } unless sensu.find{|e| e['name'] == name}
+    sensu << { 'host' => host } unless sensu.find{|e| e['host'] == host}
   end
 
   # Public: Remove the API configuration section.
   #
   # Returns nothing.
   def destroy
-    sensu.reject! { |api| api['name'] == name }
+    sensu.reject! { |api| api['host'] == host }
   end
 
   # Public: Determine if the specified API endpoint configuration section is present.
@@ -72,23 +72,23 @@ Puppet::Type.type(:sensu_enterprise_dashboard_api_config).provide(:json) do
   # Returns a Boolean, true if present, false if absent.
   def exists?
     sensu.inject(false) do |memo, api|
-      memo = true if api['name'] == name
+      memo = true if api['host'] == host
       memo
     end
   end
 
-  # Public: Retrieve the host name of the specified API endpoint
+  # Public: Retrieve the name of the specified API endpoint
   #
-  # Returns the String host
-  def host
-    api['host']
+  # Returns the String name
+  def datacenter
+    api['name']
   end
 
-  # Public: Set the host name of the specified API endpoint
+  # Public: Set the name of the specified API endpoint
   #
   # Returns nothing.
-  def host=(value)
-    api['host'] = value
+  def datacenter=(value)
+    api['name'] = value
   end
 
   # Public: Retrieve the port number that the API is configured to listen on.

--- a/lib/puppet/type/sensu_enterprise_dashboard_api_config.rb
+++ b/lib/puppet/type/sensu_enterprise_dashboard_api_config.rb
@@ -1,4 +1,5 @@
-require 'puppet/parameter/boolean'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                   'puppet_x', 'sensu', 'boolean_property.rb'))
 
 Puppet::Type.newtype(:sensu_enterprise_dashboard_api_config) do
   @doc = ""
@@ -23,8 +24,10 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_api_config) do
     defaultto :present
   end
 
-  newparam(:name) do
-    desc "The name of the Sensu API (used elsewhere as the datacenter name)."
+  newparam(:host) do
+    desc "The hostname or IP address of the Sensu API."
+
+    isnamevar
   end
 
   newparam(:base_path) do
@@ -32,9 +35,8 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_api_config) do
     defaultto '/etc/sensu/'
   end
 
-  newproperty(:host) do
-    desc "The hostname or IP address of the Sensu API."
-    isrequired
+  newproperty(:datacenter) do
+    desc "The name of the Sensu API (used elsewhere as the datacenter name)."
   end
 
   newproperty(:port) do
@@ -45,16 +47,16 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_api_config) do
     defaultto '4567'
   end
 
-  newproperty(:ssl, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:ssl, :parent => PuppetX::Sensu::BooleanProperty) do
     desc "Determines whether or not to use the HTTPS protocol."
 
-    defaultto false
+    defaultto :false
   end
 
-  newproperty(:insecure, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+  newproperty(:insecure, :parent => PuppetX::Sensu::BooleanProperty) do
     desc "Determines whether or not to accept an insecure SSL certificate."
 
-    defaultto false
+    defaultto :false
   end
 
   newproperty(:path) do

--- a/manifests/enterprise/dashboard/api.pp
+++ b/manifests/enterprise/dashboard/api.pp
@@ -4,6 +4,12 @@
 #
 # == Parameters
 #
+# [*host*]
+#   String. The hostname or IP address of the Sensu API.
+#   Default: undef
+#   This is used as the namevar for the underlying resource, so must be unique
+#   within the catalog.
+#
 # [*ensure*]
 #   String. Whether the dashboard API should be configured or not
 #   Default: present
@@ -13,8 +19,8 @@
 #   String. The base path to the client config file.
 #   Default: undef
 #
-# [*host*]
-#   String. The hostname or IP address of the Sensu API.
+# [*datacenter*]
+#   String. The datacenter name.
 #   Default: undef
 #
 # [*port*]
@@ -46,31 +52,31 @@
 #   Default: undef
 
 define sensu::enterprise::dashboard::api (
-  $ensure    = present,
-  $base_path = undef,
-  $host      = undef,
-  $port      = undef,
-  $ssl       = undef,
-  $insecure  = undef,
-  $path      = undef,
-  $timeout   = undef,
-  $user      = undef,
-  $pass      = undef,
+  $ensure     = present,
+  $base_path  = undef,
+  $datacenter = undef,
+  $port       = undef,
+  $ssl        = undef,
+  $insecure   = undef,
+  $path       = undef,
+  $timeout    = undef,
+  $user       = undef,
+  $pass       = undef,
 ) {
 
   require ::sensu::enterprise::dashboard::config
 
   sensu_enterprise_dashboard_api_config { $title:
-    ensure    => $ensure,
-    base_path => $base_path,
-    host      => $host,
-    port      => $port,
-    ssl       => $ssl,
-    insecure  => $insecure,
-    path      => $path,
-    timeout   => $timeout,
-    user      => $user,
-    pass      => $pass,
+    ensure     => $ensure,
+    base_path  => $base_path,
+    datacenter => $datacenter,
+    port       => $port,
+    ssl        => $ssl,
+    insecure   => $insecure,
+    path       => $path,
+    timeout    => $timeout,
+    user       => $user,
+    pass       => $pass,
   }
 
 }

--- a/spec/acceptance/enterprise/dashboard/api_spec.rb
+++ b/spec/acceptance/enterprise/dashboard/api_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu::enterprise::dashboard::api', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily')) do
+
+  context 'sensu' do
+    context 'default' do
+      break unless ENV['SE_USER'] && ENV['SE_PASS']
+
+      it 'should work with no errors' do
+        pp = <<-EOS
+        class { 'sensu':
+          enterprise_dashboard => true,
+          enterprise_user      => #{ENV['SE_USER']},
+          enterprise_pass      => #{ENV['SE_PASS']},
+        }
+
+        sensu::enterprise::dashboard::api { 'sensu.example.com':
+          datacenter => 'example-dc',
+        }
+
+        resources { 'sensu_enterprise_dashboard_api_config':
+          purge => true,
+        }
+        EOS
+
+        # Run it twice and test for idempotency
+        apply_manifest(pp, :catch_failures => true)
+        apply_manifest(pp, :catch_changes  => true)
+      end
+
+      describe service('sensu-enterprise-dashboard') do
+        it { is_expected.to be_running }
+        it { is_expected.to be_enabled }
+      end
+
+      describe file('/etc/sensu/dashboard.json') do
+        it { is_expected.to be_file }
+        its(:content) { should match /name.*?example-dc/ }
+        its(:content) { should match /host.*?sensu\.example\.com/ }
+      end
+    end
+  end
+end

--- a/spec/acceptance/enterprise/dashboard/api_spec.rb
+++ b/spec/acceptance/enterprise/dashboard/api_spec.rb
@@ -17,10 +17,6 @@ describe 'sensu::enterprise::dashboard::api', :unless => UNSUPPORTED_PLATFORMS.i
         sensu::enterprise::dashboard::api { 'sensu.example.com':
           datacenter => 'example-dc',
         }
-
-        resources { 'sensu_enterprise_dashboard_api_config':
-          purge => true,
-        }
         EOS
 
         # Run it twice and test for idempotency

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,3 +9,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
+  preserve_hosts: always

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -9,4 +9,3 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: foss
-  preserve_hosts: always

--- a/spec/unit/sensu_enterprise_dashboard_api_config_spec.rb
+++ b/spec/unit/sensu_enterprise_dashboard_api_config_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_enterprise_dashboard_api_config) do
+  provider_class = described_class.provider(:json)
+
+  let :resource_hash do
+    {
+      :title   => 'foo.example.com',
+      :catalog => Puppet::Resource::Catalog.new()
+    }
+  end
+
+  let :type_instance do
+    result            = described_class.new(resource_hash)
+    provider_instance = provider_class.new(resource_hash)
+    result.provider   = provider_instance
+    result
+  end
+
+  describe 'defaults to' do
+    it 'port of 4567' do
+      expect(type_instance[:port]).to eq('4567')
+    end
+
+    it 'timeout of 5' do
+      expect(type_instance[:timeout]).to eq('5')
+    end
+  end
+
+  describe 'host' do
+    it 'should be namevar' do
+      expect(
+        described_class.new(resource_hash).parameters[:host].isnamevar?
+      ).to be(true)
+    end
+
+    it 'should be title if unspecified' do
+      expect(described_class.new(resource_hash)[:host]).to eq('foo.example.com')
+    end
+
+    it 'should be host if specified' do
+      expect(
+        described_class.new(resource_hash.merge(:host => 'api.example.com'))[:host]
+      ).to eq('api.example.com')
+    end
+  end
+
+  describe 'datacenter' do
+    it 'should not be namevar' do
+      expect(
+        described_class.new(resource_hash.merge(:datacenter => 'example1')).parameters[:datacenter].isnamevar?
+      ).to_not be(true)
+    end
+  end
+
+  describe 'ssl' do
+    it 'should default to false' do
+      expect(described_class.new(resource_hash)[:ssl]).to be(:false)
+    end
+
+    it 'should be translated to a symbol (as per PuppetX::Sensu::BooleanProperty)' do
+      expect(
+        described_class.new(resource_hash.merge(:ssl => 'true'))[:ssl]
+      ).to be(:true)
+    end
+  end
+
+  describe 'insecure' do
+    it 'should default to false' do
+      expect(described_class.new(resource_hash)[:insecure]).to be(:false)
+    end
+
+    it 'should be translated to a symbol (as per PuppetX::Sensu::BooleanProperty)' do
+      expect(
+        described_class.new(resource_hash.merge(:insecure => 'true'))[:insecure]
+      ).to be(:true)
+    end
+  end
+end

--- a/spec/unit/sensu_enterprise_dashboard_api_config_spec.rb
+++ b/spec/unit/sensu_enterprise_dashboard_api_config_spec.rb
@@ -28,25 +28,29 @@ describe Puppet::Type.type(:sensu_enterprise_dashboard_api_config) do
   end
 
   describe 'host' do
-    it 'should be namevar' do
+    it 'is the namevar' do
       expect(
         described_class.new(resource_hash).parameters[:host].isnamevar?
       ).to be(true)
     end
 
-    it 'should be title if unspecified' do
-      expect(described_class.new(resource_hash)[:host]).to eq('foo.example.com')
+    context 'when host is unspecified' do
+      it 'title is used' do
+        expect(described_class.new(resource_hash)[:host]).to eq('foo.example.com')
+      end
     end
 
-    it 'should be host if specified' do
-      expect(
-        described_class.new(resource_hash.merge(:host => 'api.example.com'))[:host]
-      ).to eq('api.example.com')
+    context 'when host is specified' do
+      it 'host is used' do
+        expect(
+          described_class.new(resource_hash.merge(:host => 'api.example.com'))[:host]
+        ).to eq('api.example.com')
+      end
     end
   end
 
   describe 'datacenter' do
-    it 'should not be namevar' do
+    it 'isn\'t the namevar' do
       expect(
         described_class.new(resource_hash.merge(:datacenter => 'example1')).parameters[:datacenter].isnamevar?
       ).to_not be(true)
@@ -54,11 +58,11 @@ describe Puppet::Type.type(:sensu_enterprise_dashboard_api_config) do
   end
 
   describe 'ssl' do
-    it 'should default to false' do
+    it 'defaults to false' do
       expect(described_class.new(resource_hash)[:ssl]).to be(:false)
     end
 
-    it 'should be translated to a symbol (as per PuppetX::Sensu::BooleanProperty)' do
+    it 'is translated to a symbol (as per PuppetX::Sensu::BooleanProperty)' do
       expect(
         described_class.new(resource_hash.merge(:ssl => 'true'))[:ssl]
       ).to be(:true)
@@ -66,11 +70,11 @@ describe Puppet::Type.type(:sensu_enterprise_dashboard_api_config) do
   end
 
   describe 'insecure' do
-    it 'should default to false' do
+    it 'defaults to false' do
       expect(described_class.new(resource_hash)[:insecure]).to be(:false)
     end
 
-    it 'should be translated to a symbol (as per PuppetX::Sensu::BooleanProperty)' do
+    it 'is translated to a symbol (as per PuppetX::Sensu::BooleanProperty)' do
       expect(
         described_class.new(resource_hash.merge(:insecure => 'true'))[:insecure]
       ).to be(:true)


### PR DESCRIPTION
it turns out that 'name' isn't necessarily unique and puppet requires
that a param named 'name' must be the namevar (which must be unique)

This PR isn't complete because it needs tests and possibly documentation. Please do NOT merge.

Fixes #638 and possibly #584 