### PR TITLE
(GH-688) Default sensu-plugin gem to use sensu_gem provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -264,8 +264,12 @@
 #   Example value: { config => true, plugins => true }
 #
 # [*use_embedded_ruby*]
-#   Boolean.  If the embedded ruby should be used
-#   Default: false
+#   Boolean.  If the embedded ruby should be used, e.g. to install the
+#   sensu-plugin gem.  This value is overridden by a defined
+#   sensu_plugin_provider.  Note, the embedded ruby should always be used to
+#   provide full compatibility.  Using other ruby runtimes, e.g. the system
+#   ruby, is not recommended.
+#   Default: true
 #   Valid values: true, false
 #
 # [*rubyopt*]
@@ -416,7 +420,7 @@ class sensu (
   $purge                          = false,
   $purge_config                   = false,
   $purge_plugins_dir              = false,
-  $use_embedded_ruby              = false,
+  $use_embedded_ruby              = true,
   $rubyopt                        = undef,
   $gem_path                       = undef,
   $log_level                      = 'info',

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -169,4 +169,10 @@ describe 'sensu', :type => :class do
         :source => "puppet:///modules/sensu_module/community-plugins/handlers/notification/hipchat.rb"
     )}
   end
+
+  describe '(GH-688) default behavior of sensu_plugin_provider' do
+    it 'should be sensu_gem ' do
+      should contain_package('sensu-plugin').with(:provider => 'sensu_gem')
+    end
+  end
 end

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -40,7 +40,6 @@ describe 'sensu' do
 
         it { should contain_package('sensu-plugin').with(
           :ensure   => 'installed',
-          :provider => 'gem'
         ) }
       end
 
@@ -56,15 +55,26 @@ describe 'sensu' do
 
         it { should contain_package('sensu-plugin').with(
           :ensure   => 'installed',
-          :provider => 'gem'
         ) }
       end
     end
 
-    context 'embeded_ruby' do
-      let(:params) { { :use_embedded_ruby => true } }
+    describe 'embeded_ruby' do
+      context 'with default behavior (GH-688)' do
+        it { should contain_package('sensu-plugin').with(:provider => 'sensu_gem') }
+      end
 
-      it { should contain_package('sensu-plugin').with(:provider => 'sensu_gem') }
+      context 'with use_embedded_ruby => true' do
+        let(:params) { { :use_embedded_ruby => true } }
+
+        it { should contain_package('sensu-plugin').with(:provider => 'sensu_gem') }
+      end
+
+      context 'with use_embedded_ruby => false' do
+        let(:params) { { :use_embedded_ruby => false } }
+
+        it { should contain_package('sensu-plugin').with(:provider => 'gem') }
+      end
     end
 
     context 'sensu_plugin_provider and sensu_plugin_name' do


### PR DESCRIPTION
Without this patch the behavior of sensu-plugin is managed by the default
package provider for the system, e.g. gem.  This patch changes the default
behavior to use the embedded ruby version at `/opt/sensu/embedded/bin/gem` via
the built in provider.