### PR TITLE
Support only the latest releases of Puppet versions 4 and 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,6 @@ matrix:
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.1
-    env: PUPPET_GEM_VERSION="~> 5.0.0"
-  - rvm: 2.4.1
-    env: PUPPET_GEM_VERSION="~> 5.1.0"
-  - rvm: 2.4.1
-    env: PUPPET_GEM_VERSION="~> 5.2.0"
-  - rvm: 2.4.1
-    env: PUPPET_GEM_VERSION="~> 5.3.0"
-  - rvm: 2.4.1
     env: PUPPET_GEM_VERSION="~> 5"
 
 notifications:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Please note, that this is a **Partner Supported** module, which means that techn
 
 [![Build Status](https://travis-ci.org/sensu/sensu-puppet.png)](https://travis-ci.org/sensu/sensu-puppet)
 
+This module supports the latest releases of Puppet versions 4 and 5
+using the ruby that is packaged with the AIO (all-in-one installer). See
+`.travis.yml` for an exact matrix.
+
 ## Documented with Puppet Strings
 
 [Puppet Strings documentation](http://sensu.github.io/sensu-puppet/doc/)


### PR DESCRIPTION
# Pull Request Checklist

No longer supporting minor releases of Puppet 5. If you are having
issues, suggest updating Puppet to the newest release within your major
version.

## Description
Not testing against each minor release of puppet.

## Related Issue
None.

## Motivation and Context
Speed up testing and minimize the number of platforms that are supported.

## How Has This Been Tested?
TravisCI

## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
