### PR TITLE
Use correct version of stdlib with macos-client in vagrant

### DIFF
--- a/tests/provision_macos.sh
+++ b/tests/provision_macos.sh
@@ -65,5 +65,5 @@ defaults write /Library/Preferences/com.apple.loginwindow Hide500Users -bool YES
 echo "finished installing puppet..."
 echo "installing dependency modules..."
 /opt/puppetlabs/bin/puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
-/opt/puppetlabs/bin/puppet module install puppetlabs/stdlib --version 4.16.0
+/opt/puppetlabs/bin/puppet module install puppetlabs/stdlib --version 4.24.0
 /opt/puppetlabs/bin/puppet module install lwf-remote_file --version 1.1.3


### PR DESCRIPTION
# Pull Request Checklist



## Description
Use correct version of stdlib



Partially Fixes #891 

## Motivation and Context
Unable to bring up macos-client without this patch.

## How Has This Been Tested?
Vagrant

