### PR TITLE
(#784) Fix Sensu Enterprise API SSL configuration scope

### DIFF
--- a/lib/puppet/provider/sensu_api_config/json.rb
+++ b/lib/puppet/provider/sensu_api_config/json.rb
@@ -13,9 +13,15 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   def conf
     begin
       @conf ||= JSON.parse(File.read(config_file))
+      # (#784) Filter out ssl_port, ssl_keystore_file, and ssl_keystore_password
+      if @conf['api'].is_a?(Hash)
+        exclude_keys = %w(ssl_port ssl_keystore_file ssl_keystore_password)
+        @conf['api'].delete_if { |k,_| exclude_keys.include?(k) }
+      end
     rescue
       @conf ||= {}
     end
+    return @conf
   end
 
   # Public: Save changes to the API section of /etc/sensu/config.json to disk.
@@ -127,7 +133,9 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   #
   # Returns the String port number.
   def ssl_port
-    conf['api']['ssl_port'].to_s
+    if conf['api']['ssl'].is_a? Hash
+      conf['api']['ssl']['port']
+    end
   end
 
   # Public: Set the HTTPS (SSL) port that the API should listen on. Enterprise
@@ -135,7 +143,10 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   #
   # Returns nothing.
   def ssl_port=(value)
-    conf['api']['ssl_port'] = value.to_i
+    if not conf['api']['ssl'].is_a? Hash
+      conf['api']['ssl'] = {}
+    end
+    conf['api']['ssl']['port'] = value.to_i
   end
 
   # Public: Retrieve the file path for the SSL certificate keystore. Enterprise
@@ -143,7 +154,9 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   #
   # Returns the String password.
   def ssl_keystore_file
-    conf['api']['ssl_keystore_file']
+    if conf['api']['ssl'].is_a? Hash
+      conf['api']['ssl']['keystore_file']
+    end
   end
 
   # Public: Set the file path for the SSL certificate keystore. Enterprise only
@@ -151,7 +164,10 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   #
   # Returns nothing.
   def ssl_keystore_file=(value)
-    conf['api']['ssl_keystore_file'] = value
+    if not conf['api']['ssl'].is_a? Hash
+      conf['api']['ssl'] = {}
+    end
+    conf['api']['ssl']['keystore_file'] = value
   end
 
   # Public: Retrieve the SSL certificate keystore password. Enterprise only
@@ -159,13 +175,18 @@ Puppet::Type.type(:sensu_api_config).provide(:json) do
   #
   # Returns the String password.
   def ssl_keystore_password
-    conf['api']['ssl_keystore_password']
+    if conf['api']['ssl'].is_a? Hash
+      conf['api']['ssl']['keystore_password']
+    end
   end
 
   # Public: Set the SSL certificate keystore password. Enterprise only feature.
   #
   # Returns nothing.
   def ssl_keystore_password=(value)
-    conf['api']['ssl_keystore_password'] = value
+    if not conf['api']['ssl'].is_a? Hash
+      conf['api']['ssl'] = {}
+    end
+    conf['api']['ssl']['keystore_password'] = value
   end
 end

--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -28,7 +28,11 @@ Puppet::Type.newtype(:sensu_api_config) do
   newproperty(:port) do
     desc "The port that the Sensu API is listening on"
 
-    defaultto '4567'
+    defaultto 4567
+
+    munge do |value|
+      value.to_i
+    end
   end
 
   newproperty(:host) do
@@ -58,6 +62,9 @@ Puppet::Type.newtype(:sensu_api_config) do
 
   newproperty(:ssl_port) do
     desc "Port of the HTTPS (SSL) sensu api service. Enterprise only feature."
+    munge do |value|
+      value.to_i
+    end
   end
 
   newproperty(:ssl_keystore_file) do

--- a/tests/sensu-server-enterprise.pp
+++ b/tests/sensu-server-enterprise.pp
@@ -22,15 +22,6 @@
 #
 node 'sensu-server' {
 
-  Ini_setting {
-    ensure            => present,
-    path              => '/etc/default/sensu',
-    key_val_separator => '=',
-    show_diff         => true,
-    require           => Package['sensu-enterprise'],
-    notify            => Service['sensu-enterprise'],
-  }
-
   file { 'api.keystore':
     ensure => 'file',
     path   => '/etc/sensu/api.keystore',
@@ -56,6 +47,7 @@ node 'sensu-server' {
     api_ssl_port              => '4568',
     api_ssl_keystore_file     => '/etc/sensu/api.keystore',
     api_ssl_keystore_password => 'sensutest',
+    heap_size                 => '256m',
   }
 
   sensu::handler { 'default':
@@ -95,11 +87,5 @@ node 'sensu-server' {
     handlers    => 'email',
     contacts    => ['ops', 'support'],
     subscribers => 'sensu-test',
-  }
-
-  # Tune the JVM Heap size for Sensu Enterprise on Vagrant
-  ini_setting { 'Sensu JVM Heap Size':
-    setting => 'HEAP_SIZE',
-    value   => '"256m"',
   }
 }


### PR DESCRIPTION
Without this path the Puppet module incorrectly configures Sensu Enterprise API
SSL parameters.  This patch corrects the configuration scope to match
https://sensuapp.org/docs/1.0/enterprise/api.html#ssl-attributes-example

Resolves #784