### PR TITLE
Added http_socket param to client config #776

### DIFF
--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -157,6 +157,29 @@ Puppet::Type.newtype(:sensu_client_config) do
     defaultto {}
   end
 
+  newproperty(:http_socket) do
+    desc "A set of attributes that configure the Sensu client http socket."
+    include PuppetX::Sensu::ToType
+
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
+  end
+
   autorequire(:package) do
     ['sensu']
   end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -93,5 +93,6 @@ class sensu::client (
     redact         => $::sensu::redact,
     deregister     => $::sensu::client_deregister,
     deregistration => $::sensu::client_deregistration,
+    http_socket    => $::sensu::client_http_socket,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -158,6 +158,8 @@
 #
 # @param client_keepalive Client keepalive config
 #
+# @param client_http_socket Client http_socket config
+#
 # @param safe_mode Force safe mode for checks
 #
 # @param plugins Plugins to install on the node
@@ -343,6 +345,7 @@ class sensu (
   Variant[Undef,Boolean] $client_deregister = undef,
   Variant[Undef,Hash] $client_deregistration = undef,
   Hash               $client_keepalive = {},
+  Hash               $client_http_socket = {},
   Boolean            $safe_mode = false,
   Variant[String,Array,Hash] $plugins = [],
   Hash               $plugins_defaults = {},

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -14,7 +14,8 @@ describe 'sensu', :type => :class do
           :address       => '2.3.4.5',
           :socket        => { 'bind' => '127.0.0.1', 'port' => 3030 },
           :subscriptions => [],
-          :custom        => {}
+          :custom        => {},
+          :http_socket   => {},
         ) }
 
         it { should contain_sensu_client_config('host.domain.com').without_redact }
@@ -45,7 +46,8 @@ describe 'sensu', :type => :class do
             :redact                   => ['password'],
             :client_name              => 'myclient',
             :safe_mode                => true,
-            :client_custom            => { 'bool' => true, 'foo' => 'bar' }
+            :client_custom            => { 'bool' => true, 'foo' => 'bar' },
+            :client_http_socket       => { 'bind' => '127.0.0.1', 'port' => 3031 }
           } }
 
           it { should contain_sensu_client_config('host.domain.com').with( {
@@ -56,7 +58,8 @@ describe 'sensu', :type => :class do
             :subscriptions => ['all'],
             :redact        => ['password'],
             :safe_mode     => true,
-            :custom        => { 'bool' => true, 'foo' => 'bar' }
+            :custom        => { 'bool' => true, 'foo' => 'bar' },
+            :http_socket   => { 'bind' => '127.0.0.1', 'port' => 3031 }
           } ) }
         end
 
@@ -94,6 +97,20 @@ describe 'sensu', :type => :class do
             it { is_expected.to raise_error(Puppet::Error) }
           end
         end
+
+        describe 'http_socket' do
+          http_socket = {
+            'bind' => '127.0.0.1',
+            'port' => '3031',
+            'user' => 'sensu',
+            'password' => 'sensu'
+          }
+          context "=> {'http_socket' => 'custom hash'}" do
+            let(:params_override) { {client_http_socket: http_socket} }
+            it { is_expected.to contain_sensu_client_config(title).with(http_socket: http_socket) }
+          end
+
+        end        
       end
 
       context 'purge config' do

--- a/spec/unit/sensu_client_config_spec.rb
+++ b/spec/unit/sensu_client_config_spec.rb
@@ -62,4 +62,22 @@ describe Puppet::Type.type(:sensu_client_config) do
       end
     end
   end
+  describe 'http_socket' do
+    subject { described_class.new(resource_hash)[:http_socket] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    http_socket = {
+      'bind' => '127.0.0.1',
+      'port' => '3031',
+      'user' => 'sensu',
+      'password' => 'sensu'
+    }    
+    context '=> custom values' do
+      let(:resource_hash_override) { {http_socket: http_socket} }
+      it { is_expected.to eq(http_socket) }
+    end
+
+  end
+
 end


### PR DESCRIPTION
# Pull Request Checklist

Added parameter http_socket to client config.

## Description
Added parameter to main class, and then reference to it in sunse::client is passwd to the sensu_client_config type used the new json write approach.
 
## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #776 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Tested os samples vms and spec.

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
