### PR TITLE
Added config_file params to CONFIG_FILE envvar #851

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -304,6 +304,8 @@
 #
 # @param max_open_files Value of the MAX_OPEN_FILES environment variable.
 #
+# @param config_file Value of the CONFIG_FILE environment variable.
+#
 # @param heap_dump_path Value of the HEAP_DUMP_PATH environment variable.
 #
 # @param java_opts Value of the JAVA_OPTS environment variable.
@@ -432,6 +434,7 @@ class sensu (
   String             $windows_package_title = 'sensu',
   Optional[Variant[Stdlib::Absolutepath,Array[Stdlib::Absolutepath]]] $confd_dir = undef,
   Variant[Integer,Pattern[/^(\d+)/],Undef] $heap_size = undef,
+  Variant[Stdlib::Absolutepath,Undef] $config_file = undef,
   Variant[Undef,Integer,Pattern[/^(\d+)$/]] $max_open_files = undef,
   Variant[Undef,String] $heap_dump_path = undef,
   Variant[Undef,String] $java_opts      = undef,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -10,6 +10,8 @@
 # @param heap_size Value of the HEAP_SIZE environment variable.
 #   Note: This has no effect on sensu-core.
 #
+# @param config_file Value of the CONFIG_FILE environment variable.
+# 
 # @param deregister_handler The handler to use when deregistering a client on stop.
 #
 # @param deregister_on_stop Whether the sensu client should deregister from the API on service stop
@@ -38,6 +40,7 @@ class sensu::package (
   Optional[String] $conf_dir            = $::sensu::conf_dir,
   Variant[String,Array,Undef] $confd_dir = $::sensu::confd_dir,
   Variant[Undef,Integer,Pattern[/^(\d+)/]] $heap_size = $::sensu::heap_size,
+  Variant[Stdlib::Absolutepath,Undef] $config_file = $::sensu::config_file,
   Optional[String] $deregister_handler  = $::sensu::deregister_handler,
   Optional[Boolean] $deregister_on_stop = $::sensu::deregister_on_stop,
   Optional[String] $gem_path            = $::sensu::gem_path,

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -393,6 +393,11 @@ describe 'sensu', :type => :class do
     it { should contain_file('/etc/default/sensu').with_content(%r{^HEAP_SIZE="256M"$}) }
   end
 
+  context 'config_file => "/etc/sensu/alternative.json"' do
+    let(:params) { {:config_file => '/etc/sensu/alternative.json' } }
+    it { should contain_file('/etc/default/sensu').with_content(%r{^CONFIG_FILE="/etc/sensu/alternative.json"$}) }
+  end
+
   context 'with plugins => puppet:///data/sensu/plugins/teststring.rb' do
     let(:params) { {:plugins => 'puppet:///data/sensu/plugins/teststring.rb' } }
     it { should contain_sensu__plugin('puppet:///data/sensu/plugins/teststring.rb') }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -487,6 +487,11 @@ describe 'sensu' do
     it { should contain_file('/etc/default/sensu').with_content(%r{^HEAP_SIZE="256M"$}) }
   end
 
+  context 'config_file => "/etc/sensu/alternative.json"' do
+    let(:params) { {:config_file => '/etc/sensu/alternative.json' } }
+    it { should contain_file('/etc/default/sensu').with_content(%r{^CONFIG_FILE="/etc/sensu/alternative.json"$}) }
+  end
+
   describe 'spawn_limit (#727)' do
     context 'default (undef)' do
       it { should contain_file('/etc/sensu/conf.d/spawn.json').without_content }

--- a/templates/sensu.erb
+++ b/templates/sensu.erb
@@ -19,3 +19,6 @@ CONFD_DIR="<%= @conf_dir %>,<%= Array(@confd_dir).join(",") %>"
 <% if @heap_size -%>
 HEAP_SIZE="<%= @heap_size %>"
 <% end -%>
+<% if @config_file -%>
+CONFIG_FILE="<%= @config_file %>"
+<% end -%>


### PR DESCRIPTION
# Pull Request Checklist
This MR replaces #852  adding the config_file parameter following the current approach.

Approach #852 altough more flexible in the long term introduced unnecessary complexity and the need to deprecate in the mid term, several parameters to control environment variables.
 
## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes # .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
