### PR TITLE
Add platform specific user and group for transport

### DIFF
--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -20,8 +20,8 @@ class sensu::transport {
 
   file { "${sensu::conf_dir}/transport.json":
     ensure  => $ensure,
-    owner   => 'sensu',
-    group   => 'sensu',
+    owner   => $::sensu::user,
+    group   => $::sensu::group,
     mode    => '0440',
     content => inline_template('<%= JSON.pretty_generate(@transport_type_hash) %>'),
     notify  => $::sensu::check_notify,


### PR DESCRIPTION
# Pull Request Checklist

Fixes transport class for windows

## Description
Add sensu user and group vars to file enforcement in the transport class

## Related Issue

Fixes #838

## How Has This Been Tested?
Our lab, on RHEL 6 and 7 as well as Windows Server 2012R2, using Puppet 2017.3.1

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
