### PR TITLE
(#600) Reload Sensu API when check configurations change

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -26,6 +26,7 @@ Puppet::Type.newtype(:sensu_check) do
         "Service[sensu-client]",
         "Service[sensu-server]",
         "Service[sensu-enterprise]",
+        "Service[sensu-api]",
       ].select { |ref| c.resource(ref) }
     end
   end

--- a/lib/puppet/type/sensu_check_config.rb
+++ b/lib/puppet/type/sensu_check_config.rb
@@ -9,6 +9,7 @@ Puppet::Type.newtype(:sensu_check_config) do
         'Service[sensu-client]',
         'Service[sensu-server]',
         'Service[sensu-enterprise]',
+        'Service[sensu-api]',
       ].select { |ref| c.resource(ref) }
     end
   end

--- a/spec/unit/sensu_check_config_spec.rb
+++ b/spec/unit/sensu_check_config_spec.rb
@@ -9,20 +9,31 @@ describe Puppet::Type.type(:sensu_check_config) do
   end
 
   describe 'notifications' do
+    let(:resource_hash) do
+      c = Puppet::Resource::Catalog.new
+      c.add_resource(service_resource)
+      {
+        :title => 'foo.example.com',
+        :catalog => c
+      }
+    end
+
     context 'when managing sensu-enterprise (#495)' do
       let(:service_resource) do
         Puppet::Type.type(:service).new(name: 'sensu-enterprise')
       end
-      let(:resource_hash) do
-        c = Puppet::Resource::Catalog.new
-        c.add_resource(service_resource)
-        {
-          :title => 'foo.example.com',
-          :catalog => c
-        }
-      end
-
       it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+
+    context 'when managing sensu-api (#600)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-api')
+      end
+      it 'notifies Service[sensu-api]' do
         notify_list = described_class.new(resource_hash)[:notify]
         # compare the resource reference strings, the object identities differ.
         expect(notify_list.map(&:ref)).to eq [service_resource.ref]

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -83,20 +83,31 @@ describe Puppet::Type.type(:sensu_check) do
   end
 
   describe 'notifications' do
+    let(:resource_hash) do
+      c = Puppet::Resource::Catalog.new
+      c.add_resource(service_resource)
+      {
+        :title => 'foo.example.com',
+        :catalog => c
+      }
+    end
+
     context 'when managing sensu-enterprise (#495)' do
       let(:service_resource) do
         Puppet::Type.type(:service).new(name: 'sensu-enterprise')
       end
-      let(:resource_hash) do
-        c = Puppet::Resource::Catalog.new
-        c.add_resource(service_resource)
-        {
-          :title => 'foo.example.com',
-          :catalog => c
-        }
-      end
-
       it 'notifies Service[sensu-enterprise]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+
+    context 'when managing sensu-api (#600)' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-api')
+      end
+      it 'notifies Service[sensu-api]' do
         notify_list = described_class.new(resource_hash)[:notify]
         # compare the resource reference strings, the object identities differ.
         expect(notify_list.map(&:ref)).to eq [service_resource.ref]


### PR DESCRIPTION
Without this patch changes to sensu::check and sensu::check_config resources do
not automatically reload the Sensu API service.  This causes the checks to not
show up in the dashboard UI which is a problem for the end user.

This patch adds notification relationships between sensu_check and
sensu_check_config resources and Service[sensu-api].

Resolves #600