### PR TITLE
(#495) Notify Service[sensu-enterprise] from Sensu::Check resources

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -137,7 +137,13 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     server.vm.network :forwarded_port, guest: 3000, host: 3000, auto_correct: true
     server.vm.network :forwarded_port, guest: 15672, host: 15672, auto_correct: true
     server.vm.provision :shell, :path => "tests/provision_basic_el.sh"
-    server.vm.provision :shell, :path => "tests/provision_enterprise_server.sh"
+    server.vm.provision :shell,
+      :path => "tests/provision_enterprise_server.sh",
+      :env => {
+        'FACTER_SE_USER' => ENV['FACTER_SE_USER'].to_s,
+        'FACTER_SE_PASS' => ENV['FACTER_SE_PASS'].to_s,
+      }
+
     server.vm.provision :shell, :path => "tests/rabbitmq.sh"
   end
 

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -21,11 +21,13 @@ Puppet::Type.newtype(:sensu_check) do
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-client]",
-      "Service[sensu-server]",
-      "Service[sensu-enterprise]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        "Service[sensu-client]",
+        "Service[sensu-server]",
+        "Service[sensu-enterprise]",
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   ensurable do

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:sensu_check) do
     self[:notify] = [
       "Service[sensu-client]",
       "Service[sensu-server]",
+      "Service[sensu-enterprise]",
     ].select { |ref| catalog.resource(ref) }
   end
 

--- a/lib/puppet/type/sensu_check_config.rb
+++ b/lib/puppet/type/sensu_check_config.rb
@@ -4,10 +4,13 @@ Puppet::Type.newtype(:sensu_check_config) do
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-client]",
-      "Service[sensu-server]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-client]',
+        'Service[sensu-server]',
+        'Service[sensu-enterprise]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   ensurable do

--- a/lib/puppet/type/sensu_extension.rb
+++ b/lib/puppet/type/sensu_extension.rb
@@ -4,10 +4,13 @@ Puppet::Type.newtype(:sensu_extension) do
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-api]",
-      "Service[sensu-server]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-api]',
+        'Service[sensu-server]',
+        'Service[sensu-enterprise]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   ensurable do

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -1,12 +1,18 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
+                                   'puppet_x', 'sensu', 'boolean_property.rb'))
+
 Puppet::Type.newtype(:sensu_handler) do
   @doc = ""
 
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-server]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-server]',
+        'Service[sensu-enterprise]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   ensurable do

--- a/lib/puppet/type/sensu_mutator.rb
+++ b/lib/puppet/type/sensu_mutator.rb
@@ -4,9 +4,12 @@ Puppet::Type.newtype(:sensu_mutator) do
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-server]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-server]',
+        'Service[sensu-enterprise]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   ensurable do

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -8,12 +8,14 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
   def initialize(*args)
     super(*args)
 
-    self[:notify] = [
-      'Service[sensu-server]',
-      'Service[sensu-client]',
-      'Service[sensu-api]',
-      'Service[sensu-enterprise]'
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-server]',
+        'Service[sensu-client]',
+        'Service[sensu-api]',
+        'Service[sensu-enterprise]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   def has_cluster?

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -8,10 +8,13 @@ Puppet::Type.newtype(:sensu_redis_config) do
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-api]",
-      "Service[sensu-server]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-api]',
+        'Service[sensu-server]',
+        'Service[sensu-enterprise]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   def has_sentinels?

--- a/spec/unit/sensu_check_config_spec.rb
+++ b/spec/unit/sensu_check_config_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_check_config) do
+  let(:resource_hash) do
+    {
+      :title => 'foo.example.com',
+      :catalog => Puppet::Resource::Catalog.new
+    }
+  end
+
+  describe 'notifications' do
+    context 'when managing sensu-enterprise (#495)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      let(:resource_hash) do
+        c = Puppet::Resource::Catalog.new
+        c.add_resource(service_resource)
+        {
+          :title => 'foo.example.com',
+          :catalog => c
+        }
+      end
+
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
+end

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -55,4 +55,26 @@ describe Puppet::Type.type(:sensu_check) do
     #   ).to eq nil
     # end
   end
+
+  describe 'notifications' do
+    context 'when managing sensu-enterprise (#495)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      let(:resource_hash) do
+        c = Puppet::Resource::Catalog.new
+        c.add_resource(service_resource)
+        {
+          :title => 'foo.example.com',
+          :catalog => c
+        }
+      end
+
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
 end

--- a/spec/unit/sensu_extension_spec.rb
+++ b/spec/unit/sensu_extension_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_extension) do
+  let(:resource_hash) do
+    {
+      :title => 'Emanon',
+      :catalog => Puppet::Resource::Catalog.new
+    }
+  end
+
+  describe 'notifications' do
+    context 'when managing sensu-enterprise (#495)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      let(:resource_hash) do
+        c = Puppet::Resource::Catalog.new
+        c.add_resource(service_resource)
+        {
+          :title => 'Emanon',
+          :catalog => c
+        }
+      end
+
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
+end

--- a/spec/unit/sensu_handler_spec.rb
+++ b/spec/unit/sensu_handler_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_handler) do
+  let(:resource_hash) do
+    {
+      :title => 'myhandler',
+      :catalog => Puppet::Resource::Catalog.new
+    }
+  end
+
+  describe 'notifications' do
+    context 'when managing sensu-enterprise (#495)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      let(:resource_hash) do
+        c = Puppet::Resource::Catalog.new
+        c.add_resource(service_resource)
+        {
+          :title => 'myhandler',
+          :catalog => c
+        }
+      end
+
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
+end

--- a/spec/unit/sensu_mutator_spec.rb
+++ b/spec/unit/sensu_mutator_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_mutator) do
+  let(:resource_hash) do
+    {
+      :title => 'mymutator',
+      :catalog => Puppet::Resource::Catalog.new
+    }
+  end
+
+  describe 'notifications' do
+    context 'when managing sensu-enterprise (#495)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      let(:resource_hash) do
+        c = Puppet::Resource::Catalog.new
+        c.add_resource(service_resource)
+        {
+          :title => 'mymutator',
+          :catalog => c
+        }
+      end
+
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
+end

--- a/spec/unit/sensu_rabbitmq_config_spec.rb
+++ b/spec/unit/sensu_rabbitmq_config_spec.rb
@@ -98,4 +98,26 @@ describe Puppet::Type.type(:sensu_rabbitmq_config) do
       end
     end
   end
+
+  describe 'notifications' do
+    context 'when managing sensu-enterprise (#495)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      let(:resource_hash) do
+        c = Puppet::Resource::Catalog.new
+        c.add_resource(service_resource)
+        {
+          :title => 'foo.example.com',
+          :catalog => c
+        }
+      end
+
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
 end

--- a/spec/unit/sensu_redis_config_spec.rb
+++ b/spec/unit/sensu_redis_config_spec.rb
@@ -180,4 +180,25 @@ describe Puppet::Type.type(:sensu_redis_config) do
     end
   end
 
+  describe 'notifications' do
+    context 'when managing sensu-enterprise (#495)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      let(:resource_hash) do
+        c = Puppet::Resource::Catalog.new
+        c.add_resource(service_resource)
+        {
+          :title => 'foo.example.com',
+          :catalog => c
+        }
+      end
+
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
 end

--- a/tests/provision_enterprise_server.sh
+++ b/tests/provision_enterprise_server.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+if [ -z "${FACTER_SE_USER:-}" ]; then
+  echo "ERROR: You must export FACTER_SE_USER and FACTER_SE_PASS" >&2
+  echo "ERROR: In the shell that executes vagrant up" >&2
+  exit 1
+fi
+echo "FACTER_SE_USER=$FACTER_SE_USER"
+
 # setup module dependencies
 puppet module install puppetlabs/rabbitmq
 

--- a/tests/sensu-server-enterprise.pp
+++ b/tests/sensu-server-enterprise.pp
@@ -9,18 +9,19 @@ node 'sensu-server' {
     mode   => '0600',
   }
 
+  # NOTE: When testing sensu enterprise, provide the SE_USER and SE_PASS to use
+  # with the online repository using the FACTER_SE_USER and FACTER_SE_PASS
+  # environment variables.  An effective way to manage this is with `direnv`
   class { '::sensu':
     install_repo              => true,
-    server                    => true,
+    enterprise                => true,
+    enterprise_user           => $facts['se_user'],
+    enterprise_pass           => $facts['se_pass'],
     manage_services           => true,
     manage_user               => true,
     rabbitmq_password         => 'correct-horse-battery-staple',
     rabbitmq_vhost            => '/sensu',
-    api                       => true,
-    api_user                  => 'admin',
-    api_password              => 'secret',
     client_address            => $::ipaddress_eth1,
-    # enterprise options
     api_ssl_port              => '4568',
     api_ssl_keystore_file     => '/etc/sensu/api.keystore',
     api_ssl_keystore_password => 'sensutest',


### PR DESCRIPTION
Without this patch The sensu-enterprise service is not notified
automatically when `sensu::check` resources are declared.  This patch
addresses the problem by checking the catalog for the service and
automatically adding the notify relationship.

resolves #502 
resolves #495
closes #653