### PR TITLE
(#748) Add puppet-strings gem and dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec strings:generate'
 
 matrix:
   fast_finish: true

--- a/Gemfile
+++ b/Gemfile
@@ -38,6 +38,12 @@ group :development, :unit_tests do
   end
 end
 
+group :documentation do
+  gem 'yard',           require: false
+  gem 'redcarpet',      require: false
+  gem 'puppet-strings', require: false
+end
+
 group :system_tests do
   gem 'beaker-rspec',    :require => false
   gem 'serverspec',      :require => false

--- a/Rakefile
+++ b/Rakefile
@@ -33,3 +33,10 @@ task :validate do
     sh "bash -n #{shell_script}" unless shell_script =~ /spec\/fixtures/
   end
 end
+
+# Puppet Strings (Documentation generation from inline comments)
+# See: https://github.com/puppetlabs/puppet-strings#rake-tasks
+require 'puppet-strings/tasks'
+
+desc 'Alias for strings:generate'
+task :doc => ['strings:generate']

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -110,9 +110,8 @@ Puppet::Type.newtype(:sensu_redis_config) do
     end
 
     munge do |value|
-      Hash[value.map do |k, v|
-        [k, if k == "port" then v.to_i else v.to_s end]
-      end]
+      hsh_ary = value.map {|k,v| [k, k == "port" ? v.to_i : v.to_s] }
+      Hash[hsh_ary]
     end
   end
 


### PR DESCRIPTION
Build the documentation with `bundle exec rake puppet:strings`

The documentation is generated in every matrix cell for Travis.

RedCarpet is used to support Github Flavored Markdown.

The change to sensu_redis_config.rb is to avoid a bug in YARD, throwing
ArgumentError trying to parse the affected node in the syntax tree.  This patch
changes the code to be compatible with YARD.

Resolves #748