### PR TITLE
Fix spec test warnings

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,8 @@
+# RSpec.configure specified twice due to bug in puppetlabs_spec_helper.
+# https://tickets.puppetlabs.com/browse/PDK-916
+RSpec.configure do |c|
+  c.mock_with :rspec
+end
 require 'puppetlabs_spec_helper/module_spec_helper'
 
 case ENV['COVERAGE']


### PR DESCRIPTION
## Description
FIx spec test warning

See https://github.com/puppetlabs/puppetlabs_spec_helper#mock_with

## General

- [x] Tests pass - `bundle exec rake validate lint spec`
