### PR TITLE
(#598) Improve rabbitmq clustering robustness

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,6 +51,18 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     server.vm.provision :shell, :path => "tests/rabbitmq.sh"
   end
 
+  config.vm.define 'sensu-server-cluster', autostart: false do |server|
+    server.vm.box = 'centos/7'
+    server.vm.hostname = 'sensu-server.example.com'
+    server.vm.network :private_network, ip: ENV['ALTERNATE_IP'] || '192.168.56.10'
+    server.vm.network :forwarded_port, guest: 4567, host: 4567, auto_correct: true
+    server.vm.network :forwarded_port, guest: 3000, host: 3000, auto_correct: true
+    server.vm.network :forwarded_port, guest: 15672, host: 15672, auto_correct: true
+    server.vm.provision :shell, :path => "tests/provision_basic_el.sh"
+    server.vm.provision :shell, :path => "tests/provision_server_cluster.sh"
+    server.vm.provision :shell, :path => "tests/rabbitmq.sh"
+  end
+
   # This system is meant to be started without 'sensu-server' running.
   config.vm.define "sensu-server-puppet5", autostart: false do |server|
     server.vm.box = "centos/7"

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -124,17 +124,17 @@ class sensu::rabbitmq::config {
 
   sensu_rabbitmq_config { $::fqdn:
     ensure          => $ensure,
-    base_path       => $::sensu::conf_dir,
-    port            => $::sensu::rabbitmq_port,
-    host            => $::sensu::rabbitmq_host,
-    user            => $::sensu::rabbitmq_user,
-    password        => $::sensu::rabbitmq_password,
-    vhost           => $::sensu::rabbitmq_vhost,
-    heartbeat       => $::sensu::rabbitmq_heartbeat,
+    base_path       => $base_path,
+    port            => $port,
+    host            => $host,
+    user            => $user,
+    password        => $password,
+    vhost           => $vhost,
+    heartbeat       => $heartbeat,
     ssl_transport   => $enable_ssl,
     ssl_cert_chain  => $ssl_cert_chain,
     ssl_private_key => $ssl_private_key,
-    prefetch        => $::sensu::rabbitmq_prefetch,
+    prefetch        => $prefetch,
     cluster         => $cluster,
   }
 }

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -48,8 +48,16 @@ Pj3BM+E9hNMOQ6N7H87G4rbDz4T/kswNSiyF3v5Vlm0U5nGWWbk7
 -----END RSA PRIVATE KEY-----"
 
 describe 'sensu', :type => :class do
-  let(:facts) { { :fqdn => 'hostname.domain.com', :osfamily => 'RedHat' } }
-  let(:params) { { :client => true } }
+  let(:facts) do
+    {
+      :fqdn            => 'hostname.domain.com',
+      :operatingsystem => 'CentOS',
+      :osfamily        => 'RedHat',
+    }
+  end
+  let(:params_base) { { :client => true } }
+  let(:params_override) { {} }
+  let(:params) { params_base.merge(params_override) }
 
   context 'rabbitmq config' do
     context 'no ssl (default)' do
@@ -171,7 +179,7 @@ describe 'sensu', :type => :class do
         ]
       }
 
-      let(:params) { {
+      let(:params_base) { {
         :rabbitmq_ssl_cert_chain  => rabbitmq_ssl_cert_chain_test,
         :rabbitmq_ssl_private_key => rabbitmq_ssl_private_key_test,
         :rabbitmq_cluster => cluster_config
@@ -181,6 +189,43 @@ describe 'sensu', :type => :class do
       it { should contain_file('/etc/sensu/ssl/cert.pem').with_content(rabbitmq_ssl_cert_chain_test) }
       it { should contain_file('/etc/sensu/ssl/key.pem').with_content(rabbitmq_ssl_private_key_test) }
       it { should contain_sensu_rabbitmq_config('hostname.domain.com').with_cluster(cluster_config) }
+
+      context 'with rabbitmq_* class parameters also specified (#598)' do
+        describe 'sensu::rabbitmq_port' do
+          let(:params_override) { { rabbitmq_port: 6379 } }
+          it { is_expected.to contain_sensu_rabbitmq_config(facts[:fqdn]).without_port }
+        end
+
+        describe 'sensu::rabbitmq_host' do
+          let(:params_override) { { rabbitmq_host: 'rabbitmq.example.com' } }
+          it { is_expected.to contain_sensu_rabbitmq_config(facts[:fqdn]).without_host }
+        end
+
+        describe 'sensu::rabbitmq_user' do
+          let(:params_override) { { rabbitmq_user: 'sensu-ignored' } }
+          it { is_expected.to contain_sensu_rabbitmq_config(facts[:fqdn]).without_user }
+        end
+
+        describe 'sensu::rabbitmq_password' do
+          let(:params_override) { { rabbitmq_password: 'ignored-secret' } }
+          it { is_expected.to contain_sensu_rabbitmq_config(facts[:fqdn]).without_password }
+        end
+
+        describe 'sensu::rabbitmq_vhost' do
+          let(:params_override) { { rabbitmq_vhost: '/sensu-ignored' } }
+          it { is_expected.to contain_sensu_rabbitmq_config(facts[:fqdn]).without_vhost }
+        end
+
+        describe 'sensu::rabbitmq_heartbeat' do
+          let(:params_override) { { rabbitmq_heartbeat: 30 } }
+          it { is_expected.to contain_sensu_rabbitmq_config(facts[:fqdn]).without_heartbeat }
+        end
+
+        describe 'sensu::rabbitmq_prefetch' do
+          let(:params_override) { { rabbitmq_prefetch: 1 } }
+          it { is_expected.to contain_sensu_rabbitmq_config(facts[:fqdn]).without_prefetch }
+        end
+      end
     end
 
     context 'when using prefetch attribute' do
@@ -219,5 +264,4 @@ describe 'sensu', :type => :class do
       it { should contain_file('/etc/sensu/conf.d/rabbitmq.json').with_ensure('absent') }
     end
   end # rabbitmq config
-
 end

--- a/tests/provision_server_cluster.sh
+++ b/tests/provision_server_cluster.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# setup module dependencies
+puppet module install puppetlabs/rabbitmq
+
+# install dependencies for sensu
+yum -y install redis jq nagios-plugins-ntp
+systemctl start redis
+systemctl enable redis
+
+# run puppet
+puppet apply /vagrant/tests/rabbitmq.pp
+puppet apply /vagrant/tests/sensu-server-cluster.pp
+puppet apply /vagrant/tests/uchiwa.pp

--- a/tests/sensu-server-cluster.pp
+++ b/tests/sensu-server-cluster.pp
@@ -1,31 +1,48 @@
+# This provisioning manifest configures sensu-server as if it were connected to
+# a rabbitmq cluster.  It doesn't actually configure multiple running rabbitmq
+# instances, it configures just one.  The purpose is to exercise the sensu
+# cluster configuration, e.g. to exercise the expected behavior reported
+# in https://github.com/sensu/sensu-puppet/issues/598
+#
+# NOTE: rabbitmq_password should be ignored with rabbitmq_cluster specified.
 node 'sensu-server' {
   class { '::sensu':
-    install_repo     => true,
-    server           => true,
-    manage_services  => true,
-    manage_user      => true,
-    api              => true,
-    api_user         => 'admin',
-    api_password     => 'secret',
-    client_address   => $::ipaddress_eth1,
-    rabbitmq_cluster => [
+    install_repo      => true,
+    server            => true,
+    manage_services   => true,
+    manage_user       => true,
+    api               => true,
+    api_user          => 'admin',
+    api_password      => 'secret',
+    client_address    => $::ipaddress_eth1,
+    rabbitmq_password => 'correct-horse-battery-staple',
+    rabbitmq_cluster  => [
       {
-        'port'            => '1234',
-        'host'            => 'sensu-server.example.com',
-        'user'            => 'sensuuser',
-        'password'        => 'sensupass',
-        'vhost'           => '/myvhost',
-        'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
-        'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+        'port'      => '5671',
+        'host'      => 'sensu-server.example.com',
+        'user'      => 'sensu',
+        'password'  => 'correct-horse-battery-staple',
+        'vhost'     => '/sensu',
+        'prefetch'  => 50,
+        'heartbeat' => 30,
       },
       {
-        'port'            => '1234',
-        'host'            => 'sensu-server.example.com',
-        'user'            => 'sensuuser',
-        'password'        => 'sensupass',
-        'vhost'           => '/myvhost',
-        'ssl_cert_chain'  => '/etc/sensu/ssl/cert.pem',
-        'ssl_private_key' => '/etc/sensu/ssl/key.pem'
+        'port'      => '5672',
+        'host'      => 'sensu-server.example.com',
+        'user'      => 'sensu',
+        'password'  => 'correct-horse-battery-staple',
+        'vhost'     => '/sensu',
+        'prefetch'  => 50,
+        'heartbeat' => 30,
+      },
+      {
+        'port'      => '5673',
+        'host'      => 'sensu-server.example.com',
+        'user'      => 'sensu',
+        'password'  => 'correct-horse-battery-staple',
+        'vhost'     => '/sensu',
+        'prefetch'  => 50,
+        'heartbeat' => 30,
       },
     ],
   }

--- a/tests/sensu-server.pp
+++ b/tests/sensu-server.pp
@@ -23,7 +23,7 @@ node 'sensu-server' {
     subscribers => 'sensu-test',
   }
 
-  $proxy_requests = {
+  $proxy_requests_ntp = {
     'client_attributes' => {
       'subscriptions' => 'eval: value.include?("ntp")',
     },
@@ -36,6 +36,36 @@ node 'sensu-server' {
     handlers       => 'default',
     subscribers    => 'roundrobin:poller',
     cron           => '*/5 * * * *',
-    proxy_requests => $proxy_requests,
+    proxy_requests => $proxy_requests_ntp,
+  }
+
+  # A client defined in the Dashboard with a subscription of "http" will
+  # automatically have this check associated with it.  Check Google with the
+  # following API call to create a proxy client definition:
+  #
+  #     curl -s -i -X POST -H 'Content-Type: application/json' \
+  #       -d '{"name":"google.com","address":"google.com","subscriptions":["http"]}' \
+  #       http://admin:secret@127.0.0.1:4567/clients
+  #
+  # Then, trigger the check with:
+  #
+  #     curl -s -i -X POST -H 'Content-Type: application/json' \
+  #       -d '{"check": "remote_http"}' \
+  #       http://admin:secret@127.0.0.1:4567/request
+  $proxy_requests_http = {
+    'client_attributes' => {
+      'subscriptions' => 'eval: value.include?("http")',
+    },
+  }
+  sensu::check { 'remote_http':
+    command             => '/opt/sensu/embedded/bin/check-http.rb -u http://:::address:::',
+    occurrences         => 2,
+    interval            => 300,
+    refresh             => 600,
+    low_flap_threshold  => 20,
+    high_flap_threshold => 60,
+    standalone          => false,
+    subscribers         => 'roundrobin:poller',
+    proxy_requests      => $proxy_requests_http,
   }
 }


### PR DESCRIPTION
Without this patch, Puppet errors out when both `sensu::rabbitmq_password`, or
any of the `sensu::rabbitmq_*` parameters are specified along with
`sensu::rabbitmq_cluster`.  The error is:

    Error: /Stage[main]/Sensu::Rabbitmq::Config/Sensu_rabbitmq_config[sensu-server.example.com]: Could not evaluate: no implicit conversion of String into Integer
    /vagrant/lib/puppet/provider/sensu_rabbitmq_config/json.rb:137:in `[]'
    /vagrant/lib/puppet/provider/sensu_rabbitmq_config/json.rb:137:in `password'

This patch addresses the problem by changing sensu::rabbitmq::config to ignore
sensu::rabbitmq_* class parameters when the cluster configuration is specified
via `sensu::rabbitmq_cluster`.

Resolves #598 