### PR TITLE
Add handle_silenced parameter to handler defined type

### DIFF
--- a/lib/puppet/provider/sensu_handler/json.rb
+++ b/lib/puppet/provider/sensu_handler/json.rb
@@ -143,4 +143,12 @@ Puppet::Type.type(:sensu_handler).provide(:json) do
     conf['handlers'][resource[:name]]['handle_flapping'] = value
   end
 
+  def handle_silenced
+    conf['handlers'][resource[:name]]['handle_silenced']
+  end
+
+  def handle_silenced=(value)
+    conf['handlers'][resource[:name]]['handle_silenced'] = value
+  end
+
 end

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -107,6 +107,10 @@ Puppet::Type.newtype(:sensu_handler) do
     desc "If events in the flapping state should be handled"
   end
 
+  newproperty(:handle_silenced, :parent => PuppetX::Sensu::BooleanProperty) do
+    desc "If events in the silenced state should be handled"
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/handler.pp
+++ b/manifests/handler.pp
@@ -67,6 +67,11 @@
 #   Default: false.
 #   Valid values: true, false
 #
+# [*handle_silenced*]
+#   Boolean.  If events in the silenced state should be handled.
+#   Default: false.
+#   Valid values: true, false
+#
 define sensu::handler(
   Enum['present','absent'] $ensure = 'present',
   Enum['pipe','tcp','udp','amqp','set','transport'] $type = 'pipe',
@@ -86,6 +91,7 @@ define sensu::handler(
   Any $subdue                      = undef,
   Optional[Integer] $timeout       = undef,
   Boolean $handle_flapping         = false,
+  Boolean $handle_silenced         = false,
 ) {
 
   if $subdue{ fail('Subdue at handler is deprecated since sensu 0.26. See https://sensuapp.org/docs/0.26/overview/changelog.html#core-v0-26-0')}
@@ -163,6 +169,7 @@ define sensu::handler(
     config          => $config,
     timeout         => $timeout,
     handle_flapping => $handle_flapping,
+    handle_silenced => $handle_silenced,
     notify          => $notify_services,
     require         => File['/etc/sensu/conf.d/handlers'],
   }

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -183,7 +183,7 @@ describe 'sensu::handler', :type => :define do
   end
 
   context 'handle_silenced set to false' do
-    let(:params) { { :command => 'mycommand.rb', :type => 'pipe' } }
+    let(:params) { { :command => 'mycommand.rb', :type => 'pipe', :handle_silenced => false } }
     it { should contain_sensu_handler('myhandler').with_handle_silenced( false ) }
   end
 

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -177,4 +177,9 @@ describe 'sensu::handler', :type => :define do
     it { should contain_sensu_handler('myhandler').with_handle_flapping( true ) }
   end
 
+  context 'handle_silenced' do
+    let(:params) { { :command => 'mycommand.rb', :type => 'pipe', :handle_silenced => true } }
+    it { should contain_sensu_handler('myhandler').with_handle_silenced( true ) }
+  end
+
 end

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -182,4 +182,9 @@ describe 'sensu::handler', :type => :define do
     it { should contain_sensu_handler('myhandler').with_handle_silenced( true ) }
   end
 
+  context 'handle_silenced set to default' do
+    let(:params) { { :command => 'mycommand.rb', :type => 'pipe' } }
+    it { should contain_sensu_handler('myhandler').with_handle_silenced( false ) }
+  end
+
 end

--- a/spec/defines/sensu_handler_spec.rb
+++ b/spec/defines/sensu_handler_spec.rb
@@ -182,6 +182,11 @@ describe 'sensu::handler', :type => :define do
     it { should contain_sensu_handler('myhandler').with_handle_silenced( true ) }
   end
 
+  context 'handle_silenced set to false' do
+    let(:params) { { :command => 'mycommand.rb', :type => 'pipe' } }
+    it { should contain_sensu_handler('myhandler').with_handle_silenced( false ) }
+  end
+
   context 'handle_silenced set to default' do
     let(:params) { { :command => 'mycommand.rb', :type => 'pipe' } }
     it { should contain_sensu_handler('myhandler').with_handle_silenced( false ) }

--- a/tests/sensu-server.pp
+++ b/tests/sensu-server.pp
@@ -22,6 +22,34 @@ node 'sensu-server' {
     command => 'mail -s \'sensu alert\' ops@example.com',
   }
 
+  # Example handler which operates in silenced checks
+  #
+  # This should create a file in /etc/sensu/conf.d/handlers/handle_silenced.json, containing the following:
+  #
+  #  {
+  #    "handlers": {
+  #      "mail_handle_silenced": {
+  #        "command": "mail -s 'sensu alert' ops@example.com",
+  #        "type": "pipe",
+  #        "filters": [
+  #
+  #        ],
+  #        "severities": [
+  #          "ok",
+  #          "warning",
+  #          "critical",
+  #          "unknown"
+  #        ],
+  #        "handle_flapping": false,
+  #        "handle_silenced": true
+  #      }
+  #    }
+  #  }
+  sensu::handler { 'mail_handle_silenced':
+    command => 'mail -s \'sensu alert\' ops@example.com',
+    handle_silenced => true,
+  }
+
   sensu::check { 'check_ntp':
     command     => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H pool.ntp.org -w 30 -c 60',
     handlers    => 'default',

--- a/tests/sensu-server.pp
+++ b/tests/sensu-server.pp
@@ -46,7 +46,7 @@ node 'sensu-server' {
   #    }
   #  }
   sensu::handler { 'mail_handle_silenced':
-    command => 'mail -s \'sensu alert\' ops@example.com',
+    command         => 'mail -s \'sensu alert\' ops@example.com',
     handle_silenced => true,
   }
 


### PR DESCRIPTION
We have a handler that needs to operate on events, regardless of whether they've been silenced or not - this change implements the `handle_silenced` handler config option, as outlined in https://sensuapp.org/docs/0.29/reference/handlers.html