### PR TITLE
fix

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -149,8 +149,8 @@ define sensu::check (
     'windows': {
       $etc_dir = 'C:/opt/sensu'
       $conf_dir = "${etc_dir}/conf.d"
-      $user = undef
-      $group = undef
+      $user = $::sensu::user
+      $group = $::sensu::group
       $file_mode = undef
     }
     default: {

--- a/manifests/enterprise/dashboard/api.pp
+++ b/manifests/enterprise/dashboard/api.pp
@@ -39,7 +39,7 @@ define sensu::enterprise::dashboard::api (
   Optional[String]  $pass          = undef,
 ) {
 
-  require ::sensu::enterprise::dashboard
+  include ::sensu::enterprise::dashboard
 
   sensu_enterprise_dashboard_api_config { $title:
     ensure     => $ensure,


### PR DESCRIPTION
# Pull Request Checklist

Changing user and group from undef to use the user paramater

## Description
Changing user and group from undef to use the user paramater


## Related Issue
I was having an issue where the module was setting the user to a domain account because we had set it to that using a very old fork of a module. For some reason, puppet kept changing it back to that user if I'd change the ownership, so I'm defining the user from init.pp rather than leaving it as undef

Fixes # .

## Motivation and Context

I was having an issue where the module was setting the user to a domain account because we had set it to that using a very old fork of a module. For some reason, puppet kept changing it back to that user if I'd change the ownership, so I'm defining the user from init.pp rather than leaving it as undef. Also adding in the cyclical dependency fix that @glarizza put in.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
