### PR TITLE
(#589) Add Chocolatey support for Windows

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -83,7 +83,33 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     client.vm.provision :shell, :path => "tests/provision_basic_win.ps1"
     ## Symlink module into place, run puppet module install for puppet apply
     client.vm.provision :shell, :path => "tests/provision_basic_win.2.ps1"
+    ## Install Sensu using the default Windows package provider (MSI)
     client.vm.provision :shell, :inline => 'iex "puppet apply -v C:/vagrant/tests/sensu-client-windows.pp"'
+  end
+
+  config.vm.define "win2012r2-client-chocolatey", autostart: false do |client|
+    client.vm.box = "opentable/win-2012r2-standard-amd64-nocm"
+    client.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--memory", "2048"]
+      vb.customize ["modifyvm", :id, "--cpus", "1"]
+    end
+    client.vm.hostname = 'win2012r2-client'
+    client.vm.network  :private_network, ip: "192.168.56.16"
+    client.vm.network "forwarded_port", host: 3389, guest: 3389, auto_correct: true
+    # There are two basic power shell scripts.  The first installs Puppet, but
+    # puppet is not in the PATH.  The second invokes a new shell which will have
+    # Puppet in the PATH.
+    #
+    ## Install Puppet
+    client.vm.provision :shell, :path => "tests/provision_basic_win.ps1"
+    ## Symlink module into place, run puppet module install for puppet apply
+    client.vm.provision :shell, :path => "tests/provision_basic_win.2.ps1"
+    ## Install Chocolatey
+    client.vm.provision :shell, :inline => 'iex ((New-Object System.Net.WebClient).DownloadString("https://chocolatey.org/install.ps1"))'
+    ## Install the chocolatey Puppet module to get the provider
+    client.vm.provision :shell, :inline => 'iex "puppet module install chocolatey-chocolatey --version 1.2.6"'
+    ## Install sensu using Chocolatey
+    client.vm.provision :shell, :inline => 'iex "puppet apply -v C:/vagrant/tests/sensu-client-windows-chocolatey.pp"'
   end
 
   config.vm.define "debian8-client", autostart: false do |client|

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -396,6 +396,32 @@
 #   the Windows package.  For example:
 #   `"https://repositories.sensuapp.org/msi/2012r2/sensu-0.29.0-11-x64.msi"`
 #   Default: undef
+#
+# [*windows_package_provider*]
+#   String.  When something other than `undef`, use the specified package
+#   provider to install Windows packages.  The default behavior of `undef`
+#   defers to the default package provider in Puppet which is expected to be the
+#   msi provider.  Valid values are `undef` or `'chocolatey'`.
+#   Default: undef
+#
+# [*windows_choco_repo*]
+#   String.  The URL of the Chocolatey repository, used with the chocolatey
+#   windows package provider.
+#   Default: undef
+#
+# [*windows_package_name*]
+#   String.  The package name used to identify the package filename.  Defaults
+#   to `'sensu'` which matches the MSI filename published at
+#   `https://repositories.sensuapp.org/msi`.  Note, this is distinct from the
+#   windows_package_title, which is used to identify the package name as
+#   displayed in Add/Remove programs in Windows.
+#   Default: 'sensu'
+#
+# [*windows_package_title*]
+#   String.  The package name used to identify the package as listed in
+#   Add/Remove programs.  Note this is distinct from the package filename
+#   identifier specified with windows_package_name.
+#   Default: 'Sensu'
 
 class sensu (
   $version                        = 'installed',
@@ -501,6 +527,10 @@ class sensu (
   $windows_logrotate              = false,
   $windows_log_number             = '10',
   $windows_log_size               = '10240',
+  $windows_package_provider       = undef,
+  $windows_choco_repo             = undef,
+  $windows_package_name           = 'Sensu',
+  $windows_package_title          = 'sensu',
 
   ### START Hiera Lookups ###
   $extensions                  = {},

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -396,6 +396,15 @@ describe 'sensu' do
           )
         end
       end
+
+      context 'with sensu::windows_package_provider: chocolatey' do
+        let(:params) do
+          { windows_package_provider: 'chocolatey' }
+        end
+        it 'uses the chocolatey provider for Package[Sensu]' do
+          should contain_package('sensu').with(provider: 'chocolatey')
+        end
+      end
     end
   end
 end

--- a/tests/sensu-client-windows-chocolatey.pp
+++ b/tests/sensu-client-windows-chocolatey.pp
@@ -1,0 +1,11 @@
+# Note: Check http://repositories.sensuapp.org/msi/ for the latest version.
+node default {
+  class { '::sensu':
+    windows_package_provider => 'chocolatey',
+    rabbitmq_password        => 'correct-horse-battery-staple',
+    rabbitmq_host            => '192.168.56.10',
+    rabbitmq_vhost           => '/sensu',
+    subscriptions            => 'all',
+    client_address           => $facts['networking']['ip'],
+  }
+}


### PR DESCRIPTION
Without this patch package resource used to install sensu on Windows defaults
to the `msi` provider and can't easily be changed to the Chocolatey provider.
This patch addresses the problem by adding a new class parameter,
`sensu::windows_package_provider` which defaults to `undef`, the default
behavior of Puppet on windows, and can be set to `'chocolatey'`.

The chocolatey package provider may be exercised with `vagrant up
win2012r2-client-chocolatey`.  There is no `sensu` package in the public
chocolatey repository, however, so installation will fail with the following error:

    ==> win2012r2-client-chocolatey: Error: Execution of 'C:\ProgramData\chocolatey\bin\choco.exe install sensu -y ' returned 1: Ch
    ocolatey v0.10.7
    ==> win2012r2-client-chocolatey: Installing the following packages:
    ==> win2012r2-client-chocolatey: sensu
    ==> win2012r2-client-chocolatey: By installing you accept licenses for the packages.
    ==> win2012r2-client-chocolatey: sensu not installed. The package was not found with the source(s) listed.
    ==> win2012r2-client-chocolatey:  If you specified a particular version and are receiving this message, it is possible that the
     package name exists but the version does not.
    ==> win2012r2-client-chocolatey:  Version: ""
    ==> win2012r2-client-chocolatey:  Source(s): "https://chocolatey.org/api/v2/"
    ==> win2012r2-client-chocolatey: Chocolatey installed 0/1 packages. 1 packages failed.
    ==> win2012r2-client-chocolatey:  See the log for details (C:\ProgramData\chocolatey\logs\chocolatey.log).

Even with this error, the behavior of the chocolatey package provider is
exercised.

Closes #664
Resolves #589

Original Author: john.puskar <jpuskar@us.ibm.com>