### PR TITLE
(#649) Enumerate sensu_enterprise_dashboard_config instances

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,8 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
-Gemfile.lock
+/Gemfile.lock
+/Gemfile.local
 
 # YARD artifacts
 .yardoc

--- a/Gemfile
+++ b/Gemfile
@@ -50,4 +50,8 @@ group :development do
   gem 'listen', '~> 3.0.0', :require => false
 end
 
+if File.exists? 'Gemfile.local'
+  eval(File.read('Gemfile.local'), binding)
+end
+
 # vim:ft=ruby

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Sensu-Puppet module.
 
 ## Installation
 
-    $ puppet module install sensu/sensu
+```bash
+puppet module install sensu/sensu
+```
 
 ## Prerequisites
 
@@ -55,11 +57,15 @@ or gem on all your nodes.
 
 Rubygem:
 
-    $ sudo gem install json
+```bash
+sudo gem install json
+```
 
 Debian & Ubuntu:
 
-    $ sudo apt-get install ruby-json
+```bash
+sudo apt-get install ruby-json
+```
 
 ## Quick start
 
@@ -72,23 +78,31 @@ Before this Puppet module can be used, the following items must be configured on
 
 To quickly try out Sensu, spin up a test virtual machine with Vagrant that already has these prerequisites installed.
 
-    $ vagrant up
-    $ vagrant status
-    $ vagrant ssh sensu-server
+```bash
+vagrant up
+vagrant status
+vagrant ssh sensu-server
+```
 
 You can then access the API.
 
-    $ curl http://admin:secret@192.168.56.10:4567/info
+```bash
+curl http://admin:secret@192.168.56.10:4567/info
+```
 
 Navigate to `192.168.56.10:3000` to use the uchiwa dashboard
 
-    username => uchiwa
-    password => uchiwa
+```yaml
+username: uchiwa
+password: uchiwa
+```
 
 Navigate to `192.168.56.10:15672` to manage RabbitMQ
 
-    username => sensu
-    password => correct-horse-battery-staple
+```yaml
+username: sensu
+password: correct-horse-battery-staple
+```
 
 See the [tests
 directory](https://github.com/sensu/sensu-puppet/tree/master/tests) and
@@ -99,42 +113,45 @@ for examples on setting up the prerequisites.
 
 ### Sensu server
 
-    node 'sensu-server.foo.com' {
-      class { 'sensu':
-        rabbitmq_password => 'correct-horse-battery-staple',
-        server            => true,
-        api               => true,
-        plugins           => [
-          'puppet:///data/sensu/plugins/ntp.rb',
-          'puppet:///data/sensu/plugins/postfix.rb'
-        ]
-      }
+```puppet
+node 'sensu-server.foo.com' {
+  class { 'sensu':
+    rabbitmq_password => 'correct-horse-battery-staple',
+    server            => true,
+    api               => true,
+    plugins           => [
+      'puppet:///data/sensu/plugins/ntp.rb',
+      'puppet:///data/sensu/plugins/postfix.rb'
+    ]
+  }
 
-      sensu::handler { 'default':
-        command => 'mail -s \'sensu alert\' ops@foo.com',
-      }
+  sensu::handler { 'default':
+    command => 'mail -s \'sensu alert\' ops@foo.com',
+  }
 
-      sensu::check { 'check_ntp':
-        command     => 'PATH=$PATH:/usr/lib/nagios/plugins check_ntp_time -H pool.ntp.org -w 30 -c 60',
-        handlers    => 'default',
-        subscribers => 'sensu-test'
-      }
+  sensu::check { 'check_ntp':
+    command     => 'PATH=$PATH:/usr/lib/nagios/plugins check_ntp_time -H pool.ntp.org -w 30 -c 60',
+    handlers    => 'default',
+    subscribers => 'sensu-test'
+  }
 
-      sensu::check { '...':
-        ...
-      }
-    }
-
+  sensu::check { '...':
+    ...
+  }
+}
+```
 
 ### Sensu client
 
-    node 'sensu-client.foo.com' {
-       class { 'sensu':
-         rabbitmq_password  => 'correct-horse-battery-staple',
-         rabbitmq_host      => 'sensu-server.foo.com',
-         subscriptions      => 'sensu-test',
-       }
-    }
+```puppet
+node 'sensu-client.foo.com' {
+   class { 'sensu':
+     rabbitmq_password  => 'correct-horse-battery-staple',
+     rabbitmq_host      => 'sensu-server.foo.com',
+     subscriptions      => 'sensu-test',
+   }
+}
+```
 
 ## Advanced example using Hiera
 
@@ -144,82 +161,94 @@ and configures Sensu on each individual node via
 
 ### hiera.yaml
 
-    ---
-    :hierarchy:
-      - %{fqdn}
-      - %{datacenter}
-      - common
-    :backends:
-      - yaml
-    :yaml:
-      :datadir: '/etc/puppet/%{environment}/modules/hieradata'
+```yaml
+---
+:hierarchy:
+  - %{fqdn}
+  - %{datacenter}
+  - common
+:backends:
+  - yaml
+:yaml:
+  :datadir: '/etc/puppet/%{environment}/modules/hieradata'
+```
 
 ### common.yaml
 
-    sensu::install_repo: false
-    sensu::purge:
-      config: true
-    sensu::rabbitmq_host: 10.31.0.90
-    sensu::rabbitmq_password: password
-    sensu::rabbitmq_port: 5672
+```yaml
+sensu::install_repo: false
+sensu::purge:
+  config: true
+sensu::rabbitmq_host: 10.31.0.90
+sensu::rabbitmq_password: password
+sensu::rabbitmq_port: 5672
+```
 
 ### sensu-server.foo.com.yaml
 
-    sensu::server: true
+```yaml
+sensu::server: true
+```
 
 nosensu.foo.com.yaml
 
-    sensu::client: false
+```yaml
+sensu::client: false
+```
 
 site.pp
 
-    node default {
-      class { 'sensu': }
-      ...
-    }
+```puppet
+node default {
+  class { 'sensu': }
+  ...
+}
+```
 
 ### sensu-client.foo.com.yaml
 
-    ---
-    sensu::subscriptions:
-        - all
-    sensu::server: false
-    sensu::extensions:
-      'system':
-        source: 'puppet:///modules/supervision/system_profile.rb'
-    sensu::handlers:
-      'graphite':
-        type: 'tcp'
-        socket:
-          host: '127.0.0.1'
-          port: '2003'
-        mutator: "only_check_output"
-      'file':
-        command: '/etc/sensu/handlers/file.rb'
-      'mail':
-        command: 'mail -s 'sensu event' email@address.com'
-    sensu::handler_defaults:
-      type: 'pipe'
-    sensu::checks:
-      'file_test':
-        command: '/usr/local/bin/check_file_test.sh'
-      'chef_client':
-        command: 'check-chef-client.rb'
-    sensu::filters:
-      'recurrences-30':
-        attributes:
-          occurrences: "eval: value == 1 || value % 30 == 0"
-    sensu::filter_defaults:
-      negate: true
-    sensu::check_defaults:
-      handlers: 'mail'
-    sensu::mutators:
-      'tag':
-        command: '/etc/sensu/mutators/tag.rb'
-      'graphite':
-        command: '/etc/sensu/plugins/graphite.rb'
-    classes:
-        - sensu
+```yaml
+---
+sensu::subscriptions:
+    - all
+sensu::server: false
+sensu::extensions:
+  'system':
+    source: 'puppet:///modules/supervision/system_profile.rb'
+sensu::handlers:
+  'graphite':
+    type: 'tcp'
+    socket:
+      host: '127.0.0.1'
+      port: '2003'
+    mutator: "only_check_output"
+  'file':
+    command: '/etc/sensu/handlers/file.rb'
+  'mail':
+    command: 'mail -s 'sensu event' email@address.com'
+sensu::handler_defaults:
+  type: 'pipe'
+sensu::checks:
+  'file_test':
+    command: '/usr/local/bin/check_file_test.sh'
+  'chef_client':
+    command: 'check-chef-client.rb'
+sensu::filters:
+  'recurrences-30':
+    attributes:
+      occurrences: "eval: value == 1 || value % 30 == 0"
+sensu::filter_defaults:
+  negate: true
+sensu::check_defaults:
+  handlers: 'mail'
+sensu::mutators:
+  'tag':
+    command: '/etc/sensu/mutators/tag.rb'
+  'graphite':
+    command: '/etc/sensu/plugins/graphite.rb'
+classes:
+    - sensu
+```
 
 
 ## Safe Mode checks
@@ -239,176 +268,196 @@ A usage example is shown below.
 Each component of Sensu can be controlled separately. The server components
 are managed with the server, and API parameters.
 
-    node 'sensu-server.foo.com' {
-      class { 'sensu':
-        rabbitmq_password => 'correct-horse-battery-staple',
-        server            => true,
-        api               => true,
-        plugins           => [
-          'puppet:///data/sensu/plugins/ntp.rb',
-          'puppet:///data/sensu/plugins/postfix.rb'
-        ],
-        safe_mode         => true,
-      }
+```puppet
+node 'sensu-server.foo.com' {
+  class { 'sensu':
+    rabbitmq_password => 'correct-horse-battery-staple',
+    server            => true,
+    api               => true,
+    plugins           => [
+      'puppet:///data/sensu/plugins/ntp.rb',
+      'puppet:///data/sensu/plugins/postfix.rb'
+    ],
+    safe_mode         => true,
+  }
 
-      ...
+  # ...
 
-      sensu::check { "diskspace":
-        command => '/etc/sensu/plugins/system/check-disk.rb',
-      }
-
-
-    }
+  sensu::check { "diskspace":
+    command => '/etc/sensu/plugins/system/check-disk.rb',
+  }
+}
+```
 
 If you need only one plugin you can also use a simple string:
 
-    node 'sensu-server.foo.com' {
-      class { 'sensu':
-        plugins           => 'puppet:///data/sensu/plugins/ntp.rb'
-        ...
-    }
+```puppet
+node 'sensu-server.foo.com' {
+  class { 'sensu':
+    plugins => 'puppet:///data/sensu/plugins/ntp.rb',
+    # ...
+  }
+}
+```
 
 Specifying the plugins as hash, you can pass all parameters supported by
 the sensu::plugin define:
 
-    node 'sensu-server.foo.com' {
-      class { 'sensu':
-        plugins           => {
-          'puppet:///data/sensu/plugins/ntp.rb' => {
-            'install_path' => '/alternative/path',
-          'puppet:///data/sensu/plugins/postfix.rb'
-            'type'         => 'package',
-            'pkg_version'  => '2.4.2',
-        },
-        ...
-      }
-    }
+```puppet
+node 'sensu-server.foo.com' {
+  class { 'sensu':
+    plugins           => {
+      'puppet:///data/sensu/plugins/ntp.rb' => {
+        'install_path' => '/alternative/path',
+      'puppet:///data/sensu/plugins/postfix.rb'
+        'type'         => 'package',
+        'pkg_version'  => '2.4.2',
+    },
+    ...
+  }
+}
+```
 
 
 ### Sensu client
 
-    node 'sensu-client.foo.com' {
-       class { 'sensu':
-         rabbitmq_password  => 'correct-horse-battery-staple',
-         rabbitmq_host      => 'sensu-server.foo.com',
-         subscriptions      => 'sensu-test',
-         safe_mode          => true,
-       }
+```puppet
+node 'sensu-client.foo.com' {
+  class { 'sensu':
+    rabbitmq_password => 'correct-horse-battery-staple',
+    rabbitmq_host     => 'sensu-server.foo.com',
+    subscriptions     => 'sensu-test',
+    safe_mode         => true,
+  }
 
-      sensu::check { "diskspace":
-        command => '/etc/sensu/plugins/system/check-disk.rb',
-      }
-    }
-
+  sensu::check { 'diskspace':
+    command => '/etc/sensu/plugins/system/check-disk.rb',
+  }
+}
+```
 
 ## Using custom variables in check definitions
 
-    sensu::check{ 'check_file_test':
-      command      => '/usr/local/bin/check_file_test.sh',
-      handlers     => 'notifu',
-      custom       => {
-        'foo'      => 'bar',
-        'numval'   => 6,
-        'boolval'  => true,
-        'in_array' => ['foo','baz']
-      },
-      subscribers  => 'sensu-test'
-    }
+```puppet
+sensu::check{ 'check_file_test':
+  command      => '/usr/local/bin/check_file_test.sh',
+  handlers     => 'notifu',
+  custom       => {
+    'foo'      => 'bar',
+    'numval'   => 6,
+    'boolval'  => true,
+    'in_array' => ['foo','baz']
+  },
+  subscribers  => 'sensu-test'
+}
+```
 
 This will create the following check definition for Sensu:
 
-    {
-      "checks": {
-        "check_file_test": {
-          "handlers": [
-            "notifu"
-          ],
-          "in_array": [
-            "foo",
-            "baz"
-          ],
-          "command": "/usr/local/bin/check_file_test.sh",
-          "subscribers": [
-            "sensu-test"
-          ],
-          "foo": "bar",
-          "interval": 60,
-          "numval": 6,
-          "boolval": true
-        }
-      }
+```json
+{
+  "checks": {
+    "check_file_test": {
+      "handlers": [
+        "notifu"
+      ],
+      "in_array": [
+        "foo",
+        "baz"
+      ],
+      "command": "/usr/local/bin/check_file_test.sh",
+      "subscribers": [
+        "sensu-test"
+      ],
+      "foo": "bar",
+      "interval": 60,
+      "numval": 6,
+      "boolval": true
     }
+  }
+}
+```
 
 ## Writing custom configuration files
 
 You can also use the `sensu::write_json` defined resource type to write custom
 json config files:
 
-    $contact_data = {
-      'support' => {
-        'pagerduty' => {
-          'service_key' => 'r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE',
-        },
-        'slack' => {
-          'channel'  => '#support',
-          'username' => 'sensu',
-        }
-      }
+```puppet
+$contact_data = {
+  'support' => {
+    'pagerduty' => {
+      'service_key' => 'r3FPuDvNOTEDyQYCc7trBkymIFcy2NkE',
+    },
+    'slack' => {
+      'channel'  => '#support',
+      'username' => 'sensu',
     }
+  }
+}
 
-    sensu::write_json { '/etc/sensu/conf.d/contacts.json':
-      content => $contact_data,
-    }
+sensu::write_json { '/etc/sensu/conf.d/contacts.json':
+  content => $contact_data,
+}
+```
 
 ## Handler configuration
 
-    sensu::handler {
-      'handler_foobar':
-        command => '/etc/sensu/handlers/foobar.py',
-        type    => 'pipe',
-        config  => {
-          'foobar_setting' => 'value',
-      }
-    }
+```puppet
+sensu::handler {
+  'handler_foobar':
+    command => '/etc/sensu/handlers/foobar.py',
+    type    => 'pipe',
+    config  => {
+      'foobar_setting' => 'value',
+  }
+}
+```
 
 This will create the following handler definition for Sensu (server):
 
-     {
-       "handler_foobar": {
-         "foobar_setting": "value"
-       },
-       "handlers": {
-          "handler_foobar": {
-            "command": "/etc/sensu/plugins/foobar.py",
-            "severities": [
-              "ok",
-              "warning",
-              "critical",
-              "unknown"
-            ],
-          "type": "pipe"
-          }
-       }
-     }
+```json
+{
+  "handler_foobar": {
+    "foobar_setting": "value"
+  },
+  "handlers": {
+     "handler_foobar": {
+       "command": "/etc/sensu/plugins/foobar.py",
+       "severities": [
+         "ok",
+         "warning",
+         "critical",
+         "unknown"
+       ],
+     "type": "pipe"
+    }
+  }
+}
+```
 
 ## Extension configuration
 
-    sensu::extension {
-      'an_extension':
-        source  => 'puppet://somewhere/an_extension.rb',
-        config  => {
-          'foobar_setting' => 'value',
-      }
-    }
+```puppet
+sensu::extension {
+  'an_extension':
+    source  => 'puppet://somewhere/an_extension.rb',
+    config  => {
+      'foobar_setting' => 'value',
+  }
+}
+```
 
 This will save the extension under /etc/sensu/extensions and create
 the following configuration definition for Sensu:
 
-     {
-       "an_extension": {
-         "foobar_setting": "value"
-       },
-     }
+```json
+{
+  "an_extension": {
+    "foobar_setting": "value"
+  },
+}
+```
 
 ### Disable Service Management
 
@@ -416,7 +465,9 @@ If you'd prefer to use an external service management tool such as
 DaemonTools or SupervisorD, you can disable the module's internal
 service management functions like so:
 
-    sensu::manage_services: false
+```yaml
+sensu::manage_services: false
+```
 
 ## Purging Configuration
 
@@ -428,7 +479,9 @@ If all sensu plugins, extensions, handlers, mutators, and configuration
 should be managed by puppet, set the `purge` parameter to `true` to
 delete files which are not defined using this puppet module:
 
-    sensu::purge: true
+```yaml
+sensu::purge: true
+```
 
 To get more fine-grained control over what is purged, set the `purge`
 parameter to a hash. The possible keys are: `config`, `plugins`,
@@ -436,9 +489,11 @@ parameter to a hash. The possible keys are: `config`, `plugins`,
 cause files of that type which are not defined using this puppet module
 to be deleted. Keys which are not specified will not be purged:
 
-    sensu::purge:
-      config: true
-      plugins: true
+```yaml
+sensu::purge:
+  config: true
+  plugins: true
+```
 
 ## Including Sensu monitoring in other modules
 
@@ -449,46 +504,54 @@ standalone check, for example:
 
 apache/manifests/monitoring/sensu.pp
 
-    class apache::monitoring::sensu {
-      sensu::check { 'apache-running':
-        handlers    => 'default',
-        command     => '/etc/sensu/plugins/check-procs.rb -p /usr/sbin/httpd -w 100 -c 200 -C 1',
-        custom      => {
-          refresh     => 1800,
-          occurrences => 2,
-        },
-      }
-    }
+```puppet
+class apache::monitoring::sensu {
+  sensu::check { 'apache-running':
+    handlers    => 'default',
+    command     => '/etc/sensu/plugins/check-procs.rb -p /usr/sbin/httpd -w 100 -c 200 -C 1',
+    custom      => {
+      refresh     => 1800,
+      occurrences => 2,
+    },
+  }
+}
+```
 
 You could also include subscription information and let the Sensu server
 schedule checks for this service as a subscriber:
 
 apache/manifests/monitoring/sensu.pp
 
-    class apache::monitoring::sensu {
-      sensu::subscription { 'apache': }
-    }
+```puppet
+class apache::monitoring::sensu {
+  sensu::subscription { 'apache': }
+}
+```
 
 You can also define custom variables as part of the subscription:
 
 ntp/manifests/monitoring/ntp.pp
 
-    class ntp::monitoring::sensu {
-      sensu::subscription { 'ntp':
-        custom => {
-          ntp {
-            server => $ntp::servers[0],
-          },
-        },
-      }
-    }
+```puppet
+class ntp::monitoring::sensu {
+  sensu::subscription { 'ntp':
+    custom => {
+      ntp {
+        server => $ntp::servers[0],
+      },
+    },
+  }
+}
+```
 
 And then use that variable on your Sensu server:
 
-    sensu::check { 'check_ntp':
-      command     => 'PATH=$PATH:/usr/lib/nagios/plugins check_ntp_time -H :::ntp.server::: -w 30 -c 60',
-      ...
-    }
+```puppet
+sensu::check { 'check_ntp':
+  command => 'PATH=$PATH:/usr/lib/nagios/plugins check_ntp_time -H :::ntp.server::: -w 30 -c 60',
+  # ...
+}
+```
 
 If you would like to automatically include the Sensu monitoring class as
 part of your existing module with the ability to support different
@@ -496,43 +559,47 @@ monitoring platforms, you could do something like:
 
 apache/manifests/service.pp
 
-    $monitoring = hiera('monitoring', '')
+```puppet
+$monitoring = hiera('monitoring', '')
 
-    case $monitoring {
-      'sensu':  { include apache::monitoring::sensu }
-      'nagios': { include apache::monitoring::nagios }
-    }
+case $monitoring {
+  'sensu':  { include apache::monitoring::sensu }
+  'nagios': { include apache::monitoring::nagios }
+}
+```
 
 ## Installing Gems into the embedded ruby
 
 If you are using the embedded ruby that ships with Sensu, you can install gems
 by using the `sensu_gem` package provider:
 
-    package { 'redphone':
-      ensure   => 'installed',
-      provider => sensu_gem,
-    }
+```puppet
+package { 'redphone':
+  ensure   => 'installed',
+  provider => sensu_gem,
+}
+```
 
 ## Sensitive String Redaction
 
 Redaction of passwords is supported by this module. To enable it, pass a value to `sensu::redact`
 and set some password values with `sensu::client_custom`
 
-```
-  class { 'sensu':
-    redact  => 'password',
-    client_custom => {
-      github => {
-        password => 'correct-horse-battery-staple',
-      },
+```puppet
+class { 'sensu':
+  redact  => 'password',
+  client_custom => {
+    github => {
+      password => 'correct-horse-battery-staple',
     },
-  }
+  },
+}
 ```
 
 Or with hiera:
 
-```
-sensu::redact
+```yaml
+sensu::redact:
   - :password"
 sensu::client_custom:
   - sensu::client_custom:
@@ -546,15 +613,71 @@ This ends up like this in the uchiwa console:
 
 You can make use of the password now when defining a check by using command substitution:
 
-```
-sensu::check{ 'check_password_test':
-  command      => '/usr/local/bin/check_password_test --password :::github.password::: ',
+```puppet
+sensu::check { 'check_password_test':
+  command => '/usr/local/bin/check_password_test --password :::github.password::: ',
 }
 ```
 
 
-
 ## Dashboards
+
+### Sensu Enterprise Dashboard
+
+The [Sensu Enterprise
+Dashboard](https://sensuapp.org/docs/latest/platforms/sensu-on-rhel-centos.html#install-sensu-enterprise-repository)
+is fully managed by this module.  Credentials for the repository are required to
+automatically install packages and configure the enterprise dashboard.  For
+example:
+
+```puppet
+class { '::sensu':
+  enterprise_dashboard => true,
+  enterprise_user      => '1234567890',
+  enterprise_pass      => 'PASSWORD',
+}
+```
+
+The `enterprise_user` and `enterprise_pass` class parameters map to the
+`SE_USER` and `SE_PASS` as described at [Install the Sensu Enterprise repository
+](https://sensuapp.org/docs/latest/platforms/sensu-on-rhel-centos.html#install-sensu-enterprise-repository)
+
+### Enterprise Dashboard API
+
+The API to the enterprise dashboard is managed using the
+`sensu::enterprise::dashboard::api` defined type.  This defined type is a
+wrapper around the `sensu_enterprise_dashboard_api_config` custom type and
+provider included in this module.
+
+These Puppet resource types manage the Dashboard API entries in
+`/etc/sensu/dashboard.json`.
+
+Multiple API endpoints may be defined in the same datacenter.  This example will
+create two endpoints at sensu.example.net and sensu.example.org.
+
+```puppet
+sensu::enterprise::dashboard::api { 'sensu.example.net':
+  datacenter => 'example-dc',
+}
+
+sensu::enterprise::dashboard::api { 'sensu.example.org':
+  datacenter => 'example-dc',
+}
+```
+
+Unmanaged API endpoints may be purged using the resources resource.  For
+example:
+
+```puppet
+resources { 'sensu_enterprise_dashboard_api_config':
+  purge => true,
+}
+```
+
+This will ensure `/etc/sensu/dashboard.json` contains only
+`sensu::enterprise::dashboard::api` resources managed by Puppet.
+
+### Community
 
 The following puppet modules exist for managing dashboards
 

--- a/lib/puppet/type/sensu_enterprise_dashboard_api_config.rb
+++ b/lib/puppet/type/sensu_enterprise_dashboard_api_config.rb
@@ -6,10 +6,13 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_api_config) do
 
   def initialize(*args)
     super *args
-
-    self[:notify] = [
-      "Service[sensu-enterprise-dashboard]",
-    ].select { |ref| catalog.resource(ref) }
+    # N.B. catalog will return `nil` when running in the context of `puppet
+    # resource`.  We must take care not to call methods on a nil object.
+    if c = catalog
+      # Notify the service if it exists in the catalog.
+      id = 'Service[sensu-enterprise-dashboard]'
+      self[:notify] = [c.resource(id)].compact
+    end
   end
 
   ensurable do

--- a/spec/unit/sensu_enterprise_dashboard_api_config_spec.rb
+++ b/spec/unit/sensu_enterprise_dashboard_api_config_spec.rb
@@ -80,4 +80,16 @@ describe Puppet::Type.type(:sensu_enterprise_dashboard_api_config) do
       ).to be(:true)
     end
   end
+
+  describe '.instances' do
+    subject do
+      described_class.instances
+    end
+    it 'returns an array of provider instances' do
+      expect(subject).to be_a_kind_of(Array)
+      subject.each do |v|
+        expect(v).to be_a_kind_of(Puppet::Provider)
+      end
+    end
+  end
 end

--- a/tests/sensu-enterprise-dashboard-multi-api.pp
+++ b/tests/sensu-enterprise-dashboard-multi-api.pp
@@ -25,16 +25,30 @@ node 'sensu-server' {
   }
 
   class { '::sensu':
+    install_repo         => true,
+    server               => true,
+    manage_services      => true,
+    manage_user          => true,
+    rabbitmq_password    => 'correct-horse-battery-staple',
+    rabbitmq_vhost       => '/sensu',
+    api                  => true,
+    api_user             => 'admin',
+    api_password         => 'secret',
+    client_address       => $::ipaddress_eth1,
     enterprise_dashboard => true,
     enterprise_user      => $facts['se_user'],
     enterprise_pass      => $facts['se_pass'],
   }
 
-  sensu::enterprise::dashboard::api { 'sensu.example.com':
+  resources { 'sensu_enterprise_dashboard_api_config':
+    purge => true,
+  }
+
+  sensu::enterprise::dashboard::api { 'sensu.example.net':
     datacenter => 'example-dc',
   }
 
-  sensu::enterprise::dashboard::api { 'sensu.example.org':
+  sensu::enterprise::dashboard::api { 'sensu.example.io':
     datacenter => 'example-dc',
   }
 }


### PR DESCRIPTION
Without this patch the `resources` resource cannot be used to purge unmanaged
API endpoints as requested in #649.  This patch implements the instances class
method providing this functionality.

resolves #649