### PR TITLE
(GH-896) Support beaker testing on windows server 2012r2 (continued)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,9 @@ group :system_tests do
   gem 'serverspec',                   :require => false
   gem 'beaker-puppet_install_helper', :require => false
   gem 'beaker-module_install_helper', :require => false
+  gem 'vagrant-wrapper',              :require => false
+  gem 'beaker-windows',               :require => false
+  gem 'winrm',                        :require => false
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -53,7 +53,6 @@ group :system_tests do
   gem 'beaker-module_install_helper', :require => false
   gem 'vagrant-wrapper',              :require => false
   gem 'beaker-windows',               :require => false
-  gem 'winrm',                        :require => false
 end
 
 group :development do

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -22,6 +22,9 @@ describe 'sensu class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily
     end #default
 
     context 'server => true, api => true' do
+      if fact('osfamily') == 'windows'
+        before { skip("Server not supported on Windows") }
+      end
       it 'should work with no errors' do
         pp = <<-EOS
         class { 'sensu':
@@ -56,6 +59,9 @@ describe 'sensu class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily
 
     if ENV['SE_USER'] && ENV['SE_PASS']
       context 'enterprise => true and enterprise_dashboard => true' do
+        if fact('osfamily') == 'windows'
+          before { skip("Enterprise not supported on Windows") }
+        end
         it 'should work with no errors' do
           pp = <<-EOS
           class { 'sensu':
@@ -119,7 +125,11 @@ describe 'sensu class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily
 
         # Run it twice and test for idempotency
         apply_manifest(pp, :catch_failures => true)
-        shell('sleep 5') # Give services time to stop
+        if fact('osfamily') == 'windows'
+          shell('waitfor SomethingThatIsNeverHappening /t 5 2>NUL', :acceptable_exit_codes => [0,1])
+        else
+          shell('sleep 5') # Give services time to stop
+        end
         apply_manifest(pp, :catch_changes  => true)
       end
 

--- a/spec/acceptance/nodesets/windows-server-2012r2.yml
+++ b/spec/acceptance/nodesets/windows-server-2012r2.yml
@@ -6,6 +6,7 @@ HOSTS:
     box : opentable/win-2012r2-standard-amd64-nocm
     box_url : https://vagrantcloud.com/opentable/boxes/win-2012r2-standard-amd64-nocm
     hypervisor : vagrant
+    user: vagrant
 CONFIG:
   log_level: verbose
   type: foss

--- a/spec/acceptance/nodesets/windows-server-2012r2.yml
+++ b/spec/acceptance/nodesets/windows-server-2012r2.yml
@@ -3,6 +3,7 @@ HOSTS:
     roles:
       - agent
     platform: windows-server-amd64
+    is_cygwin: false
     box : opentable/win-2012r2-standard-amd64-nocm
     box_url : https://vagrantcloud.com/opentable/boxes/win-2012r2-standard-amd64-nocm
     hypervisor : vagrant

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -10,7 +10,7 @@ install_puppet_agent_on(hosts, :puppet_collection => 'puppet5', :puppet_agent_ve
 install_module_on(hosts)
 install_module_dependencies_on(hosts)
 
-UNSUPPORTED_PLATFORMS = ['Suse','windows','AIX','Solaris']
+UNSUPPORTED_PLATFORMS = ['Suse','AIX','Solaris']
 
 RSpec.configure do |c|
   # Readable test descriptions
@@ -23,16 +23,6 @@ RSpec.configure do |c|
       if fact('osfamily') == 'RedHat'
         # CentOS has epel-release package in Extras, enabled by default
         shell('yum -y install epel-release')
-      end
-      puts "platform is #{host['platform']}"
-      if host['platform'] =~ /windows/
-        require 'winrm'
-        include Serverspec::Helper::Windows
-        include Serverspec::Helper::WinRM
-
-        endpoint = "http://127.0.0.1:5985/wsman"
-        c.winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => 'vagrant', :pass => 'vagrant', :basic_auth_only => true)
-        c.winrm.set_timeout 300
       end
       on host, puppet('module', 'install', 'puppet-rabbitmq'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'fsalum-redis'), { :acceptable_exit_codes => [0,1] }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -24,6 +24,16 @@ RSpec.configure do |c|
         # CentOS has epel-release package in Extras, enabled by default
         shell('yum -y install epel-release')
       end
+      puts "platform is #{host['platform']}"
+      if host['platform'] =~ /windows/
+        require 'winrm'
+        include Serverspec::Helper::Windows
+        include Serverspec::Helper::WinRM
+
+        endpoint = "http://127.0.0.1:5985/wsman"
+        c.winrm = ::WinRM::WinRMWebService.new(endpoint, :ssl, :user => 'vagrant', :pass => 'vagrant', :basic_auth_only => true)
+        c.winrm.set_timeout 300
+      end
       on host, puppet('module', 'install', 'puppet-rabbitmq'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'fsalum-redis'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }


### PR DESCRIPTION
This is a continuation of #897 

```
$ bundle exec rake beaker:windows-server-2012r2
<SNIP>
Finished in 2 minutes 42 seconds (files took 5 minutes 44 seconds to load)
13 examples, 0 failures, 7 pending
```

Could probably use `unless` with contexts that should skip for windows but wasn't sure if better to have output explaining why some tests were skipped or just skip silently.