### PR TITLE
(#737) Add cron attribute to sensu::check type

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -89,6 +89,11 @@ Puppet::Type.newtype(:sensu_check) do
     end
   end
 
+  newproperty(:cron) do
+    desc 'When the check should be executed, using the Cron syntax.'
+    newvalues(/.*/, :absent)
+  end
+
   newproperty(:interval) do
     desc "How frequently the check runs in seconds"
     newvalues(/.*/, :absent)

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -8,13 +8,12 @@ describe 'sensu::check', :type => :define do
   end
   let(:facts) { { :osfamily => 'RedHat' } }
 
+  let(:title) { 'mycheck' }
   let(:params_base) {{ command: '/etc/sensu/somecommand.rb' }}
   let(:params_override) {{}}
   let(:params) { params_base.merge(params_override) }
 
   context 'without whitespace in name' do
-    let(:title) { 'mycheck' }
-
     context 'defaults' do
       it { should contain_sensu_check('mycheck').with(
         :command     => '/etc/sensu/somecommand.rb',
@@ -142,8 +141,6 @@ describe 'sensu::check', :type => :define do
   end
 
   context 'notifications' do
-    let(:title) { 'mycheck' }
-
     context 'no client, sever, or api' do
       let(:pre_condition) { 'class {"sensu": client => false, api => false, server => false}' }
       it { should contain_sensu_check('mycheck').with(:notify => []) }
@@ -186,8 +183,6 @@ describe 'sensu::check', :type => :define do
   end
 
   context 'with subdue' do
-    let(:title) { 'mycheck' }
-
     context 'valid subdue hash' do
       let(:params) {
         {
@@ -249,8 +244,6 @@ describe 'sensu::check', :type => :define do
   end
 
   describe 'param proxy_requests' do
-    let(:title) { 'mycheck' }
-
     context 'valid proxy_requests hash' do
       let(:params_override) do
         { proxy_requests: { 'client_attributes' => { 'subscriptions' => 'eval: value.include?("http")' } } }
@@ -272,6 +265,26 @@ describe 'sensu::check', :type => :define do
 
     context '= undef' do
       it { should contain_sensu_check('mycheck').without_proxy_requests }
+    end
+  end
+
+  describe 'param cron' do
+    context 'default behavior (not specified)' do
+      let(:params_override) { {} }
+      it { is_expected.to contain_sensu_check('mycheck').with(cron: 'absent') }
+      it { is_expected.to contain_sensu_check('mycheck').with(interval: 60) }
+    end
+
+    context 'without interval' do
+      let(:params_override) { {cron: '*/5 * * * *'} }
+      it { is_expected.to contain_sensu_check('mycheck').with(cron: params[:cron]) }
+      it { is_expected.to contain_sensu_check('mycheck').with(interval: 'absent') }
+    end
+
+    context 'with interval' do
+      let(:params_override) { {cron: '*/5 * * * *', interval: 99} }
+      it { is_expected.to contain_sensu_check('mycheck').with(cron: params[:cron]) }
+      it { is_expected.to contain_sensu_check('mycheck').with(interval: 'absent') }
     end
   end
 end

--- a/tests/sensu-server.pp
+++ b/tests/sensu-server.pp
@@ -10,6 +10,7 @@ node 'sensu-server' {
     api_user          => 'admin',
     api_password      => 'secret',
     client_address    => $::ipaddress_eth1,
+    subscriptions     => ['all', 'roundrobin:poller'],
   }
 
   sensu::handler { 'default':
@@ -20,5 +21,21 @@ node 'sensu-server' {
     command     => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H pool.ntp.org -w 30 -c 60',
     handlers    => 'default',
     subscribers => 'sensu-test',
+  }
+
+  $proxy_requests = {
+    'client_attributes' => {
+      'subscriptions' => 'eval: value.include?("ntp")',
+    },
+  }
+
+  # Example check using the cron schedule.
+  sensu::check { 'remote_check_ntp':
+    command        => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H :::address::: -w 30 -c 60',
+    standalone     => false,
+    handlers       => 'default',
+    subscribers    => 'roundrobin:poller',
+    cron           => '*/5 * * * *',
+    proxy_requests => $proxy_requests,
   }
 }


### PR DESCRIPTION
Without this patch the sensu::check type does not manage the
[cron](https://sensuapp.org/docs/latest/reference/checks#check-attributes)
attribute.  This patch adds the `cron` parameter.  If specified, the interval
parameter will be set to `'absent'` which will remove the interval attribute
from the JSON check configuration if present.

Resolves #737