### PR TITLE
[WIP] check type should notify sensu-enterprise

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:sensu_check) do
     self[:notify] = [
       "Service[sensu-client]",
       "Service[sensu-server]",
+      "Service[sensu-enterprise]",
     ].select { |ref| catalog.resource(ref) }
   end
 


### PR DESCRIPTION
I believe this resolves #495 in spirit, but I'm still working on writing a good test. It may be preferable to implement Puppet 4's `autonotify()` now that we've dropped support for Puppet 3...