### PR TITLE
Add parameters to configure dir and file modes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -69,6 +69,12 @@
 # @param sensu_group Name of the group Sensu is running as. Default is calculated
 #   according to the underlying OS
 #
+# @param config_dir_mode Directory mode for Sensu conf directory. Default is calculated
+#   according to the underlying OS
+#
+# @param config_file_mode File mode for config files under Sensu conf directory . Default is calculated
+#   according to the underlying OS
+#
 # @param rabbitmq_port Rabbitmq port to be used by sensu
 #
 # @param rabbitmq_host Host running rabbitmq for sensu
@@ -347,6 +353,14 @@ class sensu (
   Boolean            $manage_mutators_dir = true,
   Optional[String]   $sensu_user = undef,
   Optional[String]   $sensu_group = undef,
+  Optional[Stdlib::Filemode] $config_dir_mode = $::osfamily ? {
+    'windows' => undef,
+    default   => '0555',
+  },
+  Optional[Stdlib::Filemode] $config_file_mode = $::osfamily ? {
+    'windows' => undef,
+    default   => '0440',
+  },
   Variant[Undef,Integer,Pattern[/^(\d+)$/]] $rabbitmq_port = undef,
   Optional[String]   $rabbitmq_host = undef,
   Optional[String]   $rabbitmq_user = undef,
@@ -459,8 +473,8 @@ class sensu (
       $group             = 'wheel'
       $home_dir          = '/opt/sensu'
       $shell             = '/bin/false'
-      $dir_mode          = '0555'
-      $file_mode         = '0440'
+      $dir_mode          = $config_dir_mode
+      $file_mode         = $config_file_mode
       $service_name      = 'org.sensuapp.sensu-client'
     }
     'Linux': {
@@ -477,8 +491,8 @@ class sensu (
       }
       $home_dir          = '/opt/sensu'
       $shell             = '/bin/false'
-      $dir_mode          = '0555'
-      $file_mode         = '0440'
+      $dir_mode          = $config_dir_mode
+      $file_mode         = $config_file_mode
       $service_name      = 'sensu-client'
     }
     'windows': {
@@ -495,8 +509,8 @@ class sensu (
       }
       $home_dir          = $etc_dir
       $shell             = undef
-      $dir_mode          = undef
-      $file_mode         = undef
+      $dir_mode          = $config_dir_mode
+      $file_mode         = $config_file_mode
       $service_name      = 'sensu-client'
     }
     default: {

--- a/spec/classes/sensu_init_spec.rb
+++ b/spec/classes/sensu_init_spec.rb
@@ -131,6 +131,20 @@ describe 'sensu', :type => :class do
       let(:params) { {:sensu_etc_dir => '/opt/etc/sensu', :enterprise_dashboard => true, :enterprise_user => 'user', :enterprise_pass => 'pass'  } }
       it { should contain_file('/opt/etc/sensu/dashboard.json') }
     end
+
+    context 'when config_dir_mode is set' do
+      let(:params) { {:config_dir_mode => '0755'} }
+      it { should contain_file('/etc/sensu/conf.d').with(
+        :mode   => '0755',
+      ) }
+    end
+
+    context 'when config_file_mode is set' do
+      let(:params) { {:config_file_mode => '0644'} }
+      it { should contain_file('/etc/sensu/conf.d/client.json').with(
+        :mode   => '0644',
+      ) }
+    end
   end
 
   describe 'osfamily windows defaults' do
@@ -253,6 +267,20 @@ describe 'sensu', :type => :class do
       context 'when enterprise_dashboard => true (and enterprise_user & enterprise_pass set) ' do
         let(:params) { {:sensu_etc_dir => 'C:/etc/sensu', :enterprise_dashboard => true, :enterprise_user => 'user', :enterprise_pass => 'pass'  } }
         it { should contain_file('C:/etc/sensu/dashboard.json') }
+      end
+
+      context 'when config_dir_mode is set' do
+        let(:params) { {:config_dir_mode => '0755'} }
+        it { should contain_file('C:/opt/sensu/conf.d').with(
+          :mode   => '0755',
+        ) }
+      end
+
+      context 'when config_file_mode is set' do
+        let(:params) { {:config_file_mode => '0644'} }
+        it { should contain_file('C:/opt/sensu/conf.d/client.json').with(
+          :mode   => '0644',
+        ) }
       end
     end
 


### PR DESCRIPTION
This patch adds config_dir_mode and config_file_mode parameters and uses
the default values already present in the sensu class.


# Pull Request Checklist

Just a rebase of PR #868.

## Description

Fixes #825 
Fixes #868 