### PR TITLE
Change default mode value for creation of json files

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -147,17 +147,13 @@ define sensu::check (
 
   case $::osfamily {
     'windows': {
-      $etc_dir = 'C:/opt/sensu'
-      $conf_dir = "${etc_dir}/conf.d"
-      $user = $::sensu::user
-      $group = $::sensu::group
+      $etc_dir   = 'C:/opt/sensu'
+      $conf_dir  = "${etc_dir}/conf.d"
       $file_mode = undef
     }
     default: {
-      $etc_dir = '/etc/sensu'
-      $conf_dir = "${etc_dir}/conf.d"
-      $user = $::sensu::user
-      $group = $::sensu::group
+      $etc_dir   = '/etc/sensu'
+      $conf_dir  = "${etc_dir}/conf.d"
       $file_mode = '0440'
     }
   }
@@ -252,8 +248,8 @@ define sensu::check (
   sensu::write_json { "${conf_dir}/checks/${check_name}.json":
     ensure      => $ensure,
     content     => $content_real,
-    owner       => $user,
-    group       => $group,
+    owner       => $::sensu::user,
+    group       => $::sensu::group,
     mode        => $file_mode,
     notify_list => $::sensu::check_notify,
   }

--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -156,8 +156,8 @@ define sensu::check (
     default: {
       $etc_dir = '/etc/sensu'
       $conf_dir = "${etc_dir}/conf.d"
-      $user = 'sensu'
-      $group = 'sensu'
+      $user = $::sensu::user
+      $group = $::sensu::group
       $file_mode = '0440'
     }
   }

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -18,23 +18,15 @@ class sensu::transport {
     },
   }
 
-  case $::osfamily {
-    'windows': {
-      $user      = $::sensu::user
-      $group     = $::sensu::group
-      $file_mode = undef
-    }
-    default: {
-      $user      = 'sensu'
-      $group     = 'sensu'
-      $file_mode = '0440'
-    }
+  $file_mode = $::osfamily ? {
+    'windows' => undef,
+    default   => '0440',
   }
 
   file { "${sensu::conf_dir}/transport.json":
     ensure  => $ensure,
-    owner   => $user,
-    group   => $group,
+    owner   => $::sensu::user,
+    group   => $::sensu::group,
     mode    => $file_mode,
     content => inline_template('<%= JSON.pretty_generate(@transport_type_hash) %>'),
     notify  => $::sensu::check_notify,

--- a/manifests/transport.pp
+++ b/manifests/transport.pp
@@ -18,11 +18,24 @@ class sensu::transport {
     },
   }
 
+  case $::osfamily {
+    'windows': {
+      $user      = $::sensu::user
+      $group     = $::sensu::group
+      $file_mode = undef
+    }
+    default: {
+      $user      = 'sensu'
+      $group     = 'sensu'
+      $file_mode = '0440'
+    }
+  }
+
   file { "${sensu::conf_dir}/transport.json":
     ensure  => $ensure,
-    owner   => 'sensu',
-    group   => 'sensu',
-    mode    => '0440',
+    owner   => $user,
+    group   => $group,
+    mode    => $file_mode,
     content => inline_template('<%= JSON.pretty_generate(@transport_type_hash) %>'),
     notify  => $::sensu::check_notify,
   }

--- a/manifests/write_json.pp
+++ b/manifests/write_json.pp
@@ -33,7 +33,7 @@ define sensu::write_json (
   Enum['present', 'absent'] $ensure = 'present',
   String                    $owner = 'sensu',
   String                    $group = 'sensu',
-  String                    $mode = '0755',
+  String                    $mode = '0775',
   Boolean                   $pretty = true,
   Hash                      $content = {},
   Array[Variant[Data,Type]] $notify_list = [],

--- a/spec/defines/sensu_write_json_spec.rb
+++ b/spec/defines/sensu_write_json_spec.rb
@@ -21,7 +21,7 @@ describe 'sensu::write_json', :type => :define do
 
       it { should contain_sensu__write_json(CFG_PATH).with(
         :ensure => 'present',
-        :mode => '0755',
+        :mode => '0775',
         :owner => 'sensu',
         :group => 'sensu',
         :pretty => true,
@@ -30,7 +30,7 @@ describe 'sensu::write_json', :type => :define do
 
       it { should contain_file(CFG_PATH).with(
         :ensure => 'present',
-        :mode => '0755',
+        :mode => '0775',
         :owner => 'sensu',
         :group => 'sensu',
         :content => CUSTOM_CFG_PRETTY,
@@ -48,7 +48,7 @@ describe 'sensu::write_json', :type => :define do
         :ensure => 'absent',
         :owner => 'sensu',
         :group => 'sensu',
-        :mode => '0755',
+        :mode => '0775',
         :notify => [],
         :subscribe => nil,
       ) }
@@ -92,7 +92,7 @@ describe 'sensu::write_json', :type => :define do
 
       it { should contain_file(CFG_PATH).with(
         :ensure => 'present',
-        :mode => '0755',
+        :mode => '0775',
         :owner => 'sensu',
         :group => 'sensu',
         :content => "{\"custom\":\"data\"}",


### PR DESCRIPTION
## Problem
I was testing the latest version of the module in a vagrant windows machine, after running puppet several times, the creation of the JSON checks by `sensu::write_json` tries repeatedly to apply `mode changed '0775' to '0755'`.

Supposedly this piece of code on `sensu::check` should avoid this situation but when it is a Windows machine the `$file_mode = undef` doesn't have any effect
```
case $::osfamily {
    'windows': {
      $etc_dir = 'C:/opt/sensu'
      $conf_dir = "${etc_dir}/conf.d"
      $user = $::sensu::user
      $group = $::sensu::group
      $file_mode = undef
    }
    default: {
      $etc_dir = '/etc/sensu'
      $conf_dir = "${etc_dir}/conf.d"
      $user = 'sensu'
      $group = 'sensu'
      $file_mode = '0440'
    }
  }
```
Due to having `$mode = '0755'` in the `sensu::write_json`

```
define sensu::write_json (
  Enum['present', 'absent'] $ensure = 'present',
  String                    $owner = 'sensu',
  String                    $group = 'sensu',
  String                    $mode = '0755',
  Boolean                   $pretty = true,
  Hash                      $content = {},
  Array[Variant[Data,Type]] $notify_list = [],
) {
```

## Motivation and Context
This modification is required because of:
- To avoid trying to change the mode each time puppet runs
- Odd results in the checks

![image](https://user-images.githubusercontent.com/722128/32500724-6d778de6-c3d6-11e7-80af-8306d6af9b9b.png)

## How Has This Been Tested?
I tested it in a vagrant machine `opentable/win-2012r2-standard-amd64-nocm` and also in a windows server from Azure.
I just create some checks with:
```
sensu::check { $title:
    ensure      => $ensure,
    command     => $check,
    type        => 'check',
    custom      => $custom,
    handlers    => $handler,
    interval    => $interval,
    occurrences => $occurrences,
    refresh     => $refresh,
    notify      => Service['sensu-client'],
  }
```
This change doesn't affects other operating systems due to the default case in the `sensu::check`
```
default: {
      $etc_dir = '/etc/sensu'
      $conf_dir = "${etc_dir}/conf.d"
      $user = 'sensu'
      $group = 'sensu'
      $file_mode = '0440'
    }
```

## General

- [x] Tests pass - `bundle exec rake validate lint spec`
