### PR TITLE
Force array for sensu::check subscribers, handlers and aggregates params #801

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,19 @@
 # Change Log
 
-## [v2.32.0](https://github.com/sensu/sensu-puppet/tree/v2.32.0)
+## [v2.33.0](https://github.com/sensu/sensu-puppet/tree/v2.33.0)
 
+[Full Changelog](https://github.com/sensu/sensu-puppet/compare/v2.32.0...v2.33.0)
+
+**Closed issues:**
+
+- Default linux path not working on Windows with $has\_cluster [\#790](https://github.com/sensu/sensu-puppet/issues/790)
+
+**Merged pull requests:**
+
+- Quick fix for \#790 [\#800](https://github.com/sensu/sensu-puppet/pull/800) ([alvagante](https://github.com/alvagante))
+- Support puppet 5.1 [\#799](https://github.com/sensu/sensu-puppet/pull/799) ([ghoneycutt](https://github.com/ghoneycutt))
+
+## [v2.32.0](https://github.com/sensu/sensu-puppet/tree/v2.32.0) (2017-08-18)
 [Full Changelog](https://github.com/sensu/sensu-puppet/compare/v2.31.0...v2.32.0)
 
 **Implemented enhancements:**

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -95,7 +95,7 @@ define sensu::check (
   Enum['present','absent']              $ensure = 'present',
   Optional[String]                      $type = undef,
   Variant[Undef,String,Array]           $handlers = undef,
-  Optional[Array]                       $contacts = undef,
+  Variant[Undef,String,Array]           $contacts = undef,
   Variant[Boolean,Enum['absent']]       $standalone = true,
   String                                $cron = 'absent',
   Variant[Integer,Enum['absent']]       $interval = 60,
@@ -162,6 +162,32 @@ define sensu::check (
     }
   }
 
+  case $handlers {
+    Pattern[/absent/]: { $handlers_array = undef }
+    String:   { $handlers_array = [ $handlers ] ; deprecation('handlers', 'Parameter handlers should be an array') }
+    default:  { $handlers_array = $handlers }
+  }
+  case $subscribers {
+    Pattern[/absent/]: { $subscribers_array = undef }
+    String:   { $subscribers_array = [ $subscribers ] ; deprecation('subscribers', 'Parameter subscribers should be an array') }
+    default:  { $subscribers_array = $subscribers }
+  }
+  case $aggregates {
+    Pattern[/absent/]: { $aggregates_array = undef }
+    String:   { $aggregates_array = [ $aggregates ] ; deprecation('aggregates', 'Parameter aggregates should be an array') }
+    default:  { $aggregates_array = $aggregates }
+  }
+  case $contacts {
+    Pattern[/absent/]: { $contacts_array = undef }
+    String:   { $contacts_array = [ $contacts ] ; deprecation('contacts', 'Parameter contacts should be an array') }
+    default:  { $contacts_array = $contacts }
+  }
+  case $dependencies {
+    Pattern[/absent/]: { $dependencies_array = undef }
+    String:   { $dependencies_array = [ $dependencies ] ; deprecation('dependencies', 'Parameter dependencies should be an array') }
+    default:  { $dependencies_array = $dependencies }
+  }
+
   # (#463) All plugins must come before all checks.  Collections are not used to
   # avoid realizing any resources.
   Anchor['plugins_before_checks']
@@ -173,22 +199,22 @@ define sensu::check (
     type                => $type,
     standalone          => $standalone,
     command             => $command,
-    handlers            => $handlers,
-    contacts            => $contacts,
+    handlers            => $handlers_array,
+    contacts            => $contacts_array,
     cron                => $cron,
     interval            => $interval_real,
     occurrences         => $occurrences,
     refresh             => $refresh,
     source              => $source,
-    subscribers         => $subscribers,
+    subscribers         => $subscribers_array,
     low_flap_threshold  => $low_flap_threshold,
     high_flap_threshold => $high_flap_threshold,
     timeout             => $timeout,
     aggregate           => $aggregate,
-    aggregates          => $aggregates,
+    aggregates          => $aggregates_array,
     handle              => $handle,
     publish             => $publish,
-    dependencies        => $dependencies,
+    dependencies        => $dependencies_array,
     subdue              => $subdue,
     proxy_requests      => $proxy_requests,
     ttl                 => $ttl,

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -118,7 +118,7 @@ class sensu::rabbitmq::config {
   $cert_chain = $has_cluster ? { false => $ssl_cert_chain, true => undef, }
   $private_key = $has_cluster ? { false => $ssl_private_key, true => undef, }
   $prefetch = $has_cluster ? { false => $::sensu::rabbitmq_prefetch, true => undef, }
-  $base_path = $has_cluster ? { false => $::sensu::conf_dir, true => undef, }
+  $base_path = $::sensu::conf_dir
   $cluster = $has_cluster ? { true => $::sensu::rabbitmq_cluster, false => undef, }
   $heartbeat = $has_cluster ? { false => $::sensu::rabbitmq_heartbeat, true => undef, }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "sensu-sensu",
-  "version": "2.32.0",
+  "version": "2.33.0",
   "author": "sensu",
   "summary": "A module to install the Sensu monitoring framework",
   "license": "MIT",

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -361,4 +361,29 @@ describe 'sensu::check', :type => :define do
     let(:expected) { { notify: ["Sensu::Check[#{title}]"] } }
     it { should contain_anchor('plugins_before_checks').with(expected)}
   end
+
+  describe 'strings where arrays are expected (#803)' do
+    context 'handlers is passed as String' do
+      let(:params_override) { {handlers: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "handlers"=>["default"], "interval"=>60}}) }
+    end
+    context 'subscribers is passed as String' do
+      let(:params_override) { {subscribers: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "subscribers"=>["default"], "interval"=>60}}) }
+    end
+    context 'aggregates is passed as String' do
+      let(:params_override) { {aggregates: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "aggregates"=>["default"], "interval"=>60}}) }
+    end
+    context 'dependencies is passed as String' do
+      let(:params_override) { {dependencies: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "dependencies"=>["default"], "interval"=>60}}) }
+    end
+    context 'contacts is passed as String' do
+      let(:params_override) { {contacts: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "contacts"=>["default"], "interval"=>60}}) }
+    end
+  end
+
+
 end


### PR DESCRIPTION
# Pull Request Checklist

This commit converts strings to arrays with a single element, when a String is used for the handlers, subscribers and aggregates parameters in sensu::check

## Description
Parameter type is evaluated, if i'ts s String is converted to an array and a deprecation notice is cast.

## Related Issue
This fixes #801 

## Motivation and Context

## How Has This Been Tested?
Tested on sensu-server vagrant vm and spec tests.

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
