### PR TITLE
Use puppet5 to provision debian based vagrant boxes

### DIFF
--- a/tests/provision_basic_debian.sh
+++ b/tests/provision_basic_debian.sh
@@ -31,7 +31,7 @@ apt-key adv --fetch-keys http://apt.puppetlabs.com/DEB-GPG-KEY-puppet
 apt-get -y install wget
 
 # install and configure puppet
-deb_install http://apt.puppetlabs.com/puppetlabs-release-pc1-${CODENAME}.deb
+deb_install http://apt.puppetlabs.com/puppet5-release-${CODENAME}.deb
 apt-get update
 apt-get -y install puppet-agent
 ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use Puppet 5 when provisioning Debian based vagrant boxes.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
#901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Get vagrant boxes uses Puppet version supported by sensu2 changes as well as necessary to support Ubuntu 18.04.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
