### PR TITLE
Add vagrant tests for add/remove checks with sensu::check

### DIFF
--- a/tests/add_remove-check.pp
+++ b/tests/add_remove-check.pp
@@ -1,0 +1,33 @@
+node 'sensu-server' {
+
+  class { '::sensu':
+    install_repo          => true,
+    server                => true,
+    manage_services       => true,
+    manage_user           => true,
+    rabbitmq_password     => 'correct-horse-battery-staple',
+    rabbitmq_vhost        => '/sensu',
+    spawn_limit           => 16,
+    api                   => true,
+    api_user              => 'admin',
+    api_password          => 'secret',
+    client_address        => $::ipaddress_eth1,
+    subscriptions         => ['all', 'roundrobin:poller'],
+    client_deregister     => true,
+    client_deregistration => {'handler' => 'deregister_client'},
+  }
+
+  if $::test == 'add' {
+    sensu::check { 'check_to_remove':
+      command     => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H :::address::: -w 30 -c 60',
+      standalone  => false,
+      handlers    => 'default',
+      subscribers => 'roundrobin:poller',
+      cron        => '*/5 * * * *',
+    }
+  } else {
+    sensu::check { 'check_to_remove':
+      ensure => 'absent',
+    }
+  }
+}

--- a/tests/add_remove-check.sh
+++ b/tests/add_remove-check.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+exitcode=1
+
+function get_available_checks {
+  curl -s http://admin:secret@127.0.0.1:4567/checks | jq .[].name | awk -F \" '{print $2}' | awk -F \. '{print $1}'
+}
+
+function check_available() {
+  checks=$(get_available_checks)
+
+  if [ -z "${checks##*$1*}" ] ;then
+    echo 'true'
+  else
+    echo 'false'
+  fi
+}
+
+echo -e "\nList of checks available beforehand:"
+get_available_checks
+
+
+if [ $(check_available check_to_remove) == 'false' ]; then
+  echo -e "\nThe check 'check_to_remove' isn't available and should get added now\n"
+  FACTER_test='add' puppet apply /vagrant/tests/add_remove-check.pp
+
+  if [ $(check_available check_to_remove) == 'true' ]; then
+    echo -e "\nThe check 'check_to_remove' have been addedd successfully"
+    exitcode=0
+  else
+    echo -e "\nSomething went wrong, the check 'check_to_remove' have NOT been addedd successfully"
+  fi
+
+else
+  echo -e "\nThe check 'check_to_remove' is available and should get removed now\n"
+  FACTER_test='remove' puppet apply /vagrant/tests/add_remove-check.pp
+  if [ $(check_available check_to_remove) == 'false' ]; then
+    echo -e "\nThe check 'check_to_remove' have been removed successfully"
+    exitcode=0
+  else
+    echo -e "\nSomething went wrong, the check 'check_to_remove' have NOT been removed successfully"
+  fi
+fi
+
+echo -e "\nList of checks available afterwards:"
+get_available_checks
+exit $exitcode


### PR DESCRIPTION
Welcome my first tests for Vagrant. Hope this is what was indented.

`add_remove-check.sh` will test if the check `check_to_remove` is available. Depending of the result, the check will get created or deleted.

The script is prepared for further automation and gives exit code `0` only if successfully.

Fixes #747 
