### PR TITLE
Added support to client config for servicenow, ec2, chef, puppet #772 #773 #774 #775

### DIFF
--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -180,7 +180,100 @@ Puppet::Type.newtype(:sensu_client_config) do
     defaultto {}
   end
 
+  newproperty(:servicenow) do
+    desc "Configure Service Now integration on Sensu client."
+    include PuppetX::Sensu::ToType
+
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
+  end
+
+  newproperty(:ec2) do
+    desc "Configure ec2 integration on Sensu client."
+    include PuppetX::Sensu::ToType
+
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
+  end
+
+  newproperty(:chef) do
+    desc "Configure Chef integration on Sensu client."
+    include PuppetX::Sensu::ToType
+
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
+  end
+
+  newproperty(:puppet) do
+    desc "Configure Puppet integration on Sensu client."
+    include PuppetX::Sensu::ToType
+
+    munge do |value|
+      value.each { |k, v| value[k] = to_type(v) }
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
+  end
+
   autorequire(:package) do
     ['sensu']
   end
+
 end

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -94,5 +94,9 @@ class sensu::client (
     deregister     => $::sensu::client_deregister,
     deregistration => $::sensu::client_deregistration,
     http_socket    => $::sensu::client_http_socket,
+    servicenow     => $::sensu::client_servicenow,
+    ec2            => $::sensu::client_ec2,
+    chef           => $::sensu::client_chef,
+    puppet         => $::sensu::client_puppet,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -156,9 +156,28 @@
 #   status, and issued timestamp. The following attributes are provided as
 #   recommendations for controlling client deregistration behavior.
 #
-# @param client_keepalive Client keepalive config
+# @param client_keepalive Client keepalive configuration
 #
-# @param client_http_socket Client http_socket config
+# @param client_http_socket Client http_socket configuration. Must be an Hash of
+#    parameters as described in:
+#    https://sensuapp.org/docs/latest/reference/clients.html#http-socket-attributes
+#
+# @param client_servicenow Client servicenow configuration. Supported only
+#   on Sensu Enterprise. It expects an Hash with a single key named
+#   'configuration_item' containing an Hash of parameters, as described in:
+#   https://sensuapp.org/docs/latest/reference/clients.html#servicenow-attributes
+#
+# @param client_ec2 Client ec2 configuration. Supported only on Sensu
+#   Enterprise. It expects an Hash with valid paramters as described in:
+#   https://sensuapp.org/docs/latest/reference/clients.html#ec2-attributes
+#
+# @param client_chef Client chef configuration. Supported only on Sensu
+#   Enterprise. It expects an Hash with valid paramters as described in:
+#   https://sensuapp.org/docs/latest/reference/clients.html#chef-attributes
+#
+# @param client_puppet Client puppet configuration. Supported only on Sensu
+#   Enterprise. It expects an Hash with valid paramters as described in:
+#   https://sensuapp.org/docs/latest/reference/clients.html#puppet-attributes
 #
 # @param safe_mode Force safe mode for checks
 #
@@ -346,6 +365,10 @@ class sensu (
   Variant[Undef,Hash] $client_deregistration = undef,
   Hash               $client_keepalive = {},
   Hash               $client_http_socket = {},
+  Hash               $client_servicenow = {},
+  Hash               $client_ec2 = {},
+  Hash               $client_chef = {},
+  Hash               $client_puppet = {},
   Boolean            $safe_mode = false,
   Variant[String,Array,Hash] $plugins = [],
   Hash               $plugins_defaults = {},

--- a/spec/unit/sensu_client_config_spec.rb
+++ b/spec/unit/sensu_client_config_spec.rb
@@ -62,6 +62,7 @@ describe Puppet::Type.type(:sensu_client_config) do
       end
     end
   end
+
   describe 'http_socket' do
     subject { described_class.new(resource_hash)[:http_socket] }
     context 'in the default case' do
@@ -77,7 +78,80 @@ describe Puppet::Type.type(:sensu_client_config) do
       let(:resource_hash_override) { {http_socket: http_socket} }
       it { is_expected.to eq(http_socket) }
     end
+  end
 
+  describe 'servicenow' do
+    subject { described_class.new(resource_hash)[:servicenow] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    servicenow = {
+      'configuration_item' => {
+        'name' => 'test server',
+        'os_version' => '7',
+      }
+    }
+    context '=> custom values' do
+      let(:resource_hash_override) { {servicenow: servicenow} }
+      it { is_expected.to eq(servicenow) }
+    end
+  end
+
+  describe 'ec2' do
+    subject { described_class.new(resource_hash)[:ec2] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    ec2 = {
+      'instance-id' => 'i-424242',
+      'allowed_instance_states' => [ 'pending','running','rebooting'],
+      'region' => 'us-west-1',
+      'access_key_id' => 'AlygD0X6Z4Xr2m3gl70J',
+      'secret_access_key' => 'y9Jt5OqNOqdy5NCFjhcUsHMb6YqSbReLAJsy4d6obSZIWySv',
+      'timeout' => '30',
+    }
+    context '=> custom values' do
+      let(:resource_hash_override) { {ec2: ec2} }
+      it { is_expected.to eq(ec2) }
+    end
+  end
+
+  describe 'chef' do
+    subject { described_class.new(resource_hash)[:chef] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    chef = {
+      'nodename' => 'test',
+      'endpoint' => 'https://api.chef.io/organizations/example',
+      'flavor' => 'enterprise',
+      'client' => 'sensu-server',
+      'key' => '/etc/chef/i-424242.pem',
+      'ssl_verify' => 'false',
+      'proxy_address' => 'proxy.example.com',
+      'proxy_port' => '8080',
+      'proxy_username' => 'chef',
+      'proxy_password' => 'secret',
+      'timeout' => '30',
+    }
+    context '=> custom values' do
+      let(:resource_hash_override) { {chef: chef} }
+      it { is_expected.to eq(chef) }
+    end
+  end
+
+  describe 'puppet' do
+    subject { described_class.new(resource_hash)[:puppet] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    puppet = {
+      'nodename' => 'test',
+    }
+    context '=> custom values' do
+      let(:resource_hash_override) { {puppet: puppet} }
+      it { is_expected.to eq(puppet) }
+    end
   end
 
 end

--- a/tests/sensu-client.pp
+++ b/tests/sensu-client.pp
@@ -42,12 +42,31 @@ node default {
     $ip = $facts['networking']['ip']
   }
 
+  $client_ec2 = {
+    'instance-id' => 'i-2102113',
+  }
+  $client_puppet = {
+    'nodename' => $::fqdn,
+  }
+  $client_chef = {
+    'nodename' => $::fqdn,
+  }
+  $client_servicenow = {
+    'configuration_item' => {
+      'name' => 'ServiceNow test',
+      'os_version' => '16.04',
+    },
+  }
   class { '::sensu':
     rabbitmq_password => 'correct-horse-battery-staple',
     rabbitmq_host     => '192.168.56.10',
     rabbitmq_vhost    => '/sensu',
     subscriptions     => 'all',
     client_address    => $ip,
+    client_ec2        => $client_ec2,
+    client_chef       => $client_chef,
+    client_puppet     => $client_puppet,
+    client_servicenow => $client_servicenow,
     filters           => $filters,
     filter_defaults   => $filter_defaults,
   }


### PR DESCRIPTION
# Pull Request Checklist

This is a cumulative PR which adds support to Client config for servicenow, ec2, chef and puppet.

## Description
Added parameters to sensu class, sensu::client class and sensu_client_config type

## Related Issue
Resolves:  #772 #773 #774 #775

## Motivation and Context
Have configuration parity support to sensu client

## How Has This Been Tested?
Spec tests done.
Vagrant tests WIP

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
