### PR TITLE
Added register and registration params to client config #749

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,19 +21,15 @@ matrix:
   fast_finish: true
   include:
   - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.6.0"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.7.0"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.8.0"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.9.0"
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4.10.0"
+    env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5.0.0"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5.1.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.2.0"
+  - rvm: 2.4.1
+    env: PUPPET_GEM_VERSION="~> 5.3.0"
   - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,27 @@
 # Change Log
 
-## [v2.35.0](https://github.com/sensu/sensu-puppet/tree/v2.35.0)
+## [v2.36.0](https://github.com/sensu/sensu-puppet/tree/v2.36.0)
 
+[Full Changelog](https://github.com/sensu/sensu-puppet/compare/v2.35.0...v2.36.0)
+
+**Closed issues:**
+
+- Absolute path set for rabbitmq ssl certs [\#798](https://github.com/sensu/sensu-puppet/issues/798)
+- Client config should support servicenow [\#775](https://github.com/sensu/sensu-puppet/issues/775)
+- Client config should support puppet [\#774](https://github.com/sensu/sensu-puppet/issues/774)
+- Client config should support chef [\#773](https://github.com/sensu/sensu-puppet/issues/773)
+- Cannot manage 2008 R2 localised \(french\) [\#769](https://github.com/sensu/sensu-puppet/issues/769)
+- Add a test in vagrant for PR \#745 [\#747](https://github.com/sensu/sensu-puppet/issues/747)
+
+**Merged pull requests:**
+
+- Change test versions [\#830](https://github.com/sensu/sensu-puppet/pull/830) ([ghoneycutt](https://github.com/ghoneycutt))
+- user on check for windows to use module defaults and notifying sensu-enterprise [\#829](https://github.com/sensu/sensu-puppet/pull/829) ([ghoneycutt](https://github.com/ghoneycutt))
+- \[815\] Resolve circular dependency when using sensu::enterprise::dashboard::api [\#816](https://github.com/sensu/sensu-puppet/pull/816) ([glarizza](https://github.com/glarizza))
+- Add vagrant tests for add/remove checks with sensu::check [\#814](https://github.com/sensu/sensu-puppet/pull/814) ([Phil-Friderici](https://github.com/Phil-Friderici))
+- Added sensu\_user and sensu\_group params to sensu class \#769 [\#813](https://github.com/sensu/sensu-puppet/pull/813) ([alvagante](https://github.com/alvagante))
+
+## [v2.35.0](https://github.com/sensu/sensu-puppet/tree/v2.35.0) (2017-09-06)
 [Full Changelog](https://github.com/sensu/sensu-puppet/compare/v2.34.0...v2.35.0)
 
 **Closed issues:**

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -125,10 +125,6 @@ Puppet::Type.newtype(:sensu_client_config) do
     newvalues(/.*/, :absent)
   end
 
-  newproperty(:register, :parent => PuppetX::Sensu::BooleanProperty) do
-    desc 'Enable client registration'
-  end
-
   newproperty(:registration) do
     desc 'Client registration attributes'
     newvalues(/.*/, :absent)

--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -125,6 +125,15 @@ Puppet::Type.newtype(:sensu_client_config) do
     newvalues(/.*/, :absent)
   end
 
+  newproperty(:register, :parent => PuppetX::Sensu::BooleanProperty) do
+    desc 'Enable client registration'
+  end
+
+  newproperty(:registration) do
+    desc 'Client registration attributes'
+    newvalues(/.*/, :absent)
+  end
+
   newproperty(:keepalive) do
     desc "Keepalive config"
 

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -149,8 +149,8 @@ define sensu::check (
     'windows': {
       $etc_dir = 'C:/opt/sensu'
       $conf_dir = "${etc_dir}/conf.d"
-      $user = undef
-      $group = undef
+      $user = $::sensu::user
+      $group = $::sensu::group
       $file_mode = undef
     }
     default: {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -93,7 +93,6 @@ class sensu::client (
     redact         => $::sensu::redact,
     deregister     => $::sensu::client_deregister,
     deregistration => $::sensu::client_deregistration,
-    register       => $::sensu::client_register,
     registration   => $::sensu::client_registration,
     http_socket    => $::sensu::client_http_socket,
     servicenow     => $::sensu::client_servicenow,

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -93,6 +93,8 @@ class sensu::client (
     redact         => $::sensu::redact,
     deregister     => $::sensu::client_deregister,
     deregistration => $::sensu::client_deregistration,
+    register       => $::sensu::client_register,
+    registration   => $::sensu::client_registration,
     http_socket    => $::sensu::client_http_socket,
     servicenow     => $::sensu::client_servicenow,
     ec2            => $::sensu::client_ec2,

--- a/manifests/enterprise/dashboard/api.pp
+++ b/manifests/enterprise/dashboard/api.pp
@@ -39,7 +39,7 @@ define sensu::enterprise::dashboard::api (
   Optional[String]  $pass          = undef,
 ) {
 
-  require ::sensu::enterprise::dashboard
+  include ::sensu::enterprise::dashboard
 
   sensu_enterprise_dashboard_api_config { $title:
     ensure     => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -455,6 +455,12 @@ class sensu (
     $client_service = undef
   }
 
+  if $enterprise and $manage_services {
+    $enterprise_service = Service['sensu-enterprise']
+  } else {
+    $enterprise_service = undef
+  }
+
   if $server {
     $server_service_class = Class['sensu::server::service']
   } else {
@@ -467,7 +473,7 @@ class sensu (
     $api_service = undef
   }
 
-  $check_notify = delete_undef_values([ $client_service, $server_service_class, $api_service ])
+  $check_notify = delete_undef_values([ $client_service, $server_service_class, $api_service, $enterprise_service ])
 
   # Because you can't reassign a variable in puppet and we need to set to
   # false if you specify a directory, we have to use another variable.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,15 @@
 #   status, and issued timestamp. The following attributes are provided as
 #   recommendations for controlling client deregistration behavior.
 #
+# @param client_register Enable the [registration
+#   event](https://sensuapp.org/docs/latest/reference/clients#registration-attributes)
+#   if true
+#
+# @param client_registration [Attributes](https://sensuapp.org/docs/latest/reference/clients#registration-attributes)
+#   used to generate check result data for the registration event. Client
+#   registration attributes are merged with some default check definition
+#   attributes by the Sensu server during client registration.
+#
 # @param client_keepalive Client keepalive configuration
 #
 # @param client_http_socket Client http_socket configuration. Must be an Hash of
@@ -371,6 +380,8 @@ class sensu (
   Hash               $client_custom = {},
   Variant[Undef,Boolean] $client_deregister = undef,
   Variant[Undef,Hash] $client_deregistration = undef,
+  Variant[Undef,Boolean] $client_register = undef,
+  Variant[Undef,Hash] $client_registration = undef,
   Hash               $client_keepalive = {},
   Hash               $client_http_socket = {},
   Hash               $client_servicenow = {},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,10 +162,6 @@
 #   status, and issued timestamp. The following attributes are provided as
 #   recommendations for controlling client deregistration behavior.
 #
-# @param client_register Enable the [registration
-#   event](https://sensuapp.org/docs/latest/reference/clients#registration-attributes)
-#   if true
-#
 # @param client_registration [Attributes](https://sensuapp.org/docs/latest/reference/clients#registration-attributes)
 #   used to generate check result data for the registration event. Client
 #   registration attributes are merged with some default check definition
@@ -380,7 +376,6 @@ class sensu (
   Hash               $client_custom = {},
   Variant[Undef,Boolean] $client_deregister = undef,
   Variant[Undef,Hash] $client_deregistration = undef,
-  Variant[Undef,Boolean] $client_register = undef,
   Variant[Undef,Hash] $client_registration = undef,
   Hash               $client_keepalive = {},
   Hash               $client_http_socket = {},

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,12 @@
 #
 # @param manage_mutators_dir Manage the sensu mutators directory
 #
+# @param sensu_user Name of the user Sensu is running as. Default is calculated
+#   according to the underlying OS
+#
+# @param sensu_group Name of the group Sensu is running as. Default is calculated
+#   according to the underlying OS
+#
 # @param rabbitmq_port Rabbitmq port to be used by sensu
 #
 # @param rabbitmq_host Host running rabbitmq for sensu
@@ -326,6 +332,8 @@ class sensu (
   Boolean            $manage_plugins_dir = true,
   Boolean            $manage_handlers_dir = true,
   Boolean            $manage_mutators_dir = true,
+  Optional[String]   $sensu_user = undef,
+  Optional[String]   $sensu_group = undef,
   Variant[Undef,Integer,Pattern[/^(\d+)$/]] $rabbitmq_port = undef,
   Optional[String]   $rabbitmq_host = undef,
   Optional[String]   $rabbitmq_user = undef,
@@ -528,8 +536,14 @@ class sensu (
     'Debian','RedHat': {
       $etc_dir = $sensu_etc_dir
       $conf_dir = "${etc_dir}/conf.d"
-      $user = 'sensu'
-      $group = 'sensu'
+      $user = $sensu_user  ? {
+        undef   => 'sensu',
+        default => $sensu_user,
+      }
+      $group = $sensu_group ? {
+        undef   => 'sensu',
+        default => $sensu_group,
+      }
       $home_dir = '/opt/sensu'
       $shell = '/bin/false'
       $dir_mode = '0555'
@@ -539,8 +553,14 @@ class sensu (
     'windows': {
       $etc_dir = $sensu_etc_dir
       $conf_dir = "${etc_dir}/conf.d"
-      $user = 'NT Authority\SYSTEM'
-      $group = 'Administrators'
+      $user = $sensu_user  ? {
+        undef   => 'NT Authority\SYSTEM',
+        default => $sensu_user,
+      }
+      $group = $sensu_group ? {
+        undef   => 'Administrators',
+        default => $sensu_group,
+      }
       $home_dir = $etc_dir
       $shell = undef
       $dir_mode = undef

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "sensu-sensu",
-  "version": "2.35.0",
+  "version": "2.36.0",
   "author": "sensu",
   "summary": "A module to install the Sensu monitoring framework",
   "license": "MIT",

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -110,6 +110,41 @@ describe 'sensu', :type => :class do
           end
         end
 
+        describe 'register' do
+          context '=> false' do
+            let(:params_override) { {client_register: false} }
+            it { is_expected.to contain_sensu_client_config(title).with(register: false) }
+          end
+
+          context '=> true' do
+            let(:params_override) { {client_register: true} }
+            it { is_expected.to contain_sensu_client_config(title).with(register: true) }
+          end
+
+          context '=> "garbage"' do
+            let(:params_override) { {client_register: 'garbage'} }
+            it { is_expected.to raise_error(Puppet::Error) }
+          end
+        end
+
+        describe 'client_registration' do
+          let(:params_override) { {client_registration: registration} }
+          context "=> {'handler': 'register_client'}" do
+            let(:registration) { {'handler' => 'register_client'} }
+            it { is_expected.to contain_sensu_client_config(title).with(registration: registration) }
+          end
+
+          context "=> {}" do
+            let(:registration) { {} }
+            it { is_expected.to contain_sensu_client_config(title).with(registration: registration) }
+          end
+
+          context "=> 'absent' (error)" do
+            let(:registration) { 'absent' }
+            it { is_expected.to raise_error(Puppet::Error) }
+          end
+        end
+
         describe 'http_socket' do
           http_socket = {
             'bind' => '127.0.0.1',

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -110,23 +110,6 @@ describe 'sensu', :type => :class do
           end
         end
 
-        describe 'register' do
-          context '=> false' do
-            let(:params_override) { {client_register: false} }
-            it { is_expected.to contain_sensu_client_config(title).with(register: false) }
-          end
-
-          context '=> true' do
-            let(:params_override) { {client_register: true} }
-            it { is_expected.to contain_sensu_client_config(title).with(register: true) }
-          end
-
-          context '=> "garbage"' do
-            let(:params_override) { {client_register: 'garbage'} }
-            it { is_expected.to raise_error(Puppet::Error) }
-          end
-        end
-
         describe 'client_registration' do
           let(:params_override) { {client_registration: registration} }
           context "=> {'handler': 'register_client'}" do

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -182,6 +182,14 @@ describe 'sensu', :type => :class do
       it { should_not contain_user('sensu') }
     end
 
+    describe 'with sensu_user => Administrateur and sensu_group => Administrateurs' do
+      let(:params) do
+        {:sensu_user  => 'Administrateur',
+         :sensu_group => 'Administrateurs'}
+      end
+      it { should contain_file('C:/opt/sensu/conf.d').with({:owner => 'Administrateur', :group => 'Administrateurs'}) }
+    end
+
     context 'with sensu_etc_dir => C:/etc/sensu' do
       let(:params) { {:sensu_etc_dir => 'C:/etc/sensu' } }
       # resources from sensu::package

--- a/spec/unit/sensu_client_config_spec.rb
+++ b/spec/unit/sensu_client_config_spec.rb
@@ -41,6 +41,36 @@ describe Puppet::Type.type(:sensu_client_config) do
     end
   end
 
+  describe 'register' do
+    subject { described_class.new(resource_hash)[:register] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    context '=> true' do
+      let(:resource_hash_override) { {register: true} }
+      it { is_expected.to eq(:true) }
+    end
+    context '=> false' do
+      let(:resource_hash_override) { {register: false} }
+      it { is_expected.to eq(:false) }
+    end
+  end
+
+  describe 'registration' do
+    subject { described_class.new(resource_hash)[:registration] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    context '=> {}' do
+      let(:resource_hash_override) { {registration: {}} }
+      it { is_expected.to eq({}) }
+    end
+    context '=> absent' do
+      let(:resource_hash_override) { {registration: 'absent'} }
+      it { is_expected.to eq(:absent) }
+    end
+  end
+
   describe 'notifications' do
     let(:resource_hash) do
       c = Puppet::Resource::Catalog.new

--- a/spec/unit/sensu_client_config_spec.rb
+++ b/spec/unit/sensu_client_config_spec.rb
@@ -41,21 +41,6 @@ describe Puppet::Type.type(:sensu_client_config) do
     end
   end
 
-  describe 'register' do
-    subject { described_class.new(resource_hash)[:register] }
-    context 'in the default case' do
-      it { is_expected.to be_nil }
-    end
-    context '=> true' do
-      let(:resource_hash_override) { {register: true} }
-      it { is_expected.to eq(:true) }
-    end
-    context '=> false' do
-      let(:resource_hash_override) { {register: false} }
-      it { is_expected.to eq(:false) }
-    end
-  end
-
   describe 'registration' do
     subject { described_class.new(resource_hash)[:registration] }
     context 'in the default case' do

--- a/tests/add_remove-check.pp
+++ b/tests/add_remove-check.pp
@@ -1,0 +1,33 @@
+node 'sensu-server' {
+
+  class { '::sensu':
+    install_repo          => true,
+    server                => true,
+    manage_services       => true,
+    manage_user           => true,
+    rabbitmq_password     => 'correct-horse-battery-staple',
+    rabbitmq_vhost        => '/sensu',
+    spawn_limit           => 16,
+    api                   => true,
+    api_user              => 'admin',
+    api_password          => 'secret',
+    client_address        => $::ipaddress_eth1,
+    subscriptions         => ['all', 'roundrobin:poller'],
+    client_deregister     => true,
+    client_deregistration => {'handler' => 'deregister_client'},
+  }
+
+  if $::test == 'add' {
+    sensu::check { 'check_to_remove':
+      command     => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H :::address::: -w 30 -c 60',
+      standalone  => false,
+      handlers    => 'default',
+      subscribers => 'roundrobin:poller',
+      cron        => '*/5 * * * *',
+    }
+  } else {
+    sensu::check { 'check_to_remove':
+      ensure => 'absent',
+    }
+  }
+}

--- a/tests/add_remove-check.sh
+++ b/tests/add_remove-check.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+exitcode=1
+
+function get_available_checks {
+  curl -s http://admin:secret@127.0.0.1:4567/checks | jq .[].name | awk -F \" '{print $2}' | awk -F \. '{print $1}'
+}
+
+function check_available() {
+  checks=$(get_available_checks)
+
+  if [ -z "${checks##*$1*}" ] ;then
+    echo 'true'
+  else
+    echo 'false'
+  fi
+}
+
+echo -e "\nList of checks available beforehand:"
+get_available_checks
+
+
+if [ $(check_available check_to_remove) == 'false' ]; then
+  echo -e "\nThe check 'check_to_remove' isn't available and should get added now\n"
+  FACTER_test='add' puppet apply /vagrant/tests/add_remove-check.pp
+
+  if [ $(check_available check_to_remove) == 'true' ]; then
+    echo -e "\nThe check 'check_to_remove' have been addedd successfully"
+    exitcode=0
+  else
+    echo -e "\nSomething went wrong, the check 'check_to_remove' have NOT been addedd successfully"
+  fi
+
+else
+  echo -e "\nThe check 'check_to_remove' is available and should get removed now\n"
+  FACTER_test='remove' puppet apply /vagrant/tests/add_remove-check.pp
+  if [ $(check_available check_to_remove) == 'false' ]; then
+    echo -e "\nThe check 'check_to_remove' have been removed successfully"
+    exitcode=0
+  else
+    echo -e "\nSomething went wrong, the check 'check_to_remove' have NOT been removed successfully"
+  fi
+fi
+
+echo -e "\nList of checks available afterwards:"
+get_available_checks
+exit $exitcode


### PR DESCRIPTION
# Pull Request Checklist

This implements client registration settings for client config.

## Description
I've made this completely similar to the de-register configurations, but I'm now sure we actually need the register parameter (in sensu docs only registration is mentioned)

The service starts anyway, as Sensu is tolerant of unknown settings in client.json. 

Fixes #749 

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
