### PR TITLE
Notify enterprise on checks

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -149,8 +149,8 @@ define sensu::check (
     'windows': {
       $etc_dir = 'C:/opt/sensu'
       $conf_dir = "${etc_dir}/conf.d"
-      $user = undef
-      $group = undef
+      $user = $::sensu::user
+      $group = $::sensu::group
       $file_mode = undef
     }
     default: {

--- a/manifests/enterprise/dashboard/api.pp
+++ b/manifests/enterprise/dashboard/api.pp
@@ -39,7 +39,7 @@ define sensu::enterprise::dashboard::api (
   Optional[String]  $pass          = undef,
 ) {
 
-  require ::sensu::enterprise::dashboard
+  include ::sensu::enterprise::dashboard
 
   sensu_enterprise_dashboard_api_config { $title:
     ensure     => $ensure,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -455,7 +455,7 @@ class sensu (
     $client_service = undef
   }
 
-  if $enterprise $manage {
+  if $enterprise and $manage_services {
     $enterprise_service = Service['sensu-enterprise']
   } else {
     $enterprise_service = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -455,7 +455,7 @@ class sensu (
     $client_service = undef
   }
 
-  if $enterprise {
+  if $enterprise $manage {
     $enterprise_service = Service['sensu-enterprise']
   } else {
     $enterprise_service = undef

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -468,7 +468,7 @@ class sensu (
   }
 
   $check_notify = $enterprise ? {
-    true    => delete_undef_values([ $client_service, $server_service_class, $api_service, Service['sensu-enterprise'] ]),
+    true    => delete_undef_values([ $client_service, Service['sensu-enterprise'] ]),
     default => delete_undef_values([ $client_service, $server_service_class, $api_service ])
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -455,6 +455,12 @@ class sensu (
     $client_service = undef
   }
 
+  if $enterprise {
+    $enterprise_service = Service['sensu-enterprise']
+  } else {
+    $enterprise_service = undef
+  }
+
   if $server {
     $server_service_class = Class['sensu::server::service']
   } else {
@@ -467,10 +473,7 @@ class sensu (
     $api_service = undef
   }
 
-  $check_notify = $enterprise ? {
-    true    => delete_undef_values([ $client_service, Service['sensu-enterprise'] ]),
-    default => delete_undef_values([ $client_service, $server_service_class, $api_service ])
-  }
+  $check_notify = delete_undef_values([ $client_service, $server_service_class, $api_service, $enterprise_service ])
 
   # Because you can't reassign a variable in puppet and we need to set to
   # false if you specify a directory, we have to use another variable.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -467,7 +467,10 @@ class sensu (
     $api_service = undef
   }
 
-  $check_notify = delete_undef_values([ $client_service, $server_service_class, $api_service ])
+  $check_notify = $enterprise ? {
+    true    => delete_undef_values([ $client_service, $server_service_class, $api_service, Service['sensu-enterprise'] ]),
+    default => delete_undef_values([ $client_service, $server_service_class, $api_service ])
+  }
 
   # Because you can't reassign a variable in puppet and we need to set to
   # false if you specify a directory, we have to use another variable.


### PR DESCRIPTION
# Pull Request Checklist

## Description
- getting rid of dependency cycle (used this commit 2cebbdef163bf12d66b59e8b27aa58bd10559219)
- changing the user on check.pp to $::sensu::user
- adding Service['sensu-enterprise'] to $check_notify array


## Related Issue

https://github.com/sensu/sensu-puppet/issues/827

## Motivation and Context
Enterprise service is not reloading anymore

## How Has This Been Tested?
tested this against our sensu-enterprise cluster and it works fine

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
