### PR TITLE
[815] Resolve circular dependency when using sensu::enterprise::dashboard::api

### DIFF
--- a/manifests/enterprise/dashboard/api.pp
+++ b/manifests/enterprise/dashboard/api.pp
@@ -39,7 +39,7 @@ define sensu::enterprise::dashboard::api (
   Optional[String]  $pass          = undef,
 ) {
 
-  require ::sensu::enterprise::dashboard
+  include ::sensu::enterprise::dashboard
 
   sensu_enterprise_dashboard_api_config { $title:
     ensure     => $ensure,


### PR DESCRIPTION
See issue #815 on Github for more details. Previously, when declaring the sensu
class along with an instance of the sensu::enterprise::dashboard::api defined
type, a circular dependency was raised by Puppet. This was caused because
first, the sensu::enterprise::dashboard::api defined type declares an instance
of the sensu_enterprise_dashboard_api_config type, and the
sensu_enterprise_dashboard_api_config type contains, within the initialize
method, contains an automatic "notify" on the "sensu-enterprise-dashboard" service (i.e.
Service['sensu-enterprise-dashboard']). The sensu::enterprise::dashboard::api
defined type also uses the require function on the sensu::enterprise::dashboard
class, which sets a 'require' dependency on every resource within the class.
Because Service['sensu-enterprise-dashboard'] is located within the
sensu::enterprise::dashboard class, that means that
Service['sensu-enterprise-dashboard'] contains a circular dependency on any
instance of the sensu::enterprise::dashboard::api defined type.

To resolve the circular dependency, this commit changes the require function
within the sensu::enterprise::dashboard::api defined type to
the include function which eliminates the 'require' dependency.

I tested this change out with vagrant and was able to get JSON back from the
API, but I'd prefer someone with greater Sensu Enterprise knowledge to validate
and ensure that converting 'require' to 'include' didn't upset any existing
dependencies.