### PR TITLE
(#463) Ensure sensu::plugins are managed before checks

### DIFF
--- a/lib/puppet/type/sensu_check_config.rb
+++ b/lib/puppet/type/sensu_check_config.rb
@@ -11,6 +11,11 @@ Puppet::Type.newtype(:sensu_check_config) do
         'Service[sensu-enterprise]',
         'Service[sensu-api]',
       ].select { |ref| c.resource(ref) }
+      # (#463) All plugins must come before all checks.  Collections are not used to
+      # avoid realizing any resources.
+      self[:subscribe] = [
+        'Anchor[plugins_before_checks]',
+      ].select { |ref| c.resource(ref) }
     end
   end
 

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -155,7 +155,6 @@ define sensu::check (
   Variant[Undef,Enum['absent'],Hash]    $subdue = undef,
   Variant[Undef,Enum['absent'],Hash]    $proxy_requests = undef,
 ) {
-
   if $ensure == 'present' and !$command {
     fail("sensu::check{${name}}: a command must be given when ensure is present")
   }
@@ -200,6 +199,11 @@ define sensu::check (
       $file_mode = '0440'
     }
   }
+
+  # (#463) All plugins must come before all checks.  Collections are not used to
+  # avoid realizing any resources.
+  Anchor['plugins_before_checks']
+  ~> Sensu::Check[$name]
 
   file { "${conf_dir}/checks/${check_name}.json":
     ensure => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -563,9 +563,7 @@ class sensu (
   Hash               $filter_defaults = {},
   Hash               $mutators = {},
   ### END Hiera Lookups ###
-
 ) {
-
   if $dashboard { fail('Sensu-dashboard is deprecated, use a dashboard module. See https://github.com/sensu/sensu-puppet#dashboards')}
   if $purge_config { fail('purge_config is deprecated, set the purge parameter to a hash containing `config => true` instead') }
   if $purge_plugins_dir { fail('purge_plugins_dir is deprecated, set the purge parameter to a hash containing `plugins => true` instead') }
@@ -636,6 +634,10 @@ class sensu (
     $_purge_extensions = $full_purge_hash['extensions']
     $_purge_mutators   = $full_purge_hash['mutators']
   }
+
+  # (#463) This well-known anchor serves as a reference point so all checks are
+  # managed after all plugins.  It must always exist in the catalog.
+  anchor { 'plugins_before_checks': }
 
   # Create resources from hiera lookups
   create_resources('::sensu::extension', $extensions)

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -63,14 +63,18 @@ define sensu::plugin (
   Boolean $nocheckcertificate  = false,
   Any $gem_install_options = $::sensu::gem_install_options,
 ) {
-
   File {
     owner => 'sensu',
     group => 'sensu',
   }
 
   Sensu::Plugin[$name]
-  -> Class['sensu::client::service']
+  ~> Service['sensu-client']
+
+  # (#463) All plugins must come before all checks.  Collections are not used to
+  # avoid realizing any resources.
+  Sensu::Plugin[$name]
+  -> Anchor['plugins_before_checks']
 
   case $type {
     'file': {

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -13,6 +13,7 @@ describe 'sensu', :type => :class do
   it { should contain_file('/etc/default/sensu').without_content(%r{^CLIENT_DEREGISTER_ON_STOP=true\nCLIENT_DEREGISTER_HANDLER=.*$}) }
   it { should contain_file('/etc/default/sensu').with_content(%r{^SERVICE_MAX_WAIT="10"$}) }
   it { should contain_file('/etc/default/sensu').with_content(%r{^PATH=\$PATH$}) }
+  it { should contain_anchor('plugins_before_checks') }
   it { should_not contain_file('C:/opt/sensu/bin/sensu-client.xml') }
 
   describe 'osfamily windows' do
@@ -409,5 +410,4 @@ describe 'sensu', :type => :class do
       end # var[:name].each
     end # validations.sort.each
   end # describe 'variable type and content validations'
-
 end

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -299,4 +299,9 @@ describe 'sensu::check', :type => :define do
       it { is_expected.to contain_sensu_check('mycheck').with(interval: 'absent') }
     end
   end
+
+  describe 'relationships (#463)' do
+    let(:expected) { { notify: ["Sensu::Check[#{title}]"] } }
+    it { is_expected.to contain_anchor('plugins_before_checks').with(expected)}
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,4 +27,9 @@ RSpec.configure do |config|
     :kernel      => 'Linux',
     :osfamily    => 'RedHat',
   }
+  config.backtrace_exclusion_patterns = [
+    %r{/\.bundle/},
+    %r{/\.rbenv/},
+    %r{/.rvm/},
+  ]
 end

--- a/spec/unit/sensu_check_config_spec.rb
+++ b/spec/unit/sensu_check_config_spec.rb
@@ -40,4 +40,24 @@ describe Puppet::Type.type(:sensu_check_config) do
       end
     end
   end
+
+  describe 'relationships' do
+    let(:resource_hash) do
+      c = Puppet::Resource::Catalog.new
+      r = Puppet::Type.type(:anchor).new(name: 'plugins_before_checks')
+      c.add_resource(r)
+      {
+        :title => 'foo.example.com',
+        :catalog => c
+      }
+    end
+    let(:resource) do
+    end
+    context 'plugins before checks (#463)' do
+      subject { described_class.new(resource_hash)[:subscribe].map(&:ref) }
+      it 'subscribes to Anchor[plugins_before_checks]' do
+        is_expected.to eq ['Anchor[plugins_before_checks]']
+      end
+    end
+  end
 end


### PR DESCRIPTION
Without this patch plugins may be managed after the checks which use them. This
patch addresses the problem by adding a well known inert resource named
`Anchor[plugins_before_checks]`.  The sensu::check and sensu_check_config type
are managed after this anchor.  The sensu::plugin defined type is managed
before this anchor.  The anchor approach has been implemented over collections
to avoid realizing resources which the end user may be using.

Resolves #463