### PR TITLE
Add confd_dir parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -467,6 +467,11 @@
 #   Add/Remove programs.  Note this is distinct from the package filename
 #   identifier specified with windows_package_name.
 #   Default: 'Sensu'
+#
+# [*confd_dir*]
+#   String, Array of strings. Additional directories to load configuration
+#   snippets from.
+#   Default: undef
 
 class sensu (
   Pattern[/^absent$/, /^installed$/, /^latest$/, /^present$/, /^[\d\.\-el]+$/] $version = 'installed',
@@ -582,6 +587,7 @@ class sensu (
   Optional[String]   $windows_choco_repo = undef,
   String             $windows_package_name = 'Sensu',
   String             $windows_package_title = 'sensu',
+  Optional[Variant[Stdlib::Absolutepath,Array[Stdlib::Absolutepath]]] $confd_dir = undef,
   ### START Hiera Lookups###
   Hash               $extensions = {},
   Hash               $handlers = {},

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -4,6 +4,15 @@
 #
 # == Parameters
 #
+# [*conf_dir*]
+#   String. The default configuration directory.
+#   Default: $::sensu::conf_dir
+#
+# [*confd_dir*]
+#   String, Array of strings. Additional directories to load configuration
+#   snippets from.
+#   Default: $::sensu::confd_dir
+#
 # [*deregister_handler*]
 #   String. The handler to use when deregistering a client on stop.
 #   Default: $::sensu::deregister_handler
@@ -48,6 +57,8 @@
 #   Valid values: true, false
 #
 class sensu::package (
+  $conf_dir           = $::sensu::conf_dir,
+  $confd_dir          = $::sensu::confd_dir,
   $deregister_handler = $::sensu::deregister_handler,
   $deregister_on_stop = $::sensu::deregister_on_stop,
   $gem_path           = $::sensu::gem_path,
@@ -199,7 +210,7 @@ class sensu::package (
     }
   }
 
-  file { [ $::sensu::conf_dir, "${sensu::conf_dir}/handlers", "${sensu::conf_dir}/checks", "${sensu::conf_dir}/filters", "${sensu::conf_dir}/extensions", "${sensu::conf_dir}/mutators", "${sensu::conf_dir}/contacts" ]:
+  file { [ $conf_dir, "${conf_dir}/handlers", "${conf_dir}/checks", "${conf_dir}/filters", "${conf_dir}/extensions", "${conf_dir}/mutators", "${conf_dir}/contacts" ]:
     ensure  => directory,
     owner   => $::sensu::user,
     group   => $::sensu::group,

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -15,6 +15,7 @@ describe 'sensu', :type => :class do
     it { should contain_file('/etc/default/sensu').without_content(%r{^CLIENT_DEREGISTER_ON_STOP=true\nCLIENT_DEREGISTER_HANDLER=.*$}) }
     it { should contain_file('/etc/default/sensu').with_content(%r{^SERVICE_MAX_WAIT="10"$}) }
     it { should contain_file('/etc/default/sensu').with_content(%r{^PATH=\$PATH$}) }
+    it { should contain_file('/etc/default/sensu').without_content(%r{^CONFD_DIR=.*$}) }
     it { should_not contain_file('C:/opt/sensu/bin/sensu-client.xml') }
 
     # FIXME: The following resource checks are only testing $sensu_etc_dir specific values
@@ -361,6 +362,16 @@ describe 'sensu', :type => :class do
   context 'path => /spec/tests' do
     let(:params) { {:path => '/spec/tests' } }
     it { should contain_file('/etc/default/sensu').with_content(%r{^PATH=/spec/tests$}) }
+  end
+
+  context 'confd_dir => /spec/tests' do
+    let(:params) { {:confd_dir => '/spec/tests' } }
+    it { should contain_file('/etc/default/sensu').with_content(%r{^CONFD_DIR="/etc/sensu/conf\.d,/spec/tests"$}) }
+  end
+
+  context 'confd_dir => [/spec/tests,/more/tests]' do
+    let(:params) { {:confd_dir => ['/spec/tests', '/more/tests'] } }
+    it { should contain_file('/etc/default/sensu').with_content(%r{^CONFD_DIR="/etc/sensu/conf\.d,/spec/tests,/more/tests"$}) }
   end
 
   context 'with plugins => puppet:///data/sensu/plugins/teststring.rb' do

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -19,6 +19,7 @@ describe 'sensu' do
       it { should contain_file('/etc/default/sensu').without_content(%r{^CLIENT_DEREGISTER_ON_STOP=true\nCLIENT_DEREGISTER_HANDLER=.*$}) }
       it { should contain_file('/etc/default/sensu').with_content(%r{^SERVICE_MAX_WAIT="10"$}) }
       it { should contain_file('/etc/default/sensu').with_content(%r{^PATH=\$PATH$}) }
+      it { should contain_file('/etc/default/sensu').without_content(%r{^CONFD_DIR=.*$}) }
       directories.each do |dir|
         it { should contain_file(dir).with(
           :ensure  => 'directory',
@@ -463,6 +464,16 @@ describe 'sensu' do
   context 'path => /spec/tests' do
     let(:params) { {:path => '/spec/tests' } }
     it { should contain_file('/etc/default/sensu').with_content(%r{^PATH=/spec/tests$}) }
+  end
+
+  context 'confd_dir => /spec/tests' do
+    let(:params) { {:confd_dir => '/spec/tests' } }
+    it { should contain_file('/etc/default/sensu').with_content(%r{^CONFD_DIR="/etc/sensu/conf\.d,/spec/tests"$}) }
+  end
+
+  context 'confd_dir => [/spec/tests,/more/tests]' do
+    let(:params) { {:confd_dir => ['/spec/tests', '/more/tests'] } }
+    it { should contain_file('/etc/default/sensu').with_content(%r{^CONFD_DIR="/etc/sensu/conf\.d,/spec/tests,/more/tests"$}) }
   end
 
   describe 'spawn_limit (#727)' do

--- a/templates/sensu.erb
+++ b/templates/sensu.erb
@@ -13,3 +13,6 @@ CLIENT_DEREGISTER_HANDLER="<%= @deregister_handler %>"
 <% end -%>
 SERVICE_MAX_WAIT="<%= @init_stop_max_wait %>"
 PATH=<%= @path %>
+<% if @confd_dir -%>
+CONFD_DIR="<%= @conf_dir %>,<%= Array(@confd_dir).join(",") %>"
+<% end -%>


### PR DESCRIPTION
This PR adds support for setting `CONFD_DIR` in `/etc/default/sensu` to be able to have multiple configuration directories. I have a use case where I want Puppet to create an additional configuration directory but not have it subject to the same management or purging rules as the default one. See sensu/sensu-omnibus#216 which explains why it's not the documented `CONFIG_DIR` variable.

To keep my employers legal team happy, I have to include the following:

> This contribution is provided 'as is' and without any warranty or guarantee of any kind, express or implied, including in relation to its quality, suitability for a particular purpose or non-infringement. To the extent permitted by law, in no event shall the creator of this contribution be liable for any claim, damage or other liability, whether arising in contract, tort or otherwise, arising out of or in connection with this contribution.