### PR TITLE
(#433) Reload Service[sensu_api] on RabbitMQ config changes

### DIFF
--- a/manifests/api/service.pp
+++ b/manifests/api/service.pp
@@ -40,6 +40,7 @@ class sensu::api::service (
           Class['sensu::package'],
           Class['sensu::api::config'],
           Class['sensu::redis::config'],
+          Class['sensu::rabbitmq::config'],
         ],
       }
     }

--- a/spec/classes/sensu_api_spec.rb
+++ b/spec/classes/sensu_api_spec.rb
@@ -162,6 +162,11 @@ describe 'sensu', :type => :class do
           :enable     => true,
           :hasrestart => true
         )}
+        describe '(#433)' do
+          it { is_expected.to contain_service('sensu-api').that_subscribes_to('Class[sensu::redis::config]') }
+          # GH-433 Make sure the API subscribes to rabbitmq and redis
+          it { is_expected.to contain_service('sensu-api').that_subscribes_to('Class[sensu::rabbitmq::config]') }
+        end
       end # managing services
 
       context 'not managing services' do


### PR DESCRIPTION
Without this patch the Sensu API service doesn't reload itself when RabbitMQ
configuration changes occur.  This patch addresses the problem by adding a
relationship between the rabbitmq configuration class and the service resource.

Note, both sensu::rabbitmq::config and sensu::redis::config are in the catalog
regardless of which is actually being configured.

Resolves #433