### PR TITLE
Use rspec-puppet 2.5.x until 2.6.x is fixed

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 group :development, :unit_tests do
   gem 'rake',                                             '< 11.0.0'
-  gem 'rspec-puppet',                                     :require => false
+  gem 'rspec-puppet', '~> 2.5.0',                         :require => false
   gem 'puppetlabs_spec_helper', '>= 2.0.0',               :require => false
   gem 'puppet-lint', "~> 2.0",                            :require => false
   gem 'json', "~> 1.8.3",                                 :require => false


### PR DESCRIPTION
Latest update to rspec-puppet 2.6.x doesn't work correctly.
Pin to use 2.5.x until 2.6.x is fixed.