### PR TITLE
Force array for some sense::check params #801

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -95,7 +95,7 @@ define sensu::check (
   Enum['present','absent']              $ensure = 'present',
   Optional[String]                      $type = undef,
   Variant[Undef,String,Array]           $handlers = undef,
-  Optional[Array]                       $contacts = undef,
+  Variant[Undef,String,Array]           $contacts = undef,
   Variant[Boolean,Enum['absent']]       $standalone = true,
   String                                $cron = 'absent',
   Variant[Integer,Enum['absent']]       $interval = 60,
@@ -162,6 +162,32 @@ define sensu::check (
     }
   }
 
+  case $handlers {
+    Pattern[/absent/]: { $handlers_array = undef }
+    String:   { $handlers_array = [ $handlers ] }
+    default:  { $handlers_array = $handlers }
+  }
+  case $subscribers {
+    Pattern[/absent/]: { $subscribers_array = undef }
+    String:   { $subscribers_array = [ $subscribers ] }
+    default:  { $subscribers_array = $subscribers }
+  }
+  case $aggregates {
+    Pattern[/absent/]: { $aggregates_array = undef }
+    String:   { $aggregates_array = [ $aggregates ] }
+    default:  { $aggregates_array = $aggregates }
+  }
+  case $contacts {
+    Pattern[/absent/]: { $contacts_array = undef }
+    String:   { $contacts_array = [ $contacts ] }
+    default:  { $contacts_array = $contacts }
+  }
+  case $dependencies {
+    Pattern[/absent/]: { $dependencies_array = undef }
+    String:   { $dependencies_array = [ $dependencies ] }
+    default:  { $dependencies_array = $dependencies }
+  }
+
   # (#463) All plugins must come before all checks.  Collections are not used to
   # avoid realizing any resources.
   Anchor['plugins_before_checks']
@@ -173,22 +199,22 @@ define sensu::check (
     type                => $type,
     standalone          => $standalone,
     command             => $command,
-    handlers            => $handlers,
-    contacts            => $contacts,
+    handlers            => $handlers_array,
+    contacts            => $contacts_array,
     cron                => $cron,
     interval            => $interval_real,
     occurrences         => $occurrences,
     refresh             => $refresh,
     source              => $source,
-    subscribers         => $subscribers,
+    subscribers         => $subscribers_array,
     low_flap_threshold  => $low_flap_threshold,
     high_flap_threshold => $high_flap_threshold,
     timeout             => $timeout,
     aggregate           => $aggregate,
-    aggregates          => $aggregates,
+    aggregates          => $aggregates_array,
     handle              => $handle,
     publish             => $publish,
-    dependencies        => $dependencies,
+    dependencies        => $dependencies_array,
     subdue              => $subdue,
     proxy_requests      => $proxy_requests,
     ttl                 => $ttl,

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -361,4 +361,70 @@ describe 'sensu::check', :type => :define do
     let(:expected) { { notify: ["Sensu::Check[#{title}]"] } }
     it { should contain_anchor('plugins_before_checks').with(expected)}
   end
+
+  describe 'params conversions where arrays are expected (#803)' do
+    context 'handlers is passed as String' do
+      let(:params_override) { {handlers: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "handlers"=>["default"], "interval"=>60}}) }
+    end
+    context 'subscribers is passed as String' do
+      let(:params_override) { {subscribers: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "subscribers"=>["default"], "interval"=>60}}) }
+    end
+    context 'aggregates is passed as String' do
+      let(:params_override) { {aggregates: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "aggregates"=>["default"], "interval"=>60}}) }
+    end
+    context 'dependencies is passed as String' do
+      let(:params_override) { {dependencies: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "dependencies"=>["default"], "interval"=>60}}) }
+    end
+    context 'contacts is passed as String' do
+      let(:params_override) { {contacts: 'default'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "contacts"=>["default"], "interval"=>60}}) }
+    end
+
+    context 'handlers is passed as Array' do
+      let(:params_override) { {handlers: ['default']} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "handlers"=>["default"], "interval"=>60}}) }
+    end
+    context 'subscribers is passed as Array' do
+      let(:params_override) { {subscribers: ['default']} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "subscribers"=>["default"], "interval"=>60}}) }
+    end
+    context 'aggregates is passed as Array' do
+      let(:params_override) { {aggregates: ['default']} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "aggregates"=>["default"], "interval"=>60}}) }
+    end
+    context 'dependencies is passed as Array' do
+      let(:params_override) { {dependencies: ['default']} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "dependencies"=>["default"], "interval"=>60}}) }
+    end
+    context 'contacts is passed as Array' do
+      let(:params_override) { {contacts: ['default']} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "contacts"=>["default"], "interval"=>60}}) }
+    end
+
+    context 'handlers is passed as absent' do
+      let(:params_override) { {handlers: 'absent'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60}}) }
+    end
+    context 'subscribers is passed as absent' do
+      let(:params_override) { {subscribers: 'absent'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60}}) }
+    end
+    context 'aggregates is passed as absent' do
+      let(:params_override) { {aggregates: 'absent'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60}}) }
+    end
+    context 'dependencies is passed as absent' do
+      let(:params_override) { {dependencies: 'absent'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60}}) }
+    end
+    context 'contacts is passed as absent' do
+      let(:params_override) { {contacts: 'absent'} }
+      it { should contain_sensu__write_json(fpath).with_content("checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60}}) }
+    end
+  end
+
 end


### PR DESCRIPTION
# Pull Request Checklist

Changed sensu::check define and relevant spec tests.

## Description
This commit converts strings to arrays with a single element, when a String is used for the handlers, subscribers and aggregates parameters in sensu::check

This PR replaces  #803 

## Related Issue

Fixes #801 

## Motivation and Context
Syntax errors on check files when using strings on the given params.
 
## How Has This Been Tested?
Tested on sensu-server vagrant vm and spec tests.


## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
