### PR TITLE
[WIP] Refactor to use DSC for installing the service on Windows

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -40,12 +40,35 @@ class sensu::client (
         content => template("${module_name}/sensu-client.erb"),
       }
 
-      exec { 'install-sensu-client':
-        provider => 'powershell',
-        command  => "New-Service -Name sensu-client -BinaryPathName c:\\opt\\sensu\\bin\\sensu-client.exe -DisplayName 'Sensu Client' -StartupType Automatic",
-        unless   => 'if (Get-Service sensu-client -ErrorAction SilentlyContinue) { exit 0 } else { exit 1 }',
-        before   => Service['sensu-client'],
-        require  => File['C:/opt/sensu/bin/sensu-client.xml'],
+      if $::sensu::windows_service_user {
+        dsc_userrightsassignment { $::sensu::windows_service_user['user']:
+          dsc_ensure   => present,
+          dsc_policy   => 'Log_on_as_a_service',
+          dsc_identity => $::sensu::windows_service_user['user'],
+          before       => Dsc_service['sensu-client'],
+        }
+
+        acl { 'C:/opt/sensu':
+          purge       => false,
+          permissions => [
+            {
+              'identity' => $::sensu::windows_service_user['user'],
+              'rights'   => ['full'],
+            },
+          ],
+          before      => Dsc_service['sensu-client'],
+        }
+      }
+
+      dsc_service { 'sensu-client':
+        dsc_ensure      => present,
+        dsc_name        => 'sensu-client',
+        dsc_credential  => $::sensu::windows_service_user,
+        dsc_displayname => 'Sensu Client',
+        dsc_path        => 'c:\\opt\\sensu\\bin\\sensu-client.exe',
+        require         => File['C:/opt/sensu/bin/sensu-client.xml'],
+        # See MODULES-4570
+        notify          => Service['sensu-client'],
       }
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -418,6 +418,7 @@ class sensu (
   Optional[String]   $windows_choco_repo = undef,
   String             $windows_package_name = 'Sensu',
   String             $windows_package_title = 'sensu',
+  Optional[Struct[{NotUndef[user] => String, NotUndef[password] => String}]] $windows_service_user = undef,
   Optional[Variant[Stdlib::Absolutepath,Array[Stdlib::Absolutepath]]] $confd_dir = undef,
   Variant[Integer,Pattern[/^(\d+)/],Undef] $heap_size = undef,
   ### START Hiera Lookups###

--- a/metadata.json
+++ b/metadata.json
@@ -62,6 +62,14 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">=4.16.0 <5.0.0"
+    },
+    {
+      "name": "puppetlabs/dsc",
+      "version_requirement": ">=1.4.0 <2.0.0"
+    },
+    {
+      "name": "puppetlabs/acl",
+      "version_requirement": ">=2.0.1 <3.0.0"
     }
   ]
 }


### PR DESCRIPTION
## Description
* Add new parameter `$windows_service_user` which can be used to run the
  service as a different user on Windows.
* Use `dsc_service` resource instead of `exec` to install the service.
  If `$windows_service_user` isn't set then this will just use the Local
  System user as normal.
* If `$windows_service_user` is set then also use the
  `dsc_userrightsassignment` resource to grant the "Log on as a service"
  right to the user and also use the `acl` module to grant permission
  for the user to access the Sensu install directory.

## Related Issue
Fixes #819 .

## Motivation and Context
This allows you to run Sensu as a specific user account instead of the default Local System account, which in this case means it can use an AD account that has permission to monitor/read files on restricted SMB/CIFS shares.

## How Has This Been Tested?
So far I've tested this by running Puppet with and without setting `$windows_service_user` and confirming that the Sensu Client service is running.

In accordance with the DSC module, you do need to have the following resource set somewhere:
```puppet
reboot { 'dsc_reboot' :
  message => 'DSC has requested a reboot',
  when    => 'pending'
}
```
However this doesn't change doesn't trigger any reboots.

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
