### PR TITLE
(GH-883) Remove example sensu_enterprise_dashboard_api_config resources by default

### DIFF
--- a/manifests/enterprise/dashboard.pp
+++ b/manifests/enterprise/dashboard.pp
@@ -70,6 +70,16 @@ class sensu::enterprise::dashboard (
       oidc      => $::sensu::enterprise_dashboard_oidc,
       notify    => $file_notify,
     }
+
+    sensu_enterprise_dashboard_api_config { 'api1.example.com':
+      ensure => absent,
+      notify => $file_notify,
+    }
+
+    sensu_enterprise_dashboard_api_config { 'api2.example.com':
+      ensure => absent,
+      notify => $file_notify,
+    }
   }
 
   # Service

--- a/spec/classes/sensu_enterprise_spec.rb
+++ b/spec/classes/sensu_enterprise_spec.rb
@@ -156,6 +156,8 @@ describe 'sensu', :type => :class do
             it { should contain_package('sensu-enterprise-dashboard') }
             it { should contain_file('/etc/sensu/dashboard.json') }
             it { should contain_sensu_enterprise_dashboard_config('testhost.domain.com') }
+            it { should contain_sensu_enterprise_dashboard_api_config('api1.example.com').with_ensure('absent') }
+            it { should contain_sensu_enterprise_dashboard_api_config('api2.example.com').with_ensure('absent') }
           end
 
           context 'with enterprise_dashboard_version => 1.3.1-1' do
@@ -177,6 +179,8 @@ describe 'sensu', :type => :class do
             }) }
             it { should contain_file('/etc/sensu/dashboard.json') }
             it { should contain_sensu_enterprise_dashboard_config('testhost.domain.com') }
+            it { should contain_sensu_enterprise_dashboard_api_config('api1.example.com').with_ensure('absent') }
+            it { should contain_sensu_enterprise_dashboard_api_config('api2.example.com').with_ensure('absent') }
           end
 
           context 'with enterprise_dashboard_auth defined' do

--- a/tests/sensu-server-enterprise.pp
+++ b/tests/sensu-server-enterprise.pp
@@ -37,6 +37,7 @@ node 'sensu-server' {
   class { '::sensu':
     install_repo              => true,
     enterprise                => true,
+    enterprise_dashboard      => true,
     enterprise_user           => $facts['se_user'],
     enterprise_pass           => $facts['se_pass'],
     manage_services           => true,


### PR DESCRIPTION
# Pull Request Checklist

## Description
Remove `sensu_enterprise_dashboard_api_config` resources for `api1.example.com` and `api2.example.com` by default.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #883 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better support resource purging for `sensu_enterprise_dashboard_api_config`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tested

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
