### PR TITLE
This makes sensu_gem work as advertised

### DIFF
--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -15,6 +15,9 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
     if RUBY_PLATFORM =~ /cygwin|mswin|mingw|bccwin|winse|emx/
       "#{ENV['SYSTEMDRIVE']}\\opt\\sensu\\embedded\\bin\\gem.cmd"
     else
+      # grab the newest version available of the embedded ruby
+      embedded_rvm_version = Dir.glob(File.join(path, '/opt/sensu/embedded/lib/ruby/gems/*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
+      ENV['GEM_PATH] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_rvm_version}"
       "/opt/sensu/embedded/bin/gem"
     end
 

--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
       "#{ENV['SYSTEMDRIVE']}\\opt\\sensu\\embedded\\bin\\gem.cmd"
     else
       # grab the newest version available of the embedded ruby
-      embedded_rvm_version = Dir.glob(File.join(path, '/opt/sensu/embedded/lib/ruby/gems/*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
+      embedded_rvm_version = Dir.glob(File.join('/opt/sensu/embedded/lib/ruby/gems/', '*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
       ENV['GEM_PATH'] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_rvm_version}"
       "/opt/sensu/embedded/bin/gem"
     end

--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -21,7 +21,7 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
       # rip through everything in the directory and keep the newest one per comparison, omitting . and ..
       # there's probably a faster/prettier way of doing this.
       embedded_ruby_version = Dir.glob(File.join('/opt/sensu/embedded/lib/ruby/gems/', '*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
-      ENV['GEM_PATH'] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_rvm_version}"
+      ENV['GEM_PATH'] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_ruby_version}"
       "/opt/sensu/embedded/bin/gem"
     end
 

--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -17,7 +17,7 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
     else
       # grab the newest version available of the embedded ruby
       embedded_rvm_version = Dir.glob(File.join(path, '/opt/sensu/embedded/lib/ruby/gems/*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
-      ENV['GEM_PATH] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_rvm_version}"
+      ENV['GEM_PATH'] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_rvm_version}"
       "/opt/sensu/embedded/bin/gem"
     end
 

--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -20,7 +20,7 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
       # ruby slight of hand explaination: Ruby truncates full paths, so join the path, then
       # rip through everything in the directory and keep the newest one per comparison, omitting . and ..
       # there's probably a faster/prettier way of doing this.
-      embedded_rvm_version = Dir.glob(File.join('/opt/sensu/embedded/lib/ruby/gems/', '*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
+      embedded_ruby_version = Dir.glob(File.join('/opt/sensu/embedded/lib/ruby/gems/', '*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
       ENV['GEM_PATH'] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_rvm_version}"
       "/opt/sensu/embedded/bin/gem"
     end

--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -16,6 +16,10 @@ Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
       "#{ENV['SYSTEMDRIVE']}\\opt\\sensu\\embedded\\bin\\gem.cmd"
     else
       # grab the newest version available of the embedded ruby
+      # https://ruby-doc.org/core-2.4.0/Comparable.html
+      # ruby slight of hand explaination: Ruby truncates full paths, so join the path, then
+      # rip through everything in the directory and keep the newest one per comparison, omitting . and ..
+      # there's probably a faster/prettier way of doing this.
       embedded_rvm_version = Dir.glob(File.join('/opt/sensu/embedded/lib/ruby/gems/', '*')).max { |a,b| File.ctime(a) <=> File.ctime(b) }
       ENV['GEM_PATH'] = "/opt/sensu/embedded/lib/ruby/gems/#{embedded_rvm_version}"
       "/opt/sensu/embedded/bin/gem"


### PR DESCRIPTION
# Pull Request Checklist

Fixes the GEM_PATH which is causing embedded ruby to not do The Right Thing when RVM is present. 

## Description
Munge GEM_PATH appropriately.

## Related Issue
https://github.com/sensu/sensu-puppet/issues/876

Fixes # .

## Motivation and Context
Fixes installation of embedded ruby gems when RVM is present.

## How Has This Been Tested?
Fired up a Vagrant instance with RVM installed, then installed the elasticsearch gems and made sure it could find the gems without further munging.

## General

No testing required - it wasn't "broken" before. :)