### PR TITLE
(GH-896) Support beaker testing on windows server 2012r2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ group :system_tests do
   gem 'serverspec',                   :require => false
   gem 'beaker-puppet_install_helper', :require => false
   gem 'beaker-module_install_helper', :require => false
+  gem 'vagrant-wrapper',              :require => false
+  gem 'beaker-windows',               :require => false
+  gem 'winrm',                        :require => false
 end
 
 group :development do

--- a/spec/acceptance/nodesets/windows-server-2012r2.yml
+++ b/spec/acceptance/nodesets/windows-server-2012r2.yml
@@ -6,6 +6,7 @@ HOSTS:
     box : opentable/win-2012r2-standard-amd64-nocm
     box_url : https://vagrantcloud.com/opentable/boxes/win-2012r2-standard-amd64-nocm
     hypervisor : vagrant
+    user: vagrant
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -24,6 +24,16 @@ RSpec.configure do |c|
         # CentOS has epel-release package in Extras, enabled by default
         shell('yum -y install epel-release')
       end
+      puts "platform is #{host['platform']}"
+      if host['platform'] =~ /windows/
+        require 'winrm'
+        include Serverspec::Helper::Windows
+        include Serverspec::Helper::WinRM
+
+        endpoint = "http://127.0.0.1:5985/wsman"
+        c.winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => 'vagrant', :pass => 'vagrant', :basic_auth_only => true)
+        c.winrm.set_timeout 300
+      end
       on host, puppet('module', 'install', 'puppet-rabbitmq'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'fsalum-redis'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }


### PR DESCRIPTION
# Pull Request Checklist

This allows beaker to connect, though the tests fail since they are attempting to run the linux command `cat`.

Fixes #896


## General

- [ ] Tests pass
