### PR TITLE
fix apt errors by adding os facts to debian and ubuntu examples

### DIFF
--- a/spec/classes/sensu_enterprise_spec.rb
+++ b/spec/classes/sensu_enterprise_spec.rb
@@ -121,7 +121,7 @@ describe 'sensu', :type => :class do
   end
 
   context 'on Debian' do
-    let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'ubuntu', :lsbdistrelease => '14.04', :lsbdistcodename => 'trusty', } }
+    let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'ubuntu', :lsbdistrelease => '14.04', :lsbdistcodename => 'trusty', :os => {:name => 'ubuntu', :release => {:full => '14.04'} }, } }
     context 'when enterprise => true' do
       let(:params) { {
         :enterprise => true,

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -84,7 +84,7 @@ describe 'sensu' do
     context 'repos' do
 
       context 'ubuntu' do
-        let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'ubuntu', :lsbdistrelease => '14.04', :lsbdistcodename => 'trusty', } }
+        let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'ubuntu', :lsbdistrelease => '14.04', :lsbdistcodename => 'trusty', :os => {:name => 'ubuntu', :release => {:full => '14.04'} }, } }
 
         context 'with puppet-apt installed' do
           let(:pre_condition) { [ 'define apt::source ($ensure, $location, $release, $repos, $include, $key) {}' ] }
@@ -152,7 +152,7 @@ describe 'sensu' do
       end
 
       context 'debian' do
-        let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistrelease => '8.6', :lsbdistcodename => 'jessie', } }
+        let(:facts) { { :osfamily => 'Debian', :lsbdistid => 'Debian', :lsbdistrelease => '8.6', :lsbdistcodename => 'jessie', :os => {:name => 'debian', :release => {:full => '8.6'} }, } }
 
           context 'repo release' do
             it { should contain_apt__source('sensu').with(


### PR DESCRIPTION
As of https://github.com/puppetlabs/puppetlabs-apt/commit/33d17cfcfd86bef27a71e29a0fbab4b20b97327d the apt module expects the os name fact to be populated. Since the debian and ubuntu examples in our specs don't populate this fact, the apt module raises an exception.

h/t to @dzeleski for identifying the source of this breakage.