### PR TITLE
Added sensu_user and sensu_group params to sensu class #769

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,6 +63,12 @@
 #
 # @param manage_mutators_dir Manage the sensu mutators directory
 #
+# @param sensu_user Name of the user Sensu is running as. Default is calculated
+#   according to the underlying OS
+#
+# @param sensu_group Name of the group Sensu is running as. Default is calculated
+#   according to the underlying OS
+#
 # @param rabbitmq_port Rabbitmq port to be used by sensu
 #
 # @param rabbitmq_host Host running rabbitmq for sensu
@@ -326,6 +332,8 @@ class sensu (
   Boolean            $manage_plugins_dir = true,
   Boolean            $manage_handlers_dir = true,
   Boolean            $manage_mutators_dir = true,
+  Optional[String]   $sensu_user = undef,
+  Optional[String]   $sensu_group = undef,
   Variant[Undef,Integer,Pattern[/^(\d+)$/]] $rabbitmq_port = undef,
   Optional[String]   $rabbitmq_host = undef,
   Optional[String]   $rabbitmq_user = undef,
@@ -528,8 +536,14 @@ class sensu (
     'Debian','RedHat': {
       $etc_dir = $sensu_etc_dir
       $conf_dir = "${etc_dir}/conf.d"
-      $user = 'sensu'
-      $group = 'sensu'
+      $user = $sensu_user  ? {
+        undef   => 'sensu',
+        default => $sensu_user,
+      }
+      $group = $sensu_group ? {
+        undef   => 'sensu',
+        default => $sensu_group,
+      }
       $home_dir = '/opt/sensu'
       $shell = '/bin/false'
       $dir_mode = '0555'
@@ -539,8 +553,14 @@ class sensu (
     'windows': {
       $etc_dir = $sensu_etc_dir
       $conf_dir = "${etc_dir}/conf.d"
-      $user = 'NT Authority\SYSTEM'
-      $group = 'Administrators'
+      $user = $sensu_user  ? {
+        undef   => 'NT Authority\SYSTEM',
+        default => $sensu_user,
+      }
+      $group = $sensu_group ? {
+        undef   => 'Administrators',
+        default => $sensu_group,
+      }
       $home_dir = $etc_dir
       $shell = undef
       $dir_mode = undef

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -182,6 +182,14 @@ describe 'sensu', :type => :class do
       it { should_not contain_user('sensu') }
     end
 
+    describe 'with sensu_user => Administrateur and sensu_group => Administrateurs' do
+      let(:params) do
+        {:sensu_user  => 'Administrateur',
+         :sensu_group => 'Administrateurs'}
+      end
+      it { should contain_file('C:/opt/sensu/conf.d').with({:owner => 'Administrateur', :group => 'Administrateurs'}) }
+    end
+
     context 'with sensu_etc_dir => C:/etc/sensu' do
       let(:params) { {:sensu_etc_dir => 'C:/etc/sensu' } }
       # resources from sensu::package


### PR DESCRIPTION
# Pull Request Checklist

This adds parameters to override default sensu user and group.
Necessary on Windows when localisation change the default Administrators group name.

## Description
Added relevant parasm ini sensu class and managed the correspondent user and group values if such params are set

## Related Issue
Fixes #769

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
