### PR TITLE
(#727) Add sensu::spawn_limit class parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -71,6 +71,15 @@
 #   with systems that use apt.
 #   Default: $::lsbdistcodename
 #
+# [*spawn_limit*]
+#   Integer.  Tune concurrency of the sensu-server pipe handler and the
+#   sensu-client check execution.  This setting should not need to be tuned
+#   except in specific situations, e.g. when there are a large number of JIT
+#   clients.  See [#727](https://github.com/sensu/sensu-puppet/issues/727) for
+#   more information.  The default is undefined, which does not manage
+#   `/etc/sensu/conf.d/spawn.json`
+#   Default: undef
+#
 # [*client*]
 #   Boolean.  Include the sensu client
 #   Default: true
@@ -456,6 +465,7 @@ class sensu (
   $repo_key_id                    = 'EE15CFF6AB6E4E290FDAB681A20F259AEB9C94BB',
   $repo_key_source                = 'https://sensu.global.ssl.fastly.net/apt/pubkey.gpg',
   $repo_release                   = undef,
+  $spawn_limit                    = undef,
   $enterprise_repo_key_id         = '910442FF8781AFD0995D14B311AB27E8C3FE3269',
   $client                         = true,
   $server                         = false,
@@ -581,6 +591,7 @@ class sensu (
   if $purge_config { fail('purge_config is deprecated, set the purge parameter to a hash containing `config => true` instead') }
   if $purge_plugins_dir { fail('purge_plugins_dir is deprecated, set the purge parameter to a hash containing `plugins => true` instead') }
   if !is_integer($redis_db) { fail('redis_db must be an integer') }
+  if $spawn_limit and !is_integer($spawn_limit) { fail('spawn_limit must be an integer') }
 
   # sensu-enterprise supersedes sensu-server and sensu-api
   if ( $enterprise and $api ) or ( $enterprise and $server ) {

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -465,6 +465,16 @@ describe 'sensu' do
     it { should contain_file('/etc/default/sensu').with_content(%r{^PATH=/spec/tests$}) }
   end
 
+  describe 'spawn_limit (#727)' do
+    context 'default (undef)' do
+      it { should contain_file('/etc/sensu/conf.d/spawn.json').without_content }
+    end
+    context '=> 20' do
+      let(:params) { {spawn_limit: 20} }
+      it { should contain_file('/etc/sensu/conf.d/spawn.json').with_content(/limit.*20/) }
+    end
+  end
+
   describe 'variable type and content validations' do
     mandatory_params = {}
 

--- a/tests/sensu-server.pp
+++ b/tests/sensu-server.pp
@@ -6,6 +6,7 @@ node 'sensu-server' {
     manage_user       => true,
     rabbitmq_password => 'correct-horse-battery-staple',
     rabbitmq_vhost    => '/sensu',
+    spawn_limit       => 16,
     api               => true,
     api_user          => 'admin',
     api_password      => 'secret',


### PR DESCRIPTION
Without this patch the Sensu spawn limit setting cannot easily be configured by
this module.  This patch addresses the problem by adding a sensu::spawn_limit
class parameter.  If unset, the parameter defaults to the behavior of Sensu
which is to have a limit of 12 in version 0.29.0.

Resolves #727