### PR TITLE
[WIP] Remove sensu_check_config and sensu::config types

### DIFF
--- a/lib/puppet_x/sensu/sort_hash.rb
+++ b/lib/puppet_x/sensu/sort_hash.rb
@@ -1,0 +1,21 @@
+module PuppetX
+  module Sensu
+    module SortHash
+      # Given a hash, sort it recursively by the key.  This is intended to
+      # produce stable JSON output.  Only hash maps and nested values which are
+      # a hash map are affected.  Other sequences remain unmodified.  No effort
+      # is made to duplicated nested hashes.  This method is fairly inefficient
+      # because large amounts of data aren't expected as input.
+      #
+      # @param [Hash] hsh the input hash map to sort by key.
+      #
+      # @return [Hash] A new, sorted hash map by key.
+      def sort_hash(hsh)
+        ary = hsh.sort.map do |k,v|
+          Hash === v ? [k, sort_hash(v)] : [k,v]
+        end
+        Hash[ary]
+      end
+    end
+  end
+end

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -107,6 +107,14 @@
 #   Set this to 'absent' to remove it completely.
 #   Default: undef
 #
+# [*config*]
+#   Hash. Map of arbitrary configuration merged at the top level of the output
+#   JSON object.  This property is intended to configure plugins and extensions,
+#   e.g.
+#   [sensu-plugins-mailer](https://github.com/sensu-plugins/sensu-plugins-mailer)
+#   Default: undef
+#   Example: { 'mailer' => { 'mail_from' => 'sensu@example.com', 'mail_to' => 'monitor@example.com'} }
+
 # [*custom*]
 #   Hash. List of custom attributes to include in the check. You can use it to pass any attribute that is not listed here explicitly.
 #   Default: undef
@@ -150,6 +158,7 @@ define sensu::check (
   Variant[Undef,Enum['absent'],Boolean] $handle = undef,
   Variant[Undef,Enum['absent'],Boolean] $publish = undef,
   Variant[Undef,String,Array]           $dependencies = undef,
+  Optional[Hash]                        $config = undef,
   Optional[Hash]                        $custom = undef,
   Variant[Undef,Enum['absent'],Integer] $ttl = undef,
   Variant[Undef,Enum['absent'],Hash]    $subdue = undef,
@@ -235,6 +244,7 @@ define sensu::check (
     handle              => $handle,
     publish             => $publish,
     dependencies        => $dependencies,
+    config              => $config,
     custom              => $custom,
     subdue              => $subdue,
     proxy_requests      => $proxy_requests,

--- a/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_input.2.json
+++ b/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_input.2.json
@@ -1,0 +1,23 @@
+{
+  "checks": {
+    "foo": "bar",
+    "baz": ["q","u","x"],
+    "remote_http": {
+      "command": "/opt/sensu/embedded/bin/check-http.rb -u http://:::address:::",
+      "high_flap_threshold": 60,
+      "interval": 300,
+      "low_flap_threshold": 20,
+      "occurrences": 2,
+      "proxy_requests": {
+        "client_attributes": {
+          "subscriptions": "eval: value.include?(\"http\")"
+        }
+      },
+      "refresh": 600,
+      "standalone": false,
+      "subscribers": [
+        "roundrobin:poller"
+      ]
+    }
+  }
+}

--- a/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_input.json
+++ b/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_input.json
@@ -1,0 +1,25 @@
+{
+  "mailer": {
+    "mail_from": "sensu@example.com",
+    "mail_to": "monitor@example.com"
+  },
+  "checks": {
+    "remote_http": {
+      "command": "/opt/sensu/embedded/bin/check-http.rb -u http://:::address:::",
+      "high_flap_threshold": 60,
+      "interval": 300,
+      "low_flap_threshold": 20,
+      "occurrences": 2,
+      "proxy_requests": {
+        "client_attributes": {
+          "subscriptions": "eval: value.include?(\"http\")"
+        }
+      },
+      "refresh": 600,
+      "standalone": false,
+      "subscribers": [
+        "roundrobin:poller"
+      ]
+    }
+  }
+}

--- a/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_output.0.json
+++ b/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_output.0.json
@@ -1,0 +1,22 @@
+{
+  "checks": {
+    "remote_http": {
+      "command": "/opt/sensu/embedded/bin/check-http.rb -u http://:::address:::",
+      "high_flap_threshold": 60,
+      "interval": 300,
+      "low_flap_threshold": 20,
+      "occurrences": 2,
+      "proxy_requests": {
+        "client_attributes": {
+          "subscriptions": "eval: value.include?(\"http\")"
+        }
+      },
+      "refresh": 600,
+      "standalone": false,
+      "subscribers": [
+        "roundrobin:poller"
+      ]
+    }
+  },
+  "foo": "bar"
+}

--- a/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_output.1.json
+++ b/spec/fixtures/unit/provider/sensu_check/json/mycheck_config_output.1.json
@@ -1,0 +1,23 @@
+{
+  "baz": "qux",
+  "checks": {
+    "remote_http": {
+      "command": "/opt/sensu/embedded/bin/check-http.rb -u http://:::address:::",
+      "high_flap_threshold": 60,
+      "interval": 300,
+      "low_flap_threshold": 20,
+      "occurrences": 2,
+      "proxy_requests": {
+        "client_attributes": {
+          "subscriptions": "eval: value.include?(\"http\")"
+        }
+      },
+      "refresh": 600,
+      "standalone": false,
+      "subscribers": [
+        "roundrobin:poller"
+      ]
+    }
+  },
+  "foo": "bar"
+}

--- a/spec/unit/provider/sensu_check/json_spec.rb
+++ b/spec/unit/provider/sensu_check/json_spec.rb
@@ -71,8 +71,8 @@ describe Puppet::Type.type(type_id).provider(:json) do
     resource.provider
   end
 
-  context 'during catalog application' do
-    describe 'parameters (provide data)' do
+  context 'applying a catalog' do
+    describe 'parameter' do
       describe '#name' do
         subject { provider.name }
         it { is_expected.to eq title }
@@ -80,94 +80,177 @@ describe Puppet::Type.type(type_id).provider(:json) do
     end
 
     # Properties modify the system.  Parameters add supporting data.
-    describe 'properties (take action)' do
-      describe 'when writing JSON data to the filesystem with #flush' do
-        describe '#custom' do
-          context 'with a pre-existing check definition' do
-            # An existing JSON file the provider will modify.
+    describe 'property' do
+      # Stub out the filesystem read with fixture data
+      before :each do
+        expect(provider).to receive(:read_file).and_return(input)
+      end
+
+      describe '#config' do
+        subject { provider.config }
+        context 'with a pre-existing json file' do
+          context 'containing only the check configuration itself' do
             let(:input) do
               File.read(my_fixture('mycheck_example_input.json'))
             end
-            # Stub out the filesystem read with fixture data
-            before :each do
-              allow(provider).to receive(:read_file).and_return(input)
+
+            it { is_expected.to eq({}) }
+          end
+
+          context 'containing mailer plugin configuration' do
+            let(:input) do
+              File.read(my_fixture('mycheck_config_input.json'))
             end
 
-            subject { provider.custom }
+            let(:expected) do
+              {'mailer'=>{'mail_from'=>'sensu@example.com','mail_to'=>'monitor@example.com'}}
+            end
 
-            context 'without custom configuration' do
-              it { is_expected.to eq({}) }
+            it { is_expected.to eq(expected) }
+          end
+
+          context 'containing configuration nested in the "checks" map' do
+            let(:input) do
+              File.read(my_fixture('mycheck_config_input.2.json'))
             end
-            context 'with custom configuration' do
-              let(:input) do
-                File.read(my_fixture('mycheck_custom_input.json'))
-              end
-              it { is_expected.to eq({'foo' => 'bar'}) }
+
+            let(:expected) do
+              {'checks'=>{'foo'=>'bar', 'baz'=>['q', 'u', 'x']}}
             end
+
+            it { is_expected.to eq(expected) }
           end
         end
+      end
 
-        describe '#custom=' do
-          context 'with pre-existing configuration on the system' do
-            # An existing JSON file the provider will modify.
-            let(:input) do
-              File.read(my_fixture('mycheck_example_input.json'))
-            end
+      describe '#config=' do
+        context 'with a pre-existing json file' do
+          # An existing JSON file the provider will modify.
+          let(:input) do
+            File.read(my_fixture('mycheck_example_input.json'))
+          end
 
-            let(:expected_output) do
-              File.read(my_fixture('mycheck_expected_output.json'))
-            end
+          valid_configs = [
+            { 'foo' => 'bar' },
+            { 'foo' => 'bar', 'baz' => 'qux' },
+          ]
 
-            before :each do
-              # The fixed input for testing.  This is an expectation so a
-              # failure is triggered if the stub becomes mis-matched with the
-              # implemented behavior.
-              expect(provider).to receive(:read_file).and_return(input)
-            end
-
-            context 'with custom defined' do
-              # Example value for the custom property from the README
-              let(:custom) do
-                {
-                  'foo'      => 'bar',
-                  'numval'   => 6,
-                  'boolval'  => true,
-                  'in_array' => ['foo','baz'],
-                }
+          valid_configs.each_with_index do |config, idx|
+            context "and config => #{config.inspect}" do
+              let(:expected_output) do
+                File.read(my_fixture("mycheck_config_output.#{idx}.json"))
               end
 
-              # The desired state from the catalog
-              let(:rsrc_hsh_override) { {custom: custom} }
+              let(:rsrc_hsh_override) { {config: config} }
 
-              it 'writes the configuration file as a JSON object' do
+              it 'writes a JSON file to the filesystem' do
                 # TODO: Would be nice to make this a shared expectation
                 expect(provider).to receive(:write_json_object) do |fp, obj|
                   expect(fp).to eq(provider.config_file)
                   ex_out = JSON.parse(expected_output)
-                  check_def = ex_out['checks']['remote_http']
+                  check_map = ex_out['checks']['remote_http']
                   # This gives a nice diff if there is an issue
-                  expect(obj['checks']['remote_http']).to eq(check_def)
+                  expect(obj['checks']['remote_http']).to eq(check_map)
                   # This tests the complete configuration
                   expect(obj).to eq(ex_out)
                 end
 
-                provider.custom = custom
+                provider.config = config
                 provider.flush
               end
-            end
 
-            context 'with unsorted input JSON' do
-              let(:input) do
-                File.read(my_fixture('mycheck_unsorted_input.json'))
-              end
               it 'writes sorted JSON output' do
                 expect(described_class).to receive(:write_output) do |_, data|
                   # Trailing newlines must match to get a nice diff
                   # See: https://github.com/rspec/rspec-support/issues/70
                   expect(data).to eq(expected_output.chomp)
                 end
+                provider.config = config
                 provider.flush
               end
+            end
+          end
+        end
+      end
+
+      describe '#custom' do
+        context 'with a pre-existing check definition' do
+          # An existing JSON file the provider will modify.
+          let(:input) do
+            File.read(my_fixture('mycheck_example_input.json'))
+          end
+          # Stub out the filesystem read with fixture data
+          before :each do
+            allow(provider).to receive(:read_file).and_return(input)
+          end
+
+          subject { provider.custom }
+
+          context 'without custom configuration' do
+            it { is_expected.to eq({}) }
+          end
+          context 'with custom configuration' do
+            let(:input) do
+              File.read(my_fixture('mycheck_custom_input.json'))
+            end
+            it { is_expected.to eq({'foo' => 'bar'}) }
+          end
+        end
+      end
+
+      describe '#custom=' do
+        context 'with a pre-existing json file' do
+          # An existing JSON file the provider will modify.
+          let(:input) do
+            File.read(my_fixture('mycheck_example_input.json'))
+          end
+
+          let(:expected_output) do
+            File.read(my_fixture('mycheck_expected_output.json'))
+          end
+
+          context 'with custom defined' do
+            # Example value for the custom property from the README
+            let(:custom) do
+              {
+                'foo'      => 'bar',
+                'numval'   => 6,
+                'boolval'  => true,
+                'in_array' => ['foo','baz'],
+              }
+            end
+
+            # The desired state from the catalog
+            let(:rsrc_hsh_override) { {custom: custom} }
+
+            it 'writes the configuration file as a JSON object' do
+              # TODO: Would be nice to make this a shared expectation
+              expect(provider).to receive(:write_json_object) do |fp, obj|
+                expect(fp).to eq(provider.config_file)
+                ex_out = JSON.parse(expected_output)
+                check_def = ex_out['checks']['remote_http']
+                # This gives a nice diff if there is an issue
+                expect(obj['checks']['remote_http']).to eq(check_def)
+                # This tests the complete configuration
+                expect(obj).to eq(ex_out)
+              end
+
+              provider.custom = custom
+              provider.flush
+            end
+          end
+
+          context 'with unsorted input JSON' do
+            let(:input) do
+              File.read(my_fixture('mycheck_unsorted_input.json'))
+            end
+            it 'writes sorted JSON output' do
+              expect(described_class).to receive(:write_output) do |_, data|
+                # Trailing newlines must match to get a nice diff
+                # See: https://github.com/rspec/rspec-support/issues/70
+                expect(data).to eq(expected_output.chomp)
+              end
+              provider.flush
             end
           end
         end

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -11,6 +11,29 @@ describe Puppet::Type.type(:sensu_check) do
   let(:resource_hash_override) { {} }
   let(:resource_hash) { resource_hash_base.merge(resource_hash_override) }
 
+  describe 'config property' do
+    subject { described_class.new(resource_hash)[:config] }
+
+    valid = [{}, {'mailer' => {}}, {'mailer' => {'smtp_port' => '25'}}]
+    invalid = ['', 12, [1,2,3]]
+
+    valid.each do |val|
+      describe "valid: config => #{val.inspect} " do
+        let(:resource_hash_override) { {config: val} }
+        it { is_expected.to eq val }
+      end
+    end
+
+    invalid.each do |val|
+      describe "invalid: config => #{val.inspect}" do
+        let(:resource_hash_override) { {config: val} }
+        it do
+          expect { subject }.to raise_error Puppet::ResourceError, /Not a Hash/
+        end
+      end
+    end
+  end
+
   describe 'contacts parameter' do
     subject { described_class.new(resource_hash)[:contacts] }
 


### PR DESCRIPTION
Checklist:

 - [x] Add `config` property to sensu::check
 - [x] Ensure JSON maps are written in sort-order from the top level rather
   than the nested level of checks.mycheck.properties
 - [ ] Test arbitrary config already exists, does the default of {} prune it?  It shouldn't be removed by default, it should be preserved if config is undef.
 - [ ] Test arbitrary config already exists, does specifying `config => { 'foo' => 'bar' }` remove it?
 - [ ] Test arbitrary config nested under `"checks"` at the same level as `"mycheck"`.  Is it removed when `config => { 'foo' => 'bar' }`?  It should be.
 - [ ] Test the behavior when the config file doesn't exist at all.
 - [ ] Remove sensu_check_config and sensu::config related files.

Add config property to sensu::check and sensu_check

Without this patch there is no way to specify arbitrary configuration at the top
level of the sensu check configuration object.  This patch addresses the problem
by adding a new property to sensu::check and sensu_check named `config`.  This
property accepts a Hash map and merges all other configuration on top of this
base starting point.

This patch also adds a new mix-in method, `PuppetX::Sensu::SortHash#sort_hash`.
This method returns a hash sorted recursively, meaning all nested hash values
are sorted in the same manner.  This method is intended for use in the #flush
method of all Sensu providers.

Resolves #764