### PR TITLE
(#717) Remove rabbitmq_reconnect_on_error

### DIFF
--- a/lib/puppet/provider/sensu_rabbitmq_config/json.rb
+++ b/lib/puppet/provider/sensu_rabbitmq_config/json.rb
@@ -157,15 +157,6 @@ Puppet::Type.type(:sensu_rabbitmq_config).provide(:json) do
     conf['rabbitmq']['heartbeat'] = value.to_i unless value == :absent
   end
 
-  def reconnect_on_error
-    return :absent if conf['rabbitmq'].is_a?(Array)
-    conf['rabbitmq']['reconnect_on_error'] || :absent
-  end
-
-  def reconnect_on_error=(value)
-    conf['rabbitmq']['reconnect_on_error'] = value unless value == :absent
-  end
-
   def prefetch
     conf['rabbitmq']['prefetch'] ? conf['rabbitmq']['prefetch'].to_s : :absent
   end

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -111,16 +111,6 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
     end
   end
 
-  newproperty(:reconnect_on_error) do
-    desc 'Attempt to reconnect to RabbitMQ on error'
-    defaultto { :false unless @resource.has_cluster? }
-
-    def insync?(is)
-      return should == is if should.is_a?(Symbol)
-      super(is)
-    end
-  end
-
   newproperty(:prefetch) do
     desc 'The RabbitMQ AMQP consumer prefetch value'
     defaultto { 1 unless @resource.has_cluster? }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -205,10 +205,15 @@
 #   Boolean.  Reconnect to Redis in the event of a connection failure
 #   Default: true
 #
-# [*transport_types*]
+# [*transport_type*]
 #   String. Transport type to be used by Sensu
 #   Default: rabbitmq
 #   Valid values: rabbitmq, redis
+#
+# [*transport_reconnect_on_error*]
+#   Boolean. If the transport connection is closed, attempt to reconnect automatically when possible.
+#   Default: true
+#   Valid values: true, false
 #
 # [*api_bind*]
 #   String.  IP to bind api service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -184,8 +184,8 @@
 #   Default: undef
 #
 # [*redis_reconnect_on_error*]
-#   Boolean. In the event the connection or channel is closed by redis, attempt to automatically
-#     reconnect when possible.
+#   Boolean. Reconnect to Redis in the event of a Redis error, e.g. READONLY
+#     (not to be confused with a connection failure).
 #   Default: true
 #   Valid values: true, false
 #

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -153,12 +153,6 @@
 #     as a file reference, as you'd normally configure sensu.
 #   Default: undef
 #
-# [*rabbitmq_reconnect_on_error*]
-#   Boolean. In the event the connection or channel is closed by RabbitMQ, attempt to automatically
-#     reconnect when possible. Default set to fault its not guaranteed to successfully reconnect.
-#   Default: false
-#   Valid values: true, false
-#
 # [*rabbitmq_prefetch*]
 #   Integer.  The integer value for the RabbitMQ prefetch attribute
 #   Default: 1
@@ -466,7 +460,6 @@ class sensu (
   $rabbitmq_ssl                   = undef,
   $rabbitmq_ssl_private_key       = undef,
   $rabbitmq_ssl_cert_chain        = undef,
-  $rabbitmq_reconnect_on_error    = false,
   $rabbitmq_prefetch              = undef,
   $rabbitmq_cluster               = undef,
   $rabbitmq_heartbeat             = undef,
@@ -551,7 +544,7 @@ class sensu (
 ){
 
   validate_absolute_path($log_dir)
-  validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir, $deregister_on_stop)
+  validate_bool($client, $server, $api, $manage_repo, $install_repo, $enterprise, $enterprise_dashboard, $purge_config, $safe_mode, $manage_services, $redis_reconnect_on_error, $hasrestart, $redis_auto_reconnect, $manage_mutators_dir, $deregister_on_stop)
 
   validate_re($repo, ['^main$', '^unstable$'], "Repo must be 'main' or 'unstable'.  Found: ${repo}")
   validate_re($version, ['^absent$', '^installed$', '^latest$', '^present$', '^[\d\.\-el]+$'], "Invalid package version: ${version}")

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -117,26 +117,24 @@ class sensu::rabbitmq::config {
   $ssl_transport = $has_cluster ? { false => $enable_ssl, true => undef, }
   $cert_chain = $has_cluster ? { false => $ssl_cert_chain, true => undef, }
   $private_key = $has_cluster ? { false => $ssl_private_key, true => undef, }
-  $reconnect_on_error = $has_cluster ? { false => $::sensu::rabbitmq_reconnect_on_error, true => undef, }
   $prefetch = $has_cluster ? { false => $::sensu::rabbitmq_prefetch, true => undef, }
   $base_path = $has_cluster ? { false => $::sensu::conf_dir, true => undef, }
   $cluster = $has_cluster ? { true => $::sensu::rabbitmq_cluster, false => undef, }
   $heartbeat = $has_cluster ? { false => $::sensu::rabbitmq_heartbeat, true => undef, }
 
   sensu_rabbitmq_config { $::fqdn:
-    ensure             => $ensure,
-    base_path          => $::sensu::conf_dir,
-    port               => $::sensu::rabbitmq_port,
-    host               => $::sensu::rabbitmq_host,
-    user               => $::sensu::rabbitmq_user,
-    password           => $::sensu::rabbitmq_password,
-    vhost              => $::sensu::rabbitmq_vhost,
-    heartbeat          => $::sensu::rabbitmq_heartbeat,
-    ssl_transport      => $enable_ssl,
-    ssl_cert_chain     => $ssl_cert_chain,
-    ssl_private_key    => $ssl_private_key,
-    reconnect_on_error => $::sensu::rabbitmq_reconnect_on_error,
-    prefetch           => $::sensu::rabbitmq_prefetch,
-    cluster            => $cluster,
+    ensure          => $ensure,
+    base_path       => $::sensu::conf_dir,
+    port            => $::sensu::rabbitmq_port,
+    host            => $::sensu::rabbitmq_host,
+    user            => $::sensu::rabbitmq_user,
+    password        => $::sensu::rabbitmq_password,
+    vhost           => $::sensu::rabbitmq_vhost,
+    heartbeat       => $::sensu::rabbitmq_heartbeat,
+    ssl_transport   => $enable_ssl,
+    ssl_cert_chain  => $ssl_cert_chain,
+    ssl_private_key => $ssl_private_key,
+    prefetch        => $::sensu::rabbitmq_prefetch,
+    cluster         => $cluster,
   }
 }

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -17,7 +17,7 @@ class sensu::transport {
   $transport_type_hash = {
     'transport' => {
       'name'               => $::sensu::transport_type,
-      'reconnect_on_error' => true,
+      'reconnect_on_error' => $::sensu::transport_reconnect_on_error,
     },
   }
 

--- a/spec/classes/sensu_transport_spec.rb
+++ b/spec/classes/sensu_transport_spec.rb
@@ -10,10 +10,24 @@ describe 'sensu' do
   context 'transports' do
     context 'defaults' do
       it { should create_class('sensu::transport') }
+      it 'uses rabbitmq with reconnect on error' do
+        should contain_file('/etc/sensu/conf.d/transport.json').with_content(
+          JSON.pretty_generate({'transport' => {'name' => 'rabbitmq', 'reconnect_on_error' => true}})
+        )
+      end
+    end
+
+    describe 'when transport_reconnect_on_error is false' do
+      let(:params) do
+        {transport_reconnect_on_error: false}
+      end
+
+      it { should create_class('sensu::transport') }
       it { should contain_file('/etc/sensu/conf.d/transport.json').with_content(
-        JSON.pretty_generate({'transport' => {'name' => 'rabbitmq', 'reconnect_on_error' => true}})
+        JSON.pretty_generate({'transport' => {'name' => 'rabbitmq', 'reconnect_on_error' => false}})
       )}
     end
+
     context 'setting redis as transport' do
       let(:params) {{
         :transport_type => 'redis'


### PR DESCRIPTION
As noted in #717, the configuration setting for reconnecting on error lives in
the transport configuration, not the rabbitmq configuration.  This patch
removes the property and class parameter configuring the rabbitmq specific
behavior.

Resolves #717
Closes #595