### PR TITLE
Add env_vars property to sensu_check

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -155,6 +155,11 @@ Puppet::Type.newtype(:sensu_check) do
     newvalues(/.*/, :absent)
   end
 
+  newproperty(:env_vars, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
+    desc "An array of environment variables to use with command execution."
+    newvalues(/.*/, :absent)
+  end
+
   newproperty(:extended_attributes, :parent => PuppetX::Sensu::HashProperty) do
     desc "Custom attributes to include as with the check, that appear as outer-level attributes."
     defaultto {}

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -73,7 +73,8 @@ describe Puppet::Type.type(:sensu_check) do
     :check_hooks,
     :proxy_requests_entity_attributes,
     :metric_handlers,
-    :output_metric_handlers
+    :output_metric_handlers,
+    :env_vars
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = ['foo', 'bar']


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `env_vars` property to `sensu_check` type.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #901 and should resolve test failures in #915 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
sensu-go added `env_vars` to check specification.  This ensures `env_vars` don't end up getting included in `extended_attributes` property.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
