### PR TITLE
Added hooks support #836

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,6 +457,26 @@ This will create the following check definition for Sensu:
 }
 ```
 
+## Using hooks in check definitions
+
+[Hooks](https://sensuapp.org/docs/latest/reference/checks.html#check-hooks) are commands run by the Sensu client in response
+to the result of check command execution. They have been introduced in Sensu 1.1.
+
+Valid hooks names are integers from 1 to 255 and the strings 'ok', 'warning', 'critical', 'unknown' and 'non-zero'.
+
+```puppet
+sensu::check{ 'check_file_test':
+  command      => '/usr/local/bin/check_file_test.sh',
+  handlers     => 'notifu',
+  hooks => {
+    'non-zero' => {
+      'command' => 'ps aux',
+     }
+  },
+  subscribers  => 'sensu-test'
+}
+```
+
 ## Writing custom configuration files
 
 You can also use the `sensu::write_json` defined resource type to write custom

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -90,6 +90,11 @@
 #   matches the defined client attributes.  See the documentation for the format
 #   of the Hash value.
 #
+# @param hooks Manages
+# [Hooks](https://sensuapp.org/docs/latest/reference/checks.html#hooks-attributes)
+#   Since Sensu 1.1.0.  Manages hooks for a check. See the documentation for the format
+#   of the Hash value.
+#
 define sensu::check (
   Optional[String]                      $command = undef,
   Enum['present','absent']              $ensure = 'present',
@@ -116,6 +121,7 @@ define sensu::check (
   Variant[Undef,Enum['absent'],Integer] $ttl = undef,
   Variant[Undef,Enum['absent'],Hash]    $subdue = undef,
   Variant[Undef,Enum['absent'],Hash]    $proxy_requests = undef,
+  Variant[Undef,Enum['absent'],Hash]    $hooks = undef,
 ) {
   if $ensure == 'present' and !$command {
     fail("sensu::check{${name}}: a command must be given when ensure is present")
@@ -193,6 +199,16 @@ define sensu::check (
   Anchor['plugins_before_checks']
   ~> Sensu::Check[$name]
 
+  if is_hash($hooks) {
+    $hooks.each |$k,$v| {
+      $valid_k = $k ? {
+        Integer[1,255]                                           => true,
+        Enum['ok', 'warning', 'critical', 'unknown', 'non-zero'] => true,
+        default => fail("Illegal value for ${k} hook. Valid values are: Integers from 1 to 255 and any of 'ok', 'warning', 'critical', 'unknown', 'non-zero'"),
+      }
+    }
+  }
+
   # This Hash map will ultimately exist at `{"checks" => {"$check_name" =>
   # $check_config}}`
   $check_config_start = {
@@ -217,6 +233,7 @@ define sensu::check (
     dependencies        => $dependencies_array,
     subdue              => $subdue,
     proxy_requests      => $proxy_requests,
+    hooks               => $hooks,
     ttl                 => $ttl,
   }
 

--- a/spec/defines/sensu_check_spec.rb
+++ b/spec/defines/sensu_check_spec.rb
@@ -334,6 +334,40 @@ describe 'sensu::check', :type => :define do
     end
   end
 
+  describe 'param hooks' do
+    context 'valid hooks hash' do
+      let(:params_override) do
+        { hooks: { 'non-zero' => { 'command' => 'ps aux' , 'timeout' => '10' } } }
+      end
+
+      let :expected_content do
+        {"checks"=>{"mycheck"=>{"standalone"=>true, "command"=>"/etc/sensu/somecommand.rb", "interval"=>60,                                                   "hooks"=>{"non-zero"=>{"command"=>"ps aux", "timeout"=>"10"}}}}}
+      end
+
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
+    end
+
+    context 'invalid hooks hash' do
+      let(:params_override) do
+        { hooks: { 'a_value' => { 'command' => 'ps aux' , 'timeout' => '10' } } }
+      end
+
+      it 'should fail' do
+        expect { should contain_class(subject) }.to raise_error(Puppet::Error, /Illegal value for a_value hook. Valid values are: Integers from 1 to 255 and any of 'ok', 'warning', 'critical', 'unknown', 'non-zero'/)
+      end
+    end
+
+    context '=> \'absent\'' do
+      let(:params_override) { { hooks: 'absent' } }
+
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
+    end
+
+    context '= undef' do
+      it { should contain_sensu__write_json(fpath).with_content(expected_content) }
+    end
+  end
+
   describe 'param cron' do
     context 'default behavior (not specified)' do
       let(:params_override) { {} }

--- a/tests/sensu-836.pp
+++ b/tests/sensu-836.pp
@@ -1,0 +1,116 @@
+node 'sensu-server' {
+  $deregistration = { 'handler' => 'deregister_client' }
+
+  class { '::sensu':
+    install_repo          => true,
+    server                => true,
+    manage_services       => true,
+    manage_user           => true,
+    rabbitmq_password     => 'correct-horse-battery-staple',
+    rabbitmq_vhost        => '/sensu',
+    spawn_limit           => 16,
+    api                   => true,
+    api_user              => 'admin',
+    api_password          => 'secret',
+    client_address        => $::ipaddress_eth1,
+    subscriptions         => ['all', 'roundrobin:poller'],
+    client_deregister     => true,
+    client_deregistration => $deregistration,
+    redact                => ["password", "passwd", "pass", "api_key", "api_token", "access_key", "secret_key", "private_key", "secret", "ec2_access_key", "ec2_secret_key"],
+  }
+
+  sensu::handler { 'default':
+    command => 'mail -s \'sensu alert\' ops@example.com',
+  }
+
+  # Example handler which operates in silenced checks
+  #
+  # This should create a file in /etc/sensu/conf.d/handlers/handle_silenced.json, containing the following:
+  #
+  #  {
+  #    "handlers": {
+  #      "mail_handle_silenced": {
+  #        "command": "mail -s 'sensu alert' ops@example.com",
+  #        "type": "pipe",
+  #        "filters": [
+  #
+  #        ],
+  #        "severities": [
+  #          "ok",
+  #          "warning",
+  #          "critical",
+  #          "unknown"
+  #        ],
+  #        "handle_flapping": false,
+  #        "handle_silenced": true
+  #      }
+  #    }
+  #  }
+  sensu::handler { 'mail_handle_silenced':
+    command         => 'mail -s \'sensu alert\' ops@example.com',
+    handle_silenced => true,
+  }
+
+  sensu::check { 'check_ntp':
+    command     => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H pool.ntp.org -w 30 -c 60',
+    handlers    => 'default',
+    subscribers => 'sensu-test',
+  }
+
+  $proxy_requests_ntp = {
+    'client_attributes' => {
+      'subscriptions' => 'eval: value.include?("ntp")',
+    },
+  }
+
+  # Example check using the cron schedule.
+  sensu::check { 'remote_check_ntp':
+    command        => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H :::address::: -w 30 -c 60',
+    standalone     => false,
+    handlers       => 'default',
+    subscribers    => 'roundrobin:poller',
+    cron           => '*/5 * * * *',
+    proxy_requests => $proxy_requests_ntp,
+  }
+
+  # A client defined in the Dashboard with a subscription of "http" will
+  # automatically have this check associated with it.  Check Google with the
+  # following API call to create a proxy client definition:
+  #
+  #     curl -s -i -X POST -H 'Content-Type: application/json' \
+  #       -d '{"name":"google.com","address":"google.com","subscriptions":["http"]}' \
+  #       http://admin:secret@127.0.0.1:4567/clients
+  #
+  # Then, trigger the check with:
+  #
+  #     curl -s -i -X POST -H 'Content-Type: application/json' \
+  #       -d '{"check": "remote_http"}' \
+  #       http://admin:secret@127.0.0.1:4567/request
+  $proxy_requests_http = {
+    'client_attributes' => {
+      'subscriptions' => 'eval: value.include?("http")',
+    },
+  }
+  $hooks = {
+    warning => {
+      'command' => 'ps aux',
+      'timeout' =>'10',
+    },
+    wrong => {
+      'command' => 'ps aux',
+      'timeout' =>'10',
+    }
+  }
+  sensu::check { 'remote_http':
+    command             => '/opt/sensu/embedded/bin/check-http.rb -u http://:::address:::',
+    occurrences         => 2,
+    interval            => 300,
+    refresh             => 600,
+    low_flap_threshold  => 20,
+    high_flap_threshold => 60,
+    standalone          => false,
+    subscribers         => 'roundrobin:poller',
+    proxy_requests      => $proxy_requests_http,
+    hooks               => $hooks,
+  }
+}


### PR DESCRIPTION
# Pull Request Checklist

Introduces support for hooks

## Description
Commit addes the hooks parameter to the sensu::check define

## Related Issue
Fixes #836 

## Motivation and Context

## How Has This Been Tested?
Spec tested.
Integration test on PSICK setup.

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
