### PR TITLE
(#783) Add sensu::check content parameter, use sensu::write_json

### DIFF
--- a/manifests/write_json.pp
+++ b/manifests/write_json.pp
@@ -25,6 +25,10 @@
 # @param content The hash content that will be converted to json
 #   and written into the target config file.
 #
+# [*notify_list*]
+#   Array. A listing of resources to notify upon changes to the target JSON
+#          file.
+#   Default: []
 define sensu::write_json (
   Enum['present', 'absent'] $ensure = 'present',
   String                    $owner = 'sensu',
@@ -32,6 +36,7 @@ define sensu::write_json (
   String                    $mode = '0755',
   Boolean                   $pretty = true,
   Hash                      $content = {},
+  Array                     $notify_list = [],
 ) {
 
   # ensure we have a properly formatted file path for our target OS
@@ -52,5 +57,6 @@ define sensu::write_json (
     group   => $group,
     mode    => $mode,
     content => sensu_sorted_json($content, $pretty),
+    notify  => $notify_list,
   }
 }

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -526,7 +526,7 @@ describe 'sensu', :type => :class do
       }
     } }
 
-    it { should contain_sensu_check('some-check').with(
+    it { should contain_sensu__check('some-check').with(
       :type        => 'pipe',
       :command     => '/usr/local/bin/some-check',
       :occurrences => '1',
@@ -534,7 +534,7 @@ describe 'sensu', :type => :class do
     ) }
     it { should contain_file('/etc/sensu/conf.d/checks/some-check.json') }
 
-    it { should contain_sensu_check('check-cpu').with(
+    it { should contain_sensu__check('check-cpu').with(
       :type        => 'pipe',
       :command     => '/usr/local/bin/check-cpu.rb',
       :occurrences => '5',

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -12,13 +12,73 @@ describe 'sensu::check', :type => :define do
   let(:params_base) {{ command: '/etc/sensu/somecommand.rb' }}
   let(:params_override) {{}}
   let(:params) { params_base.merge(params_override) }
+  # The default, basic output
+  let :expected_content do
+    JSON.parse(File.read(my_fixture('expected_check_mycheck.json')))
+  end
+
+  # The target file path
+  let(:fpath) { "/etc/sensu/conf.d/checks/#{title}.json" }
+  # (#783) Using sensu::write_json
+  context 'with content' do
+    let :expected_content do
+      JSON.parse(File.read(my_fixture('expected_check_with_mailer_content.json')))
+    end
+
+    context 'containing sensu-plugins-mailer configuration' do
+      let(:params_override) do
+        {content: {'mailer' => {'mail_from' => 'sensu@example.com', 'mail_to' => 'alert@example.com'}}}
+      end
+      it { should contain_sensu__write_json(fpath).with(
+        content: expected_content,
+      ) }
+    end
+
+    context 'containing {"checks": {"mycheck": {"foo": "bar"}}}' do
+      let :expected_content do
+        JSON.parse(File.read(my_fixture('expected_check_mycheck.json')))
+      end
+      let(:params_override) do
+        {content: {'checks' => {'mycheck' => {'foo' => 'bar'}}}}
+      end
+      # `custom` overrides `content` at the check scope level.
+      it { should contain_sensu__write_json(fpath).with(
+        content: expected_content,
+      ) }
+    end
+
+    context 'containing {"checks": {"othercheck": {"foo": "bar"}}}' do
+      let :expected_content do
+        JSON.parse(File.read(my_fixture('expected_check_with_othercheck_content.json')))
+      end
+      let(:params_override) do
+        {content: {'checks' => {'othercheck' => {'foo' => 'bar'}}}}
+      end
+      # `custom` overrides `content` at the check scope level.
+      it { should contain_sensu__write_json(fpath).with(
+        content: expected_content,
+      ) }
+    end
+  end
 
   context 'without whitespace in name' do
     context 'defaults' do
-      it { should contain_sensu_check('mycheck').with(
-        :command     => '/etc/sensu/somecommand.rb',
-        :interval    => 60
-      ) }
+      let :expected_content do
+        {
+          'checks' => {
+            'mycheck' => {
+              'command' => '/etc/sensu/somecommand.rb',
+              'interval' => 60,
+              'standalone' => true,
+            },
+          },
+        }
+      end
+
+      it do
+        rsrc_hsh = { content: expected_content }
+        should contain_sensu__write_json(fpath).with(rsrc_hsh)
+      end
     end
 
     context 'setting params' do
@@ -42,36 +102,43 @@ describe 'sensu::check', :type => :define do
         :ttl                 => 30
       } }
 
-      it { should contain_sensu_check('mycheck').with(
-        :command             => '/etc/sensu/command2.rb',
-        :handlers            => ['/handler1', '/handler2'],
-        :interval            => 10,
-        :occurrences         => 5,
-        :refresh             => 3600,
-        :subscribers         => ['all'],
-        :custom              => { 'remediation' => { 'low_remediation' => { 'occurrences' => [1,2], 'severities' => [1], 'command' => "/bin/command", 'publish' => false, } } },
-        :type                => 'metric',
-        :standalone          => true,
-        :low_flap_threshold  => 10,
-        :high_flap_threshold => 15,
-        :timeout             => 0.5,
-        :aggregate           => 'my_aggregate',
-        :aggregates          => ['aggregate_1', 'aggregate_2'],
-        :handle              => true,
-        :publish             => true,
-        :ttl                 => 30
-      ) }
+      it do should contain_sensu__write_json(fpath).with(
+        content: {
+          'checks' => {
+            'mycheck' => {
+              'command'             => '/etc/sensu/command2.rb',
+              'handlers'            => ['/handler1', '/handler2'],
+              'interval'            => 10,
+              'occurrences'         => 5,
+              'refresh'             => 3600,
+              'subscribers'         => ['all'],
+              'remediation'         => { 'low_remediation' => { 'occurrences' => [1,2], 'severities' => [1], 'command' => "/bin/command", 'publish' => false, } },
+              'type'                => 'metric',
+              'standalone'          => true,
+              'low_flap_threshold'  => 10,
+              'high_flap_threshold' => 15,
+              'timeout'             => 0.5,
+              'aggregate'           => 'my_aggregate',
+              'aggregates'          => ['aggregate_1', 'aggregate_2'],
+              'handle'              => true,
+              'publish'             => true,
+              'ttl'                 => 30
+            }
+          }
+        }
+      )
+      end
     end
 
     context 'ensure absent' do
       let(:params) { { :command => '/etc/sensu/somecommand.rb', :ensure => 'absent' } }
 
-      it { should contain_sensu_check('mycheck').with_ensure('absent') }
+      it { should contain_sensu__write_json(fpath).with_ensure('absent') }
     end
 
-    context 'ensure absent with command undefiend' do
+    context 'ensure absent with command undefined' do
       let(:params) { { :ensure => 'absent' } }
-      it { should contain_sensu_check('mycheck').with_ensure('absent') }
+      it { should contain_sensu__write_json(fpath).with_ensure('absent') }
     end
 
     context 'ensure present with command undefiend' do
@@ -104,93 +171,72 @@ describe 'sensu::check', :type => :define do
         :type                => 'absent'
       } }
 
-      it { should contain_sensu_check('mycheck').with(
-        :command             => '/etc/sensu/command2.rb',
-        :aggregate           => :absent,
-        :aggregates          => :absent,
-        :dependencies        => :absent,
-        :handle              => :absent,
-        :handlers            => :absent,
-        :high_flap_threshold => :absent,
-        :interval            => :absent,
-        :low_flap_threshold  => :absent,
-        :occurrences         => :absent,
-        :publish             => :absent,
-        :refresh             => :absent,
-        :source              => :absent,
-        :standalone          => :absent,
-        :subdue              => :absent,
-        :subscribers         => :absent,
-        :timeout             => :absent,
-        :ttl                 => :absent,
-        :type                => :absent
-      ) }
+      let :expected_content do
+        {"checks"=>{"mycheck"=>{"command"=>"/etc/sensu/command2.rb"}}}
+      end
+
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
   end
 
   context 'with whitespace in name' do
     let(:title) { 'mycheck foobar' }
-    context 'defaults' do
-      it { should contain_sensu_check('mycheck_foobar').with(
-        :command     => '/etc/sensu/somecommand.rb',
-        :interval    => '60'
-      ) }
+    let(:fpath) { '/etc/sensu/conf.d/checks/mycheck_foobar.json' }
 
-      it { should contain_file('/etc/sensu/conf.d/checks/mycheck_foobar.json') }
+    context 'defaults' do
+      it { should contain_sensu__write_json(fpath) }
+      it { should contain_file(fpath) }
     end
   end
 
-  context 'with brackets in name' do
+  context 'with parentheses in name' do
     let(:title) { 'mycheck (foo) bar' }
+    let(:fpath) { '/etc/sensu/conf.d/checks/mycheck_foo_bar.json' }
     context 'defaults' do
-      it { should contain_sensu_check('mycheck_foo_bar').with(
-        'command'     => '/etc/sensu/somecommand.rb',
-        'interval'    => '60'
-      ) }
-
-      it { should contain_file('/etc/sensu/conf.d/checks/mycheck_foo_bar.json') }
+      it { should contain_sensu__write_json(fpath) }
+      it { should contain_file(fpath) }
     end
   end
 
   context 'notifications' do
     context 'no client, sever, or api' do
       let(:pre_condition) { 'class {"sensu": client => false, api => false, server => false}' }
-      it { should contain_sensu_check('mycheck').with(:notify => []) }
+      it { should contain_file(fpath).with(:notify => []) }
     end
 
     context 'only client' do
       let(:pre_condition) { 'class {"sensu": client => true, api => false, server => false}' }
-      it { should contain_sensu_check('mycheck').with(:notify => ['Class[Sensu::Client::Service]'] ) }
+      it { should contain_file(fpath).with(:notify => ['Class[Sensu::Client::Service]'] ) }
     end
 
     context 'only server' do
       let(:pre_condition) { 'class {"sensu": client => false, api => false, server => true}' }
-      it { should contain_sensu_check('mycheck').with(:notify => ['Class[Sensu::Server::Service]'] ) }
+      it { should contain_file(fpath).with(:notify => ['Class[Sensu::Server::Service]'] ) }
     end
 
     context 'only api' do
       let(:pre_condition) { 'class {"sensu": client => false, api => true, server => false}' }
-      it { should contain_sensu_check('mycheck').with(:notify => ['Class[Sensu::Api::Service]'] ) }
+      it { should contain_file(fpath).with(:notify => ['Class[Sensu::Api::Service]'] ) }
     end
 
     context 'client and api' do
       let(:pre_condition) { 'class {"sensu": client => true, api => true, server => false}' }
-      it { should contain_sensu_check('mycheck').with(:notify => ['Class[Sensu::Client::Service]', 'Class[Sensu::Api::Service]']) }
+      it { should contain_file(fpath).with(:notify => ['Class[Sensu::Client::Service]', 'Class[Sensu::Api::Service]']) }
     end
 
     context 'client and server' do
       let(:pre_condition) { 'class {"sensu": client => true, api => false, server => true}' }
-      it { should contain_sensu_check('mycheck').with(:notify => ['Class[Sensu::Client::Service]', 'Class[Sensu::Server::Service]']) }
+      it { should contain_file(fpath).with(:notify => ['Class[Sensu::Client::Service]', 'Class[Sensu::Server::Service]']) }
     end
 
     context 'api and server' do
       let(:pre_condition) { 'class {"sensu": client => false, api => true, server => true}' }
-      it { should contain_sensu_check('mycheck').with(:notify => ['Class[Sensu::Server::Service]', 'Class[Sensu::Api::Service]']) }
+      it { should contain_file(fpath).with(:notify => ['Class[Sensu::Server::Service]', 'Class[Sensu::Api::Service]']) }
     end
 
     context 'client, api, and server' do
       let(:pre_condition) { 'class {"sensu": client => true, api => true, server => true}' }
-      it { should contain_sensu_check('mycheck').with(:notify => ['Class[Sensu::Client::Service]', 'Class[Sensu::Server::Service]', 'Class[Sensu::Api::Service]']) }
+      it { should contain_file(fpath).with(:notify => ['Class[Sensu::Client::Service]', 'Class[Sensu::Server::Service]', 'Class[Sensu::Api::Service]']) }
     end
   end
 
@@ -216,7 +262,11 @@ describe 'sensu::check', :type => :define do
         }
       }
 
-      it { should contain_sensu_check('mycheck').with_subdue( {'days'=>{'monday'=>[{'begin'=>'12:00:00 AM PST', 'end'=>'9:00:00 AM PST'}, {'begin'=>'5:00:00 PM PST', 'end'=>'11:59:59 PM PST'}]}} ) }
+      let(:expected_content) do
+        {"checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60, "subdue"=>{"days"=>{"monday"=>[{"begin"=>"12:00:00 AM PST", "end"=>"9:00:00 AM PST"}, {"begin"=>"5:00:00 PM PST", "end"=>"11:59:59 PM PST"}]}}}}}
+      end
+
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
 
     context 'invalid subdue hash' do
@@ -241,7 +291,7 @@ describe 'sensu::check', :type => :define do
         }
       }
 
-      it { should contain_sensu_check('mycheck').with_subdue(:absent) }
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
 
     context '= undef' do
@@ -251,7 +301,7 @@ describe 'sensu::check', :type => :define do
         }
       }
 
-      it { should contain_sensu_check('mycheck').without_subdue }
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
   end
 
@@ -261,7 +311,11 @@ describe 'sensu::check', :type => :define do
         { proxy_requests: { 'client_attributes' => { 'subscriptions' => 'eval: value.include?("http")' } } }
       end
 
-      it { should contain_sensu_check('mycheck').with_proxy_requests(params_override[:proxy_requests]) }
+      let :expected_content do
+        {"checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60, "proxy_requests"=>{"client_attributes"=>{"subscriptions"=>"eval: value.include?(\"http\")"}}}}}
+      end
+
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
 
     context 'invalid proxy_requests hash' do
@@ -272,36 +326,39 @@ describe 'sensu::check', :type => :define do
     context '=> \'absent\'' do
       let(:params_override) { { proxy_requests: 'absent' } }
 
-      it { should contain_sensu_check('mycheck').with_proxy_requests(:absent) }
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
 
     context '= undef' do
-      it { should contain_sensu_check('mycheck').without_proxy_requests }
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
   end
 
   describe 'param cron' do
     context 'default behavior (not specified)' do
       let(:params_override) { {} }
-      it { is_expected.to contain_sensu_check('mycheck').with(cron: 'absent') }
-      it { is_expected.to contain_sensu_check('mycheck').with(interval: 60) }
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
     end
 
-    context 'without interval' do
-      let(:params_override) { {cron: '*/5 * * * *'} }
-      it { is_expected.to contain_sensu_check('mycheck').with(cron: params[:cron]) }
-      it { is_expected.to contain_sensu_check('mycheck').with(interval: 'absent') }
-    end
+    context 'specifying cron' do
+      let :expected_content do
+        {"checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "cron"=>"*/5 * * * *"}}}
+      end
 
-    context 'with interval' do
-      let(:params_override) { {cron: '*/5 * * * *', interval: 99} }
-      it { is_expected.to contain_sensu_check('mycheck').with(cron: params[:cron]) }
-      it { is_expected.to contain_sensu_check('mycheck').with(interval: 'absent') }
+      context 'without interval' do
+        let(:params_override) { {cron: '*/5 * * * *'} }
+        it { should contain_sensu__write_json(fpath).with_content(expected_content) }
+      end
+
+      context 'with interval' do
+        let(:params_override) { {cron: '*/5 * * * *', interval: 99} }
+        it { should contain_sensu__write_json(fpath).with_content(expected_content) }
+      end
     end
   end
 
   describe 'relationships (#463)' do
     let(:expected) { { notify: ["Sensu::Check[#{title}]"] } }
-    it { is_expected.to contain_anchor('plugins_before_checks').with(expected)}
+    it { should contain_anchor('plugins_before_checks').with(expected)}
   end
 end

--- a/spec/defines/sensu_write_json_spec.rb
+++ b/spec/defines/sensu_write_json_spec.rb
@@ -34,7 +34,7 @@ describe 'sensu::write_json', :type => :define do
         :owner => 'sensu',
         :group => 'sensu',
         :content => CUSTOM_CFG_PRETTY,
-        :notify => nil,
+        :notify => [],
         :subscribe => nil,
       ) }
     end
@@ -49,7 +49,7 @@ describe 'sensu::write_json', :type => :define do
         :owner => 'sensu',
         :group => 'sensu',
         :mode => '0755',
-        :notify => nil,
+        :notify => [],
         :subscribe => nil,
       ) }
     end
@@ -96,7 +96,7 @@ describe 'sensu::write_json', :type => :define do
         :owner => 'sensu',
         :group => 'sensu',
         :content => "{\"custom\":\"data\"}",
-        :notify => nil,
+        :notify => [],
         :subscribe => nil,
       ) }
     end

--- a/spec/fixtures/defines/sensu_check/expected_check_mycheck.json
+++ b/spec/fixtures/defines/sensu_check/expected_check_mycheck.json
@@ -1,0 +1,9 @@
+{
+  "checks": {
+    "mycheck": {
+      "command": "/etc/sensu/somecommand.rb",
+      "interval": 60,
+      "standalone": true
+    }
+  }
+}

--- a/spec/fixtures/defines/sensu_check/expected_check_with_mailer_content.json
+++ b/spec/fixtures/defines/sensu_check/expected_check_with_mailer_content.json
@@ -1,0 +1,13 @@
+{
+  "checks": {
+    "mycheck": {
+      "command": "/etc/sensu/somecommand.rb",
+      "interval": 60,
+      "standalone": true
+    }
+  },
+  "mailer": {
+    "mail_from": "sensu@example.com",
+    "mail_to": "alert@example.com"
+  }
+}

--- a/spec/fixtures/defines/sensu_check/expected_check_with_othercheck_content.json
+++ b/spec/fixtures/defines/sensu_check/expected_check_with_othercheck_content.json
@@ -1,0 +1,12 @@
+{
+  "checks": {
+    "mycheck": {
+      "command": "/etc/sensu/somecommand.rb",
+      "interval": 60,
+      "standalone": true
+    },
+    "othercheck": {
+      "foo": "bar"
+    }
+  }
+}


### PR DESCRIPTION
sensu::write_json
===

Without this patch arbitrary to-level configuration scope items cannot be
managed in a sensu check.  This patch addresses the problem by adding a
`content` parameter to the sensu::check defined type.

This patch changes the defined type to pass a JSON object to sensu::write_json
instead of passing each named property to the sensu_check custom type.
sensu::write_json is used to ensure all attributes in a configuration file are
manageable and arbitrary attributes need only be placed in the `content` hash
map, or have a new parameter defined in the `sensu::check` defined type.

When adding a new parameter, as long as the parameter and value are passed as a
key/value pare to the `sensu_check_content()` function, the attribute and value
will be placed in the check configuration scope under checks.mycheck.  The same
behavior may be achieved by passing the key and value via the `custom`
parameter.

The ultimate goal of this work is to eliminate the `custom` parameter and
eventually refactor all defined types in the Puppet module to use
sensu::write_json and this approach.

Remaining work
===

 - [x] Fix failing tests which are now marked pending.
 - [x] Add new expectations and fixture data for the expected output of
       sensu::check via the content property of sensu::write_json.
 - [x] Vagrant testing of example checks, ensure backwards compatibility.

Resolves #783