### PR TITLE
Use latest puppetlabs/stdlib (2.24.0) and Stdlib::Filemode type

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: 4.1.0
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.16.0
+      ref: 4.24.0
     remote_file:
       repo: git://github.com/lwf/puppet-remote_file.git
       ref: v1.1.3

--- a/manifests/write_json.pp
+++ b/manifests/write_json.pp
@@ -33,7 +33,7 @@ define sensu::write_json (
   Enum['present', 'absent'] $ensure = 'present',
   String                    $owner = 'sensu',
   String                    $group = 'sensu',
-  String                    $mode = '0775',
+  Stdlib::Filemode          $mode = '0775',
   Boolean                   $pretty = true,
   Hash                      $content = {},
   Array[Variant[Data,Type]] $notify_list = [],

--- a/metadata.json
+++ b/metadata.json
@@ -67,7 +67,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.16.0 <5.0.0"
+      "version_requirement": ">=4.24.0 <5.0.0"
     }
   ]
 }

--- a/tests/provision_amazon.sh
+++ b/tests/provision_amazon.sh
@@ -45,7 +45,7 @@ fi
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version 4.16.0
+puppet module install puppetlabs/stdlib --version 4.24.0
 puppet module install puppetlabs/apt --version 4.1.0
 puppet module install lwf-remote_file --version 1.1.3
 puppet module install puppetlabs/powershell --version 2.1.0

--- a/tests/provision_basic_debian.sh
+++ b/tests/provision_basic_debian.sh
@@ -47,7 +47,7 @@ EOF
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version 4.16.0
+puppet module install puppetlabs/stdlib --version 4.24.0
 puppet module install puppetlabs/apt --version 4.1.0
 puppet module install lwf-remote_file --version 1.1.3
 puppet module install puppetlabs/powershell --version 2.1.0

--- a/tests/provision_basic_el.sh
+++ b/tests/provision_basic_el.sh
@@ -43,7 +43,7 @@ fi
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version 4.16.0
+puppet module install puppetlabs/stdlib --version 4.24.0
 puppet module install puppetlabs/apt --version 4.1.0
 puppet module install lwf-remote_file --version 1.1.3
 puppet module install puppetlabs/powershell --version 2.1.0

--- a/tests/provision_basic_el_puppet5.sh
+++ b/tests/provision_basic_el_puppet5.sh
@@ -30,7 +30,7 @@ fi
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version 4.16.0
+puppet module install puppetlabs/stdlib --version 4.24.0
 puppet module install puppetlabs/apt --version 4.1.0
 puppet module install lwf-remote_file --version 1.1.3
 puppet module install puppetlabs/powershell --version 2.1.0

--- a/tests/provision_basic_win.2.ps1
+++ b/tests/provision_basic_win.2.ps1
@@ -25,7 +25,7 @@ $hiera_content | Out-File -FilePath "$hiera_file" -Encoding ascii
 # There are multiple power shell scripts.  The first installs Puppet, but
 # puppet is not in the PATH.  The second invokes a new shell which will have
 # Puppet in the PATH.
-iex "puppet module install puppetlabs/stdlib --version 4.16.0"
+iex "puppet module install puppetlabs/stdlib --version 4.24.0"
 iex "puppet module install puppetlabs/apt --version 4.1.0"
 iex "puppet module install lwf-remote_file --version 1.1.3"
 iex "puppet module install puppetlabs/powershell --version 2.1.0"


### PR DESCRIPTION
# Pull Request Checklist

Use the latest puppetlabs/stdlib module

## Description

Use the latest puppetlabs/stdlib module

## Motivation and Context
Allows us to use Stdlib::Filemode type for file modes

## How Has This Been Tested?
TravisCI and Vagrant

## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
