### PR TITLE
[866] Add Sensu Enterprise Dashboard auth and oidc configuration options

### DIFF
--- a/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
+++ b/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
@@ -119,6 +119,20 @@ Puppet::Type.type(:sensu_enterprise_dashboard_config).provide(:json) do
     conf['dashboard']['pass'] = value
   end
 
+  # Public: Retrieve the auth hash for the dashboard
+  #
+  # Returns the auth config
+  def auth
+    conf['dashboard']['auth']
+  end
+
+  # Public: Set the auth config
+  #
+  # Returns nothing.
+  def auth=(value)
+    conf['dashboard']['auth'] = value.to_hash
+  end
+
   # Public: Set the ssl listener config
   #
   # Returns nothing.
@@ -187,5 +201,19 @@ Puppet::Type.type(:sensu_enterprise_dashboard_config).provide(:json) do
   # Returns nothing.
   def ldap=(value)
     conf['dashboard']['ldap'] = value.to_hash
+  end
+
+  # Public: Retrieve the OIDC config
+  #
+  # Returns the OIDC auth config
+  def oidc
+    conf['dashboard']['oidc']
+  end
+
+  # Public: Set the OIDC config hash
+  #
+  # Returns nothing.
+  def oidc=(value)
+    conf['dashboard']['oidc'] = value.to_hash
   end
 end

--- a/lib/puppet/type/sensu_enterprise_dashboard_config.rb
+++ b/lib/puppet/type/sensu_enterprise_dashboard_config.rb
@@ -56,6 +56,16 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_config) do
     desc "A password to enable simple authentication and restrict access to the dashboard. Leave blank along with user to disable simple authentication."
   end
 
+  newproperty(:auth) do
+    desc "The auth definition scope, used to configure JSON Web Token (JWT) authentication signatures."
+
+    validate do |value|
+      unless value.respond_to?(:to_hash)
+        raise ArgumentError, "Sensu Enterprise Dashboard auth config must be a Hash"
+      end
+    end
+  end
+
   newproperty(:ssl) do
     desc "A hash of SSL attributes to enable native SSL"
 
@@ -102,6 +112,16 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_config) do
     validate do |value|
       unless value.respond_to?(:to_hash)
         raise ArgumentError, "Sensu Enterprise Dashboard LDAP config must be a Hash"
+      end
+    end
+  end
+
+  newproperty(:oidc) do
+    desc "The oidc definition scope, used to configure Role Based Access Controls with the RBAC for OpenID Connect (OIDC) driver. Overrides simple authentication."
+
+    validate do |value|
+      unless value.respond_to?(:to_hash)
+        raise ArgumentError, "Sensu Enterprise Dashboard OIDC config must be a Hash"
       end
     end
   end

--- a/manifests/enterprise/dashboard.pp
+++ b/manifests/enterprise/dashboard.pp
@@ -61,11 +61,13 @@ class sensu::enterprise::dashboard (
       refresh   => $::sensu::enterprise_dashboard_refresh,
       user      => $::sensu::enterprise_dashboard_user,
       pass      => $::sensu::enterprise_dashboard_pass,
+      auth      => $::sensu::enterprise_dashboard_auth,
       ssl       => $::sensu::enterprise_dashboard_ssl,
       audit     => $::sensu::enterprise_dashboard_audit,
       github    => $::sensu::enterprise_dashboard_github,
       gitlab    => $::sensu::enterprise_dashboard_gitlab,
       ldap      => $::sensu::enterprise_dashboard_ldap,
+      oidc      => $::sensu::enterprise_dashboard_oidc,
       notify    => $file_notify,
     }
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -235,6 +235,10 @@
 #   to properly stop and start sensu services when those scripts change,
 #   set it to false. See also http://upstart.ubuntu.com/faq.html#reload
 #
+# @param enterprise_dashboard_auth Optional auth configuration for Enterprise Dashboard
+#
+# @param enterprise_dashboard_oidc Optional OIDC configuration for Enterprise Dashboard
+#
 # @param path Used to set PATH in /etc/default/sensu
 #
 # @param redact Use to redact passwords from checks on the client side
@@ -413,11 +417,13 @@ class sensu (
   Optional[Any]      $enterprise_dashboard_refresh = undef,
   Optional[String]   $enterprise_dashboard_user = undef,
   Optional[String]   $enterprise_dashboard_pass = undef,
+  Optional[Any]      $enterprise_dashboard_auth = undef,
   Optional[Any]      $enterprise_dashboard_ssl = undef,
   Optional[Any]      $enterprise_dashboard_audit = undef,
   Optional[Any]      $enterprise_dashboard_github = undef,
   Optional[Any]      $enterprise_dashboard_gitlab = undef,
   Optional[Any]      $enterprise_dashboard_ldap = undef,
+  Optional[Any]      $enterprise_dashboard_oidc = undef,
   Variant[Stdlib::Absolutepath,Pattern[/^\$PATH$/]] $path = '$PATH',
   Optional[Array]    $redact = undef,
   Boolean            $deregister_on_stop = false,

--- a/spec/classes/sensu_enterprise_spec.rb
+++ b/spec/classes/sensu_enterprise_spec.rb
@@ -174,6 +174,32 @@ describe 'sensu', :type => :class do
             it { should contain_file('/etc/sensu/dashboard.json') }
             it { should contain_sensu_enterprise_dashboard_config('testhost.domain.com') }
           end
+
+          context 'with enterprise_dashboard_auth defined' do
+            let(:params) { {
+              :enterprise                   => true,
+              :enterprise_user              => 'sensu',
+              :enterprise_pass              => 'sensu',
+              :enterprise_dashboard         => true,
+              :enterprise_dashboard_auth    => { 'privatekey' => 'foo', 'publickey' => 'bar' }
+            } }
+            it { should contain_sensu_enterprise_dashboard_config('testhost.domain.com').with({
+              'auth' => { 'privatekey' => 'foo', 'publickey' => 'bar' }
+            }) }
+          end
+
+          context 'with enterprise_dashboard_oidc defined' do
+            let(:params) { {
+              :enterprise                   => true,
+              :enterprise_user              => 'sensu',
+              :enterprise_pass              => 'sensu',
+              :enterprise_dashboard         => true,
+              :enterprise_dashboard_oidc    => { 'key' => 'value' }
+            } }
+            it { should contain_sensu_enterprise_dashboard_config('testhost.domain.com').with({
+              'oidc' => { 'key' => 'value' }
+            }) }
+          end
         end
 
         context 'with rabbitmq_ssl => true and rabbitmq_ssl_cert_chain => undef' do

--- a/spec/unit/sensu_enterprise_dashboard_config_spec.rb
+++ b/spec/unit/sensu_enterprise_dashboard_config_spec.rb
@@ -46,4 +46,44 @@ describe Puppet::Type.type(:sensu_enterprise_dashboard_config) do
       expect(type_instance[:github]).to be_a(Hash)
     end
   end
+
+  describe 'rejects non-Hash values for :auth' do
+    it 'boolean' do
+      expect {
+        type_instance[:auth] = true
+      }.to raise_error Puppet::Error, /must be a Hash/
+    end
+    it 'string' do
+      expect {
+        type_instance[:auth] = 'test string'
+      }.to raise_error Puppet::Error, /must be a Hash/
+    end
+  end
+
+  describe 'accepts Hash values for :auth' do
+    it do
+      type_instance[:auth] = { :key => :value }
+      expect(type_instance[:auth]).to be_a(Hash)
+    end
+  end
+
+  describe 'rejects non-Hash values for :oidc' do
+    it 'boolean' do
+      expect {
+        type_instance[:oidc] = true
+      }.to raise_error Puppet::Error, /must be a Hash/
+    end
+    it 'string' do
+      expect {
+        type_instance[:oidc] = 'test string'
+      }.to raise_error Puppet::Error, /must be a Hash/
+    end
+  end
+
+  describe 'accepts Hash values for :oidc' do
+    it do
+      type_instance[:oidc] = { :key => :value }
+      expect(type_instance[:oidc]).to be_a(Hash)
+    end
+  end
 end


### PR DESCRIPTION

# Pull Request Checklist
Allow configuring Sensu Enterprise Dashboard auth and oidc configurations

## Description
* Add `enterprise_dashboard_auth` and`enterprise_dashboard_oidc` parameters
* Add `auth` and `oidc` properties to `sensu_enterprise_dashboard_config`

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #866  .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add enterprise dashboard options that were missing

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Travis-CI unit tests

## General

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
