### PR TITLE
(GH-901) Replace sensu_check subdue with subdue_days property

### DIFF
--- a/lib/puppet/provider/sensu_check/sensuctl.rb
+++ b/lib/puppet/provider/sensu_check/sensuctl.rb
@@ -37,7 +37,9 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
           value = value.to_s.to_sym
         end
         # Handle extended_attributes property
-        if ! type_properties.include?(key.to_sym)
+        if key == 'subdue'
+          check[:subdue_days] = value['days'] unless value.nil?
+        elsif ! type_properties.include?(key.to_sym)
           check[:extended_attributes][key] = value
         else
           check[key.to_sym] = value
@@ -91,7 +93,10 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
       next if property.to_s =~ /^proxy_requests/
       next if property == :extended_attributes
       if [:true, :false].include?(value)
-        spec[property] = convert_boolean_property_value(value)
+        value = convert_boolean_property_value(value)
+      end
+      if property == :subdue_days
+        spec[:subdue] = { days: value }
       else
         spec[property] = value
       end
@@ -124,7 +129,10 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
         next if property.to_s =~ /^proxy_requests/
         next if property == :extended_attributes
         if [:true, :false].include?(value)
-          spec[property] = convert_boolean_property_value(value)
+          value = convert_boolean_property_value(value)
+        end
+        if property == :subdue_days
+          spec[:subdue] = { days: value }
         elsif value == :absent
           spec[property] = nil
         else

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -82,11 +82,22 @@ Puppet::Type.newtype(:sensu_check) do
     newvalues(/.*/, :absent)
   end
 
-  newproperty(:subdue) do
+  newproperty(:subdue_days, :parent => PuppetX::Sensu::HashProperty) do
     desc "A Sensu subdue, a hash of days of the week, which define one or more time windows in which the check is not scheduled to be executed."
     validate do |value|
-      unless value.is_a?(Hash)
-        raise ArgumentError, "sensu_check subdue must be a Hash"
+      super(value)
+      value.each_pair do |k,v|
+        if ! ['monday','tuesday','wednesday','thursday','friday','saturday','sunday','all'].include?(k.to_s)
+          raise ArgumentError, "subdue_days keys must be day of the week or 'all', not #{k}"
+        end
+        if ! v.is_a?(Array)
+          raise ArgumentError, "subdue_days hash values must be an Array"
+        end
+        v.each do |d|
+          if ! d.is_a?(Hash) || ! d.key?('begin') || ! d.key?('end')
+            raise ArgumentError, "subdue_days day time window must be a hash containing keys 'begin' and 'end'"
+          end
+        end
       end
     end
   end

--- a/spec/fixtures/unit/provider/sensu_check/sensuctl/check_list.json
+++ b/spec/fixtures/unit/provider/sensu_check/sensuctl/check_list.json
@@ -1,12 +1,30 @@
 [
   {
-    "name": "marketing-site",
+    "check_hooks": null,
     "command": "check-http.rb -u https://dean-learner.book",
-    "subscriptions": ["demo"],
-    "interval": 15,
-    "handlers": ["slack"],
+    "environment": "default",
+    "handlers": [
+      "slack"
+    ],
+    "high_flap_threshold": 0,
+    "interval": 16,
+    "low_flap_threshold": 0,
+    "name": "marketing-site",
     "organization": "default",
-    "environment": "default"
+    "output_metric_format": "",
+    "output_metric_handlers": null,
+    "proxy_entity_id": "",
+    "publish": false,
+    "round_robin": false,
+    "runtime_assets": null,
+    "stdin": false,
+    "subdue": null,
+    "subscriptions": [
+      "demo"
+    ],
+    "timeout": 0,
+    "ttl": 0,
+    "history": null,
+    "issued": 0
   }
 ]
-

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -148,6 +148,38 @@ describe Puppet::Type.type(:sensu_check) do
     end
   end
 
+  describe 'subdue_days' do
+    it 'accepts valid value for when' do
+      config[:subdue_days] = {'all' => [{'begin' => '5:00 PM', 'end' => '8:00 AM'}]}
+      expect(check[:subdue_days]).to eq({'all' => [{'begin' => '5:00 PM', 'end' => '8:00 AM'}]})
+    end
+
+    it "should not accept invalid value" do
+      config[:subdue_days] = 'foo'
+      expect { check }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+
+    it 'should handle invalid day' do
+      config[:subdue_days] = {'foo' => [{'begin' => '5:00 PM', 'end' => '8:00 AM'}]}
+      expect { check }.to raise_error(Puppet::Error, /subdue_days keys must be day of the week or 'all'/)
+    end
+
+    it 'should require day key to be array' do
+      config[:subdue_days] = {'all' => 'foo'}
+      expect { check }.to raise_error(Puppet::Error, /subdue_days hash values must be an Array/)
+    end
+
+    it 'should verify time range is hash' do
+      config[:subdue_days] = {'all' => ['foo']}
+      expect { check }.to raise_error(Puppet::Error, /subdue_days day time window must be a hash containing keys 'begin' and 'end'/)
+    end
+
+    it 'should verify time range keys' do
+      config[:subdue_days] = {'all' => [{'start' => '5:00 PM', 'end' => '8:00 AM'}]}
+      expect { check }.to raise_error(Puppet::Error, /subdue_days day time window must be a hash containing keys 'begin' and 'end'/)
+    end
+  end
+
   it 'should autorequire Package[sensu-cli]' do
     package = Puppet::Type.type(:package).new(:name => 'sensu-cli')
     catalog = Puppet::Resource::Catalog.new


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace subdue property of sensu_check with subdue_days.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes the handling of subdue days a bit more similar to how when days was handled with sensu_filter.  Also ensures some validation of input.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests added.  Acceptance tests will fail in travis without #916 

## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
