### PR TITLE
Update the README to clarify support resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 Installs and manages the open source monitoring framework [Sensu](http://sensuapp.org).
 [![Puppet Forge](http://img.shields.io/puppetforge/v/sensu/sensu.svg)](https://forge.puppetlabs.com/sensu/sensu)
 
+Please note, that this is a **Partner Supported** module, which means that technical customer support for this module is solely provided by Sensu. Puppet does not provide support for any **Partner Supported** modules. Technical support for this module is provided by Sensu at https://sensuapp.org/support.
+
 ## Tested with Travis CI
 
 [![Build Status](https://travis-ci.org/sensu/sensu-puppet.png)](https://travis-ci.org/sensu/sensu-puppet)


### PR DESCRIPTION
Users should rely on Sensu, not Puppet Inc, for support of this module. This clarification was requested by our friends at Puppet.

@ghoneycutt @agoddard Any concerns wrt directing users to our support page rather than opening issues here instead?