### PR TITLE
(#562) Sensu_filter resources notify Sensu Server and Sensu Enterprise

### DIFF
--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -9,9 +9,12 @@ Puppet::Type.newtype(:sensu_filter) do
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-server]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-server]',
+        'Service[sensu-enterprise]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   ensurable do

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -6,6 +6,14 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', '..',
 Puppet::Type.newtype(:sensu_filter) do
   @doc = ""
 
+  def initialize(*args)
+    super *args
+
+    self[:notify] = [
+      "Service[sensu-server]",
+    ].select { |ref| catalog.resource(ref) }
+  end
+
   ensurable do
     newvalue(:present) do
       provider.create

--- a/spec/unit/sensu_filter_spec.rb
+++ b/spec/unit/sensu_filter_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_filter) do
+  # service_resource is context-specific
+  let(:resource_hash) do
+    c = Puppet::Resource::Catalog.new
+    c.add_resource(service_resource)
+    {
+      :title => 'myfilter',
+      :catalog => c
+    }
+  end
+
+  describe 'notifications' do
+    context '(#495) when managing sensu-enterprise' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-enterprise')
+      end
+      it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+
+    context '(#562) when managing sensu-server' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-server')
+      end
+      it 'notifies Service[sensu-server]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
+end


### PR DESCRIPTION
Without this patch, Service[sensu-server] and Service[sensu-enterprise] do not
reload when Sensu_filter resources change.

This patch addresses the problem by adding a notify relationship if the service
resources exist in the catalog.

Resolves #562