### PR TITLE
Restart sensu-enterprise service when configs are purged #854

### DIFF
--- a/manifests/enterprise.pp
+++ b/manifests/enterprise.pp
@@ -92,6 +92,7 @@ class sensu::enterprise (
           Sensu_api_config[$::fqdn],
           Class['sensu::redis::config'],
           Class['sensu::rabbitmq::config'],
+          Class['sensu::package'],
         ],
       }
     }

--- a/spec/classes/sensu_enterprise_spec.rb
+++ b/spec/classes/sensu_enterprise_spec.rb
@@ -25,7 +25,11 @@ describe 'sensu', :type => :class do
           it { should contain_yumrepo('sensu-enterprise').with(
             :baseurl => 'http://sensu:sensu@enterprise.sensuapp.com/yum/noarch/'
           ) }
-          it { should contain_service('sensu-enterprise') }
+          it { should contain_service('sensu-enterprise').that_subscribes_to('File[/etc/default/sensu-enterprise]') }
+          it { should contain_service('sensu-enterprise').that_subscribes_to('Sensu_api_config[testhost.domain.com]') }
+          it { should contain_service('sensu-enterprise').that_subscribes_to('Class[sensu::redis::config]') }
+          it { should contain_service('sensu-enterprise').that_subscribes_to('Class[sensu::rabbitmq::config]') }
+          it { should contain_service('sensu-enterprise').that_subscribes_to('Class[sensu::package]') }
           it { should_not contain_yumrepo('sensu-enterprise-dashboard') }
           it { should contain_package('sensu-enterprise') }
 


### PR DESCRIPTION
Restart sensu-enterprise service when configs are purged #854

Added spec tests


# Pull Request Checklist
Serivce sensu-enterprise notifies sensu::package as suggested in the same #854 discussion

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #854

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
