### PR TITLE
re-defining these variables for sensu-enterprise

### DIFF
--- a/manifests/enterprise/package.pp
+++ b/manifests/enterprise/package.pp
@@ -2,7 +2,17 @@
 #
 # Installs the Sensu packages
 #
-class sensu::enterprise::package {
+class sensu::enterprise::package (
+  $deregister_handler = $::sensu::deregister_handler,
+  $deregister_on_stop = $::sensu::deregister_on_stop,
+  $gem_path           = $::sensu::gem_path,
+  $init_stop_max_wait = $::sensu::init_stop_max_wait,
+  $log_dir            = $::sensu::log_dir,
+  $log_level          = $::sensu::log_level,
+  $path               = $::sensu::path,
+  $rubyopt            = $::sensu::rubyopt,
+  $use_embedded_ruby  = $::sensu::use_embedded_ruby,
+  ){
 
   if $caller_module_name != $module_name {
     fail("Use of private class ${name} by ${caller_module_name}")


### PR DESCRIPTION
/etc/default/sensu-enterprise lost these values because the module doesn't use scope.lookupvar() anymore. I tested this and it worked