### PR TITLE
(#550) Add sensu client de-registration

### DIFF
--- a/lib/puppet/provider/sensu_check/json.rb
+++ b/lib/puppet/provider/sensu_check/json.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
   end
 
   def flush
-    sort_properties
+    sort_properties!
     File.open(config_file, 'w') do |f|
       f.puts JSON.pretty_generate(conf)
     end
@@ -31,7 +31,7 @@ Puppet::Type.type(:sensu_check).provide(:json) do
     conf['checks'][resource[:name]] = {}
   end
 
-  def sort_properties
+  def sort_properties!
     conf['checks'][resource[:name]] = Hash[conf['checks'][resource[:name]].sort]
   end
 

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -9,9 +9,11 @@ Puppet::Type.newtype(:sensu_client_config) do
   def initialize(*args)
     super *args
 
-    self[:notify] = [
-      "Service[sensu-client]",
-    ].select { |ref| catalog.resource(ref) }
+    if c = catalog
+      self[:notify] = [
+        'Service[sensu-client]',
+      ].select { |ref| c.resource(ref) }
+    end
   end
 
   ensurable do
@@ -87,13 +89,8 @@ Puppet::Type.newtype(:sensu_client_config) do
   end
 
   newproperty(:custom) do
-    desc "Custom client variables"
-
+    desc 'Custom client attributes'
     include PuppetX::Sensu::ToType
-
-    munge do |value|
-      value.each { |k, v| value[k] = to_type(v) }
-    end
 
     def is_to_s(hash = @is)
       hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
@@ -116,6 +113,15 @@ Puppet::Type.newtype(:sensu_client_config) do
     end
 
     defaultto {}
+  end
+
+  newproperty(:deregister, :parent => PuppetX::Sensu::BooleanProperty) do
+    desc 'Enable client de-registration'
+  end
+
+  newproperty(:deregistration) do
+    desc 'Client deregistration attributes'
+    newvalues(/.*/, :absent)
   end
 
   newproperty(:keepalive) do
@@ -149,7 +155,6 @@ Puppet::Type.newtype(:sensu_client_config) do
 
     defaultto {}
   end
-
 
   autorequire(:package) do
     ['sensu']

--- a/manifests/client/config.pp
+++ b/manifests/client/config.pp
@@ -21,19 +21,23 @@ class sensu::client::config {
     mode   => $::sensu::file_mode,
   }
 
+  $socket_config = {
+    bind => $::sensu::client_bind,
+    port => $::sensu::client_port,
+  }
+
   sensu_client_config { $::fqdn:
-    ensure        => $ensure,
-    base_path     => $::sensu::conf_dir,
-    client_name   => $::sensu::client_name,
-    address       => $::sensu::client_address,
-    socket        => {
-                        bind => $::sensu::client_bind,
-                        port => $::sensu::client_port,
-                      },
-    subscriptions => $::sensu::subscriptions,
-    safe_mode     => $::sensu::safe_mode,
-    custom        => $::sensu::client_custom,
-    keepalive     => $::sensu::client_keepalive,
-    redact        => $::sensu::redact,
+    ensure         => $ensure,
+    base_path      => $::sensu::conf_dir,
+    client_name    => $::sensu::client_name,
+    address        => $::sensu::client_address,
+    socket         => $socket_config,
+    subscriptions  => $::sensu::subscriptions,
+    safe_mode      => $::sensu::safe_mode,
+    custom         => $::sensu::client_custom,
+    keepalive      => $::sensu::client_keepalive,
+    redact         => $::sensu::redact,
+    deregister     => $::sensu::client_deregister,
+    deregistration => $::sensu::client_deregistration,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -265,8 +265,27 @@
 #   Default: $::fqdn
 #
 # [*client_custom*]
-#   Hash.  Custom client variables
+#   Hash.  Custom client variables.
 #   Default: {}
+#
+# [*client_deregister*]
+#   Boolean.  Enable the [deregistration
+#   event](https://sensuapp.org/docs/latest/reference/clients#deregistration-attributes)
+#   if true.
+#   Default: undef
+#
+# [*client_deregistration*]
+#   Hash.
+#   [Attributes](https://sensuapp.org/docs/latest/reference/clients#deregistration-attributes)
+#   used to generate check result data for the de-registration event. Client
+#   deregistration attributes are merged with some default check definition
+#   attributes by the Sensu server during client deregistration, so any valid
+#   check definition attributes – including custom check definition attributes
+#   – may be used as deregistration attributes, with the following exceptions
+#   (which are used to ensure the check result is valid): check name, output,
+#   status, and issued timestamp. The following attributes are provided as
+#   recommendations for controlling client deregistration behavior.
+#   Default: undef
 #
 # [*client_keepalive*]
 #   Hash.  Client keepalive config
@@ -510,6 +529,8 @@ class sensu (
   String             $client_address =  $::ipaddress,
   String             $client_name =  $::fqdn,
   Hash               $client_custom = {},
+  Variant[Undef,Boolean] $client_deregister = undef,
+  Variant[Undef,Hash] $client_deregistration = undef,
   Hash               $client_keepalive = {},
   Boolean            $safe_mode = false,
   Variant[String,Array,Hash] $plugins = [],
@@ -552,7 +573,6 @@ class sensu (
   Optional[String]   $windows_choco_repo = undef,
   String             $windows_package_name = 'Sensu',
   String             $windows_package_title = 'sensu',
-
   ### START Hiera Lookups###
   Hash               $extensions = {},
   Hash               $handlers = {},
@@ -563,9 +583,7 @@ class sensu (
   Hash               $filter_defaults = {},
   Hash               $mutators = {},
   ### END Hiera Lookups ###
-
 ) {
-
   if $dashboard { fail('Sensu-dashboard is deprecated, use a dashboard module. See https://github.com/sensu/sensu-puppet#dashboards')}
   if $purge_config { fail('purge_config is deprecated, set the purge parameter to a hash containing `config => true` instead') }
   if $purge_plugins_dir { fail('purge_plugins_dir is deprecated, set the purge parameter to a hash containing `plugins => true` instead') }

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -2,11 +2,10 @@ require 'spec_helper'
 
 describe 'sensu', :type => :class do
   let(:facts) { { :ipaddress => '2.3.4.5', :fqdn => 'host.domain.com', :osfamily => 'RedHat' } }
+  let(:title) { 'host.domain.com' }
 
   context 'with client (default)' do
-
     context 'config' do
-
       context 'defaults' do
         let(:params) { { :client => true } }
         it { should contain_sensu_client_config('host.domain.com').with(
@@ -19,41 +18,91 @@ describe 'sensu', :type => :class do
         ) }
 
         it { should contain_sensu_client_config('host.domain.com').without_redact }
+        it { should contain_sensu_client_config('host.domain.com').without_deregister }
+        it { should contain_sensu_client_config('host.domain.com').without_deregistration }
       end # defaults
 
       context 'setting config params' do
-        let(:params) { {
-          :client                   => true,
-          :client_address           => '1.2.3.4',
-          :subscriptions            => ['all'],
-          :redact                   => ['password'],
-          :client_name              => 'myclient',
-          :safe_mode                => true,
-          :client_custom            => { 'bool' => true, 'foo' => 'bar' }
-        } }
+        let(:params_base) do
+          {
+            :client         => true,
+            :client_address => '1.2.3.4',
+            :subscriptions  => ['all'],
+            :redact         => ['password'],
+            :client_name    => 'myclient',
+            :safe_mode      => true,
+            :client_custom  => { 'bool' => true, 'foo' => 'bar' },
+          }
+        end
+        let(:params_override) { {} }
+        let(:params) { params_base.merge(params_override) }
 
-        it { should contain_sensu_client_config('host.domain.com').with( {
-          :ensure        => 'present',
-          :client_name   => 'myclient',
-          :address       => '1.2.3.4',
-          :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
-          :subscriptions => ['all'],
-          :redact        => ['password'],
-          :safe_mode     => true,
-          :custom        => { 'bool' => true, 'foo' => 'bar' }
-        } ) }
+        describe 'multiple attributes at once' do
+          let(:params) { {
+            :client                   => true,
+            :client_address           => '1.2.3.4',
+            :subscriptions            => ['all'],
+            :redact                   => ['password'],
+            :client_name              => 'myclient',
+            :safe_mode                => true,
+            :client_custom            => { 'bool' => true, 'foo' => 'bar' }
+          } }
 
-      end # setting config params
+          it { should contain_sensu_client_config('host.domain.com').with( {
+            :ensure        => 'present',
+            :client_name   => 'myclient',
+            :address       => '1.2.3.4',
+            :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
+            :subscriptions => ['all'],
+            :redact        => ['password'],
+            :safe_mode     => true,
+            :custom        => { 'bool' => true, 'foo' => 'bar' }
+          } ) }
+        end
+
+        describe 'deregister' do
+          context '=> false' do
+            let(:params_override) { {client_deregister: false} }
+            it { is_expected.to contain_sensu_client_config(title).with(deregister: false) }
+          end
+
+          context '=> true' do
+            let(:params_override) { {client_deregister: true} }
+            it { is_expected.to contain_sensu_client_config(title).with(deregister: true) }
+          end
+
+          context '=> "garbage"' do
+            let(:params_override) { {client_deregister: 'garbage'} }
+            it { is_expected.to raise_error(Puppet::Error) }
+          end
+        end
+
+        describe 'client_deregistration' do
+          let(:params_override) { {client_deregistration: deregistration} }
+          context "=> {'handler': 'deregister_client'}" do
+            let(:deregistration) { {'handler' => 'deregister_client'} }
+            it { is_expected.to contain_sensu_client_config(title).with(deregistration: deregistration) }
+          end
+
+          context "=> {}" do
+            let(:deregistration) { {} }
+            it { is_expected.to contain_sensu_client_config(title).with(deregistration: deregistration) }
+          end
+
+          context "=> 'absent' (error)" do
+            let(:deregistration) { 'absent' }
+            it { is_expected.to raise_error(Puppet::Error) }
+          end
+        end
+      end
 
       context 'purge config' do
         let(:params) { { :purge => { 'config' => true } } }
         it { should contain_file('/etc/sensu/conf.d/client.json').with_ensure('present') }
       end # purge config
-
     end # config
 
     context 'service' do
-
       context 'default' do
         let(:params) { { :client => true } }
         it { should contain_service('sensu-client').with(
@@ -79,20 +128,15 @@ describe 'sensu', :type => :class do
           :hasrestart => false
         ) }
       end # with hasrestart=false
-
     end #service
-
   end #with client
 
   context 'without client' do
-
     context 'config' do
-
       context 'purge config' do
         let(:params) { { :purge => { 'config' => true }, :client => false } }
         it { should contain_file('/etc/sensu/conf.d/client.json').with_ensure('absent') }
       end # purge config
-
     end # config
 
     context 'service' do
@@ -112,9 +156,6 @@ describe 'sensu', :type => :class do
         } }
         it { should_not contain_service('sensu-client') }
       end #no client, not managing services
-
     end # service
-
   end # without client
-
 end

--- a/spec/unit/sensu_client_config_spec.rb
+++ b/spec/unit/sensu_client_config_spec.rb
@@ -1,0 +1,65 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_client_config) do
+  let(:resource_hash_base) do
+    {
+      :title => 'foo.example.com',
+      :catalog => Puppet::Resource::Catalog.new
+    }
+  end
+  # Overridden on a context by context basis
+  let(:resource_hash_override) { {} }
+  let(:resource_hash) { resource_hash_base.merge(resource_hash_override) }
+
+  describe 'deregister' do
+    subject { described_class.new(resource_hash)[:deregister] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    context '=> true' do
+      let(:resource_hash_override) { {deregister: true} }
+      it { is_expected.to eq(:true) }
+    end
+    context '=> false' do
+      let(:resource_hash_override) { {deregister: false} }
+      it { is_expected.to eq(:false) }
+    end
+  end
+
+  describe 'deregistration' do
+    subject { described_class.new(resource_hash)[:deregistration] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    context '=> {}' do
+      let(:resource_hash_override) { {deregistration: {}} }
+      it { is_expected.to eq({}) }
+    end
+    context '=> absent' do
+      let(:resource_hash_override) { {deregistration: 'absent'} }
+      it { is_expected.to eq(:absent) }
+    end
+  end
+
+  describe 'notifications' do
+    let(:resource_hash) do
+      c = Puppet::Resource::Catalog.new
+      c.add_resource(service_resource)
+      {
+        :title => 'foo.example.com',
+        :catalog => c
+      }
+    end
+
+    context 'when managing sensu-client' do
+      let(:service_resource) do
+        Puppet::Type.type(:service).new(name: 'sensu-client')
+      end
+      it 'notifies Service[sensu-api]' do
+        notify_list = described_class.new(resource_hash)[:notify]
+        # compare the resource reference strings, the object identities differ.
+        expect(notify_list.map(&:ref)).to eq [service_resource.ref]
+      end
+    end
+  end
+end

--- a/tests/sensu-server.pp
+++ b/tests/sensu-server.pp
@@ -1,17 +1,21 @@
 node 'sensu-server' {
+  $deregistration = { 'handler' => 'deregister_client' }
+
   class { '::sensu':
-    install_repo      => true,
-    server            => true,
-    manage_services   => true,
-    manage_user       => true,
-    rabbitmq_password => 'correct-horse-battery-staple',
-    rabbitmq_vhost    => '/sensu',
-    spawn_limit       => 16,
-    api               => true,
-    api_user          => 'admin',
-    api_password      => 'secret',
-    client_address    => $::ipaddress_eth1,
-    subscriptions     => ['all', 'roundrobin:poller'],
+    install_repo          => true,
+    server                => true,
+    manage_services       => true,
+    manage_user           => true,
+    rabbitmq_password     => 'correct-horse-battery-staple',
+    rabbitmq_vhost        => '/sensu',
+    spawn_limit           => 16,
+    api                   => true,
+    api_user              => 'admin',
+    api_password          => 'secret',
+    client_address        => $::ipaddress_eth1,
+    subscriptions         => ['all', 'roundrobin:poller'],
+    client_deregister     => true,
+    client_deregistration => $deregistration,
   }
 
   sensu::handler { 'default':


### PR DESCRIPTION
Without this patch the sensu client does not support the deregister and
deregistration attributes.  These attributes are documented at [deregistration
attributes](https://sensuapp.org/docs/latest/reference/clients#deregistration-attributes)

This patch adds the `sensu::client_deregister` and
`sensu::client_deregistration` class parameters which flow through to the
sensu_client_config type and provider.

This patch also refactors the sensu_client_config type and provider to operate
the same way as the sensu_check type and provider.  Specifically, the JSON
provider dynamically introspects the set of properties from the type and
creates getter and setter methods to output the JSON.  Custom attributes are
enhanced, if `client_custom = absent` then all custom attributes in the client
configuration are removed.  Otherwise, the custom attributes are merged on top
of any existing custom attributes.

Resolves #550