### PR TITLE
(GH-902) Add client_socket_enabled boolean parameter

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -99,9 +99,15 @@ class sensu::client (
     mode   => $::sensu::file_mode,
   }
 
-  $socket_config = {
-    bind => $::sensu::client_bind,
-    port => $::sensu::client_port,
+  if $::sensu::client_socket_enabled {
+    $socket_config = {
+      bind => $::sensu::client_bind,
+      port => $::sensu::client_port,
+    }
+  } else {
+    $socket_config = {
+      enabled => false,
+    }
   }
 
   sensu_client_config { $::fqdn:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -160,6 +160,8 @@
 #
 # @param subscriptions Default subscriptions used by the client
 #
+# @param client_socket_enabled Boolean that determines if client socket will be enabled
+#
 # @param client_address Address of the client to report with checks
 #
 # @param client_name Name of the client to report with checks
@@ -411,6 +413,7 @@ class sensu (
   Optional[String]   $api_ssl_keystore_file = undef,
   Optional[String]   $api_ssl_keystore_password = undef,
   Variant[String,Array] $subscriptions = [],
+  Boolean            $client_socket_enabled = true,
   String             $client_bind = '127.0.0.1',
   Integer            $client_port = 3030,
   String             $client_address =  $::ipaddress,

--- a/spec/classes/sensu_client_spec.rb
+++ b/spec/classes/sensu_client_spec.rb
@@ -149,6 +149,18 @@ describe 'sensu', :type => :class do
           end
         end
 
+        describe 'socket' do
+          context " => {'client_bind' => '0.0.0.0', 'client_port' => 3031}" do
+            let(:params_override) { {client_bind: '0.0.0.0', client_port: 3031} }
+            it { is_expected.to contain_sensu_client_config(title).with(socket: {'bind' => '0.0.0.0', 'port' => 3031}) }
+          end
+
+          context " => {'client_socket_enabled' => false}" do
+            let(:params_override) { {client_socket_enabled: false} }
+            it { is_expected.to contain_sensu_client_config(title).with(socket: {'enabled' => false}) }
+          end
+        end
+
         describe 'servicenow' do
           servicenow = {
             'configuration_item' => {


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
Add `client_socket_enabled` parameter that when `false` will disable the sensu client socket.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #902  .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required to support sensu 1.3.0 to allow disabling the sensu client socket.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
