### PR TITLE
(#658) Manage the when attribute of sensu filters

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,11 @@ sensu::filters:
       occurrences: "eval: value == 1 || value % 30 == 0"
 sensu::filter_defaults:
   negate: true
+  when:
+    days:
+      all:
+        - begin: 5:00 PM
+          end: 8:00 AM
 sensu::check_defaults:
   handlers: 'mail'
 sensu::mutators:

--- a/lib/puppet/provider/sensu_filter/json.rb
+++ b/lib/puppet/provider/sensu_filter/json.rb
@@ -58,4 +58,12 @@ Puppet::Type.type(:sensu_filter).provide(:json) do
     conf['filters'][resource[:name]]['attributes'].merge!(to_type(value))
   end
 
+  def when
+    conf['filters'][resource[:name]]['when']
+  end
+
+  def when=(value)
+    conf['filters'][resource[:name]]['when'] ||= {}
+    conf['filters'][resource[:name]]['when'].merge!(to_type(value))
+  end
 end

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -54,6 +54,33 @@ Puppet::Type.newtype(:sensu_filter) do
     defaultto {}
   end
 
+  newproperty(:when) do
+    desc 'Used to determine when a filter is applied.'
+    include PuppetX::Sensu::ToType
+
+    def is_to_s(hash = @is)
+      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
+    end
+
+    def should_to_s(hash = @should)
+      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
+  end
+
   newproperty(:negate, :parent => PuppetX::Sensu::BooleanProperty) do
     desc ""
 

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -22,6 +22,7 @@ define sensu::filter (
   $ensure     = 'present',
   $negate     = undef,
   $attributes = undef,
+  $when       = undef,
 ) {
 
   validate_re($ensure, ['^present$', '^absent$'] )
@@ -31,6 +32,10 @@ define sensu::filter (
 
   if $attributes and !is_hash($attributes) {
     fail('attributes must be a hash')
+  }
+
+  if $when and !is_hash($when) {
+    fail('when must be a hash')
   }
 
   file { "/etc/sensu/conf.d/filters/${name}.json":
@@ -44,6 +49,7 @@ define sensu::filter (
     ensure     => $ensure,
     negate     => $negate,
     attributes => $attributes,
+    when       => $when,
     require    => File['/etc/sensu/conf.d/filters'],
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -136,7 +136,7 @@
 #   Boolean.  Use SSL transport to connect to RabbitMQ.  If rabbitmq_ssl_private_key and/or
 #     rabbitmq_ssl_cert_chain are set, then this is enabled automatically.  Set rabbitmq_ssl => true
 #     without specifying a private key or cert chain to use SSL transport, but not cert auth.
-#   Defaul: false
+#   Default: false
 #   Valid values: true, false
 #
 # [*rabbitmq_ssl_private_key*]
@@ -184,7 +184,7 @@
 #   Default: undef
 #
 # [*redis_reconnect_on_error*]
-#   Boolean. In the event the connection or channel is closed by Reddis, attempt to automatically
+#   Boolean. In the event the connection or channel is closed by redis, attempt to automatically
 #     reconnect when possible.
 #   Default: true
 #   Valid values: true, false
@@ -245,7 +245,7 @@
 #   Default: undef
 #
 # [*subscriptions*]
-#   Array of strings.  Default suscriptions used by the client
+#   Array of strings.  Default subscriptions used by the client
 #   Default: []
 #
 # [*client_address*]
@@ -341,7 +341,7 @@
 #   Default: true
 #
 # [*path*]
-#   String. used to set PATH in /etc/default/sensu
+#   String. Used to set PATH in /etc/default/sensu
 #
 # [*redact*]
 #   Array of strings. Use to redact passwords from checks on the client side
@@ -356,37 +356,37 @@
 #   Default: undef
 #
 # [*handlers*]
-#   Hash of handlers for use with create_sources(sensu::handler).
+#   Hash of handlers for use with create_resources(sensu::handler).
 #   Example value: { 'email' => { 'type' => 'pipe', 'command' => 'mail' } }
 #   Default: {}
 #
 # [*handler_defaults*]
-#   Handler defaults when not provided explicitely in $handlers.
+#   Handler defaults when not provided explicitly in $handlers.
 #   Example value: { 'filters' => ['production'] }
 #   Default: {}
 #
 # [*checks*]
-#   Hash of checks for use with create_sources(sensu::check).
+#   Hash of checks for use with create_resources(sensu::check).
 #   Example value: { 'check-cpu' => { 'command' => 'check-cpu.rb' } }
 #   Default: {}
 #
 # [*check_defaults*]
-#   Check defaults when not provided explicitely in $checks.
-#   Example value: { 'occurences' => 3 }
+#   Check defaults when not provided explicitly in $checks.
+#   Example value: { 'occurrences' => 3 }
 #   Default: {}
 #
 # [*filters*]
-#   Hash of filters for use with create_sources(sensu::filter).
+#   Hash of filters for use with create_resources(sensu::filter).
 #   Example value: { 'occurrence' => { 'attributes' => { 'occurrences' => '1' } } }
 #   Default: {}
 #
 # [*filter_defaults*]
-#   Filter defaults when not provided explicitely in $filters.
+#   Filter defaults when not provided explicitly in $filters.
 #   Example value: { 'negate' => true }
 #   Default: {}
 #
 # [*package_checksum*]
-#   String. used to set package_checksum for windows installs
+#   String. Used to set package_checksum for windows installs
 #   Default: undef
 #
 # [*windows_pkg_url*]
@@ -541,11 +541,11 @@ class sensu (
   if $purge_plugins_dir { fail('purge_plugins_dir is deprecated, set the purge parameter to a hash containing `plugins => true` instead') }
   if !is_integer($redis_db) { fail('redis_db must be an integer') }
 
-  # sensu-enterprise supercedes sensu-server and sensu-api
+  # sensu-enterprise supersedes sensu-server and sensu-api
   if ( $enterprise and $api ) or ( $enterprise and $server ) {
     fail('Sensu Enterprise: sensu-enterprise replaces sensu-server and sensu-api')
   }
-  # validate enterprise repo creds
+  # validate enterprise repo credentials
   if $manage_repo {
     if ( $enterprise or $enterprise_dashboard ) and $install_repo {
       validate_string($enterprise_user, $enterprise_pass)

--- a/spec/defines/sensu_filter_spec.rb
+++ b/spec/defines/sensu_filter_spec.rb
@@ -22,6 +22,17 @@ describe 'sensu::filter', :type => :define do
     it { should contain_sensu_filter('myfilter').with(:attributes => { 'a' => 'b', 'c' => 'd' } ) }
   end
 
+  describe 'when' do
+    let(:when_spec) do
+      { 'days' => { 'all' => [ { 'begin' => '5:00 PM', 'end' => '8:00 AM' } ] } }
+    end
+    let(:params) do
+      { :when => when_spec }
+    end
+    it { should contain_file('/etc/sensu/conf.d/filters/myfilter.json').with(:ensure => 'present') }
+    it { should contain_sensu_filter('myfilter').with(:when => when_spec) }
+  end
+
   context 'absent' do
     let(:params) { {
       :ensure => 'absent'

--- a/tests/sensu-client.pp
+++ b/tests/sensu-client.pp
@@ -1,16 +1,54 @@
-# Use the internal 192.168.56.* address
-if $facts['networking']['interfaces']['eth1'] != undef {
-  $ip = $facts['networking']['interfaces']['eth1']['ip']
-} elsif $facts['networking']['interfaces']['enp0s8'] != undef {
-  $ip = $facts['networking']['interfaces']['enp0s8']['ip']
-} else {
-  $ip = $facts['networking']['ip']
-}
+node default {
 
-class { '::sensu':
-  rabbitmq_password => 'correct-horse-battery-staple',
-  rabbitmq_host     => '192.168.56.10',
-  rabbitmq_vhost    => '/sensu',
-  subscriptions     => 'all',
-  client_address    => $ip,
+  $filters = {
+    'offhours'          => {
+      'attributes'      => {
+        'client'        => {
+          'environment' => 'production',
+        },
+      },
+      'when'    => {
+        'days'  => {
+          'all' => [
+            {
+              'begin' => '2:00 AM',
+              'end'   => '1:00 AM',
+            },
+          ],
+        },
+      },
+    },
+  }
+
+  $filter_defaults = {
+    'when'    => {
+      'days'  => {
+        'all' => [
+          {
+            'begin' => '2:00 AM',
+            'end'   => '1:00 AM',
+          },
+        ],
+      },
+    },
+  }
+
+  # Use the internal 192.168.56.* address
+  if $facts['networking']['interfaces']['eth1'] != undef {
+    $ip = $facts['networking']['interfaces']['eth1']['ip']
+  } elsif $facts['networking']['interfaces']['enp0s8'] != undef {
+    $ip = $facts['networking']['interfaces']['enp0s8']['ip']
+  } else {
+    $ip = $facts['networking']['ip']
+  }
+
+  class { '::sensu':
+    rabbitmq_password => 'correct-horse-battery-staple',
+    rabbitmq_host     => '192.168.56.10',
+    rabbitmq_vhost    => '/sensu',
+    subscriptions     => 'all',
+    client_address    => $ip,
+    filters           => $filters,
+    filter_defaults   => $filter_defaults,
+  }
 }


### PR DESCRIPTION
Without this patch sensu filters are unable to manage the [when
attribute](https://sensuapp.org/docs/0.26/reference/filters.html#when-attributes)

This patch implements the `when` property on the sensu_filter type and json
provider.  The `sensu::filter` defined type is also updated to support the
`when` parameter.

The behavior may be exercised with `vagrant up el7-client`.  This will produce
`/etc/sensu/conf.d/filters/offhours.json` with the content of:

    {
     "filters": {
       "offhours": {
         "attributes": {
           "client": {
             "environment": "production"
           }
         },
         "when": {
           "days": {
             "all": [
               {
                 "begin": "2:00 AM",
                 "end": "1:00 AM"
               }
             ]
           }
         },
         "negate": false
       }
     }
    }

Resolves #658 