### PR TITLE
Adding options to configure dir and file modes + tests

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,12 @@
 # @param sensu_group Name of the group Sensu is running as. Default is calculated
 #   according to the underlying OS
 #
+# @param config_dir_mode Directory mode for Sensu conf directory. Default is calculated
+#   according to the underlying OS
+#
+# @param config_file_mode File mode for config files under Sensu conf directory . Default is calculated
+#   according to the underlying OS
+#
 # @param rabbitmq_port Rabbitmq port to be used by sensu
 #
 # @param rabbitmq_host Host running rabbitmq for sensu
@@ -347,6 +353,14 @@ class sensu (
   Boolean            $manage_mutators_dir = true,
   Optional[String]   $sensu_user = undef,
   Optional[String]   $sensu_group = undef,
+  Optional[String]   $config_dir_mode = $::osfamily ? {
+    'windows' => undef,
+    default   => '0555',
+  },
+  Optional[String]   $config_file_mode = $::osfamily ? {
+    'windows' => undef,
+    default   => '0440',
+  },
   Variant[Undef,Integer,Pattern[/^(\d+)$/]] $rabbitmq_port = undef,
   Optional[String]   $rabbitmq_host = undef,
   Optional[String]   $rabbitmq_user = undef,
@@ -459,8 +473,8 @@ class sensu (
       $group             = 'wheel'
       $home_dir          = '/opt/sensu'
       $shell             = '/bin/false'
-      $dir_mode          = '0555'
-      $file_mode         = '0440'
+      $dir_mode          = $config_dir_mode
+      $file_mode         = $config_file_mode
       $service_name      = 'org.sensuapp.sensu-client'
     }
     'Linux': {
@@ -477,8 +491,8 @@ class sensu (
       }
       $home_dir          = '/opt/sensu'
       $shell             = '/bin/false'
-      $dir_mode          = '0555'
-      $file_mode         = '0440'
+      $dir_mode          = $config_dir_mode
+      $file_mode         = $config_file_mode
       $service_name      = 'sensu-client'
     }
     'windows': {
@@ -495,8 +509,8 @@ class sensu (
       }
       $home_dir          = $etc_dir
       $shell             = undef
-      $dir_mode          = undef
-      $file_mode         = undef
+      $dir_mode          = $config_dir_mode
+      $file_mode         = $config_file_mode
       $service_name      = 'sensu-client'
     }
     default: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -353,11 +353,11 @@ class sensu (
   Boolean            $manage_mutators_dir = true,
   Optional[String]   $sensu_user = undef,
   Optional[String]   $sensu_group = undef,
-  Optional[String]   $config_dir_mode = $::osfamily ? {
+  Optional[Stdlib::Filemode] $config_dir_mode = $::osfamily ? {
     'windows' => undef,
     default   => '0555',
   },
-  Optional[String]   $config_file_mode = $::osfamily ? {
+  Optional[Stdlib::Filemode] $config_file_mode = $::osfamily ? {
     'windows' => undef,
     default   => '0440',
   },

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -131,6 +131,20 @@ describe 'sensu', :type => :class do
       let(:params) { {:sensu_etc_dir => '/opt/etc/sensu', :enterprise_dashboard => true, :enterprise_user => 'user', :enterprise_pass => 'pass'  } }
       it { should contain_file('/opt/etc/sensu/dashboard.json') }
     end
+
+    context 'when config_dir_mode is set' do
+      let(:params) { {:config_dir_mode => '0755'} }
+      it { should contain_file('/etc/sensu/conf.d').with(
+        :mode   => '0755',
+      ) }
+    end
+
+    context 'when config_file_mode is set' do
+      let(:params) { {:config_file_mode => '0644'} }
+      it { should contain_file('/etc/sensu/conf.d/client.json').with(
+        :mode   => '0644',
+      ) }
+    end
   end
 
   describe 'osfamily windows defaults' do
@@ -253,6 +267,20 @@ describe 'sensu', :type => :class do
       context 'when enterprise_dashboard => true (and enterprise_user & enterprise_pass set) ' do
         let(:params) { {:sensu_etc_dir => 'C:/etc/sensu', :enterprise_dashboard => true, :enterprise_user => 'user', :enterprise_pass => 'pass'  } }
         it { should contain_file('C:/etc/sensu/dashboard.json') }
+      end
+
+      context 'when config_dir_mode is set' do
+        let(:params) { {:config_dir_mode => '0755'} }
+        it { should contain_file('C:/opt/sensu/conf.d').with(
+          :mode   => '0755',
+        ) }
+      end
+
+      context 'when config_file_mode is set' do
+        let(:params) { {:config_file_mode => '0644'} }
+        it { should contain_file('C:/opt/sensu/conf.d/client.json').with(
+          :mode   => '0644',
+        ) }
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

Adds 2 new options to manage config directory and file permissions

## Description
Adds 2 new options (`config_dir_mode` and `config_file_mode`) to enable management of directory and file permissions.  Both options are _optional_ and default to their existing settings depending on OS (Windows / other).  If the new settings are undefined, there should be net zero changes to existing configs.

## Related Issue
Closes #825

## Motivation and Context
Allow users to explicitly manage their own directory and file permissions to line up with other types of management systems where applicable (i.e. rpm packages)

## How Has This Been Tested?
Ran spec tests before and after code changes, net zero changes unless config settings are present.  Added new tests to verify settings when options are set.

## General

- [X] Update `README.md` with any necessary configuration snippets

- [X] New parameters are documented

- [X] New parameters have tests

- [X] Tests pass - `bundle exec rake validate lint spec`
