### PR TITLE
Quick fix for #790

### DIFF
--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -118,7 +118,7 @@ class sensu::rabbitmq::config {
   $cert_chain = $has_cluster ? { false => $ssl_cert_chain, true => undef, }
   $private_key = $has_cluster ? { false => $ssl_private_key, true => undef, }
   $prefetch = $has_cluster ? { false => $::sensu::rabbitmq_prefetch, true => undef, }
-  $base_path = $has_cluster ? { false => $::sensu::conf_dir, true => undef, }
+  $base_path = $::sensu::conf_dir
   $cluster = $has_cluster ? { true => $::sensu::rabbitmq_cluster, false => undef, }
   $heartbeat = $has_cluster ? { false => $::sensu::rabbitmq_heartbeat, true => undef, }
 


### PR DESCRIPTION
# Pull Request Checklist

This fixes #790 

## Description
Quick fix for #790.
If a file has to be created when $::sensu::rabbitmq_cluster is true , this should be totally safe and legit.

Fixes #790 .

## Motivation and Context

## How Has This Been Tested?
Not tested on real systems, just rake specs.

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`