### PR TITLE
Addressing #809 Added  param to sensu::transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Change Log
 
-## [v2.33.1](https://github.com/sensu/sensu-puppet/tree/HEAD)
+## [v2.34.0](https://github.com/sensu/sensu-puppet/tree/v2.34.0)
 
-[Full Changelog](https://github.com/sensu/sensu-puppet/compare/v2.33.0...HEAD)
+[Full Changelog](https://github.com/sensu/sensu-puppet/compare/v2.33.1...v2.34.0)
+
+**Closed issues:**
+
+- Client config should support http\_socket [\#776](https://github.com/sensu/sensu-puppet/issues/776)
+- Refactor inline documentation to puppet strings \(yard\) format [\#757](https://github.com/sensu/sensu-puppet/issues/757)
+- Stop using private classes and the anchor pattern [\#709](https://github.com/sensu/sensu-puppet/issues/709)
+- redacting passwords from catalogue output [\#515](https://github.com/sensu/sensu-puppet/issues/515)
+
+**Merged pull requests:**
+
+- Added http\_socket param to client config \#776 [\#805](https://github.com/sensu/sensu-puppet/pull/805) ([alvagante](https://github.com/alvagante))
+
+## [v2.33.1](https://github.com/sensu/sensu-puppet/tree/v2.33.1) (2017-08-28)
+[Full Changelog](https://github.com/sensu/sensu-puppet/compare/v2.33.0...v2.33.1)
 
 **Closed issues:**
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,6 +1,6 @@
 # @summary Defines Sensu check configurations
 # 
-# This define manages Sensu check configurations.
+# This define manages Sensu check configurations.
 #
 # @param ensure Whether the check should be present or not
 #   Valid values: present, absent

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -1,14 +1,12 @@
 # @summary Configures Sensu transport
 #
-# Configure Sensu Transport
+# Configures Sensu transport
 #
-class sensu::transport {
-
-  if $::sensu::transport_type != 'redis' {
-    $ensure = 'absent'
-  } else {
-    $ensure = 'present'
-  }
+# @param ensure If to create or remove the transport.json file
+#
+class sensu::transport (
+  Enum['present','absent'] $ensure = 'present',
+) {
 
   $transport_type_hash = {
     'transport' => {

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "sensu-sensu",
-  "version": "2.33.1",
+  "version": "2.34.0",
   "author": "sensu",
   "summary": "A module to install the Sensu monitoring framework",
   "license": "MIT",


### PR DESCRIPTION
# Pull Request Checklist

Solves issue #809 

## Description
This solves issues #809 by exposing an exnsure parameter to allow users to manage the presence of trnsport.json and by ensuring it's present if transport_type is either redis or rabbitmq.

Need double check if this is the expected and correct behaviour.

## Related Issue
Fixes # 809

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [ ] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
