### PR TITLE
Added client_registration option #749

### DIFF
--- a/lib/puppet/type/sensu_client_config.rb
+++ b/lib/puppet/type/sensu_client_config.rb
@@ -125,6 +125,11 @@ Puppet::Type.newtype(:sensu_client_config) do
     newvalues(/.*/, :absent)
   end
 
+  newproperty(:registration) do
+    desc 'Client registration attributes'
+    newvalues(/.*/, :absent)
+  end
+
   newproperty(:keepalive) do
     desc "Keepalive config"
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -93,6 +93,7 @@ class sensu::client (
     redact         => $::sensu::redact,
     deregister     => $::sensu::client_deregister,
     deregistration => $::sensu::client_deregistration,
+    registration   => $::sensu::client_registration,
     http_socket    => $::sensu::client_http_socket,
     servicenow     => $::sensu::client_servicenow,
     ec2            => $::sensu::client_ec2,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -162,6 +162,11 @@
 #   status, and issued timestamp. The following attributes are provided as
 #   recommendations for controlling client deregistration behavior.
 #
+# @param client_registration [Attributes](https://sensuapp.org/docs/latest/reference/clients#registration-attributes)
+#   used to generate check result data for the registration event. Client
+#   registration attributes are merged with some default check definition
+#   attributes by the Sensu server during client registration.
+#
 # @param client_keepalive Client keepalive configuration
 #
 # @param client_http_socket Client http_socket configuration. Must be an Hash of
@@ -371,6 +376,7 @@ class sensu (
   Hash               $client_custom = {},
   Variant[Undef,Boolean] $client_deregister = undef,
   Variant[Undef,Hash] $client_deregistration = undef,
+  Variant[Undef,Hash] $client_registration = undef,
   Hash               $client_keepalive = {},
   Hash               $client_http_socket = {},
   Hash               $client_servicenow = {},

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -110,6 +110,24 @@ describe 'sensu', :type => :class do
           end
         end
 
+        describe 'client_registration' do
+          let(:params_override) { {client_registration: registration} }
+          context "=> {'handler': 'register_client'}" do
+            let(:registration) { {'handler' => 'register_client'} }
+            it { is_expected.to contain_sensu_client_config(title).with(registration: registration) }
+          end
+
+          context "=> {}" do
+            let(:registration) { {} }
+            it { is_expected.to contain_sensu_client_config(title).with(registration: registration) }
+          end
+
+          context "=> 'absent' (error)" do
+            let(:registration) { 'absent' }
+            it { is_expected.to raise_error(Puppet::Error) }
+          end
+        end
+
         describe 'http_socket' do
           http_socket = {
             'bind' => '127.0.0.1',

--- a/spec/unit/sensu_client_config_spec.rb
+++ b/spec/unit/sensu_client_config_spec.rb
@@ -41,6 +41,21 @@ describe Puppet::Type.type(:sensu_client_config) do
     end
   end
 
+  describe 'registration' do
+    subject { described_class.new(resource_hash)[:registration] }
+    context 'in the default case' do
+      it { is_expected.to be_nil }
+    end
+    context '=> {}' do
+      let(:resource_hash_override) { {registration: {}} }
+      it { is_expected.to eq({}) }
+    end
+    context '=> absent' do
+      let(:resource_hash_override) { {registration: 'absent'} }
+      it { is_expected.to eq(:absent) }
+    end
+  end
+
   describe 'notifications' do
     let(:resource_hash) do
       c = Puppet::Resource::Catalog.new


### PR DESCRIPTION
# Pull Request Checklist

This implements client registration settings for client config.
It replaces https://github.com/sensu/sensu-puppet/pull/812

## Description
I've made this completely similar to the de-register configurations, but I'm now sure we actually need the register parameter (in sensu docs only registration is mentioned)

The service starts anyway, as Sensu is tolerant of unknown settings in client.json. 

Fixes #749 

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`