### PR TITLE
Fix destroy exception handling message

### DIFF
--- a/lib/puppet/provider/sensu_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_asset/sensuctl.rb
@@ -112,7 +112,7 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
     begin
       sensuctl_delete('asset', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete asset #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete asset #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_check/sensuctl.rb
+++ b/lib/puppet/provider/sensu_check/sensuctl.rb
@@ -157,7 +157,7 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
     begin
       sensuctl_delete('check', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete check #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete check #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_entity/sensuctl.rb
+++ b/lib/puppet/provider/sensu_entity/sensuctl.rb
@@ -138,7 +138,7 @@ Puppet::Type.type(:sensu_entity).provide(:sensuctl, :parent => Puppet::Provider:
     begin
       sensuctl_delete('entity', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete entity #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete entity #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_environment/sensuctl.rb
+++ b/lib/puppet/provider/sensu_environment/sensuctl.rb
@@ -112,7 +112,7 @@ Puppet::Type.type(:sensu_environment).provide(:sensuctl, :parent => Puppet::Prov
     begin
       sensuctl_delete('environment', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete environment #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete environment #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_filter/sensuctl.rb
+++ b/lib/puppet/provider/sensu_filter/sensuctl.rb
@@ -121,7 +121,7 @@ Puppet::Type.type(:sensu_filter).provide(:sensuctl, :parent => Puppet::Provider:
     begin
       sensuctl_delete('filter', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete filter #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete filter #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_handler/sensuctl.rb
+++ b/lib/puppet/provider/sensu_handler/sensuctl.rb
@@ -139,7 +139,7 @@ Puppet::Type.type(:sensu_handler).provide(:sensuctl, :parent => Puppet::Provider
     begin
       sensuctl_delete('handler', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete handler #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete handler #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_hook/sensuctl.rb
+++ b/lib/puppet/provider/sensu_hook/sensuctl.rb
@@ -112,7 +112,7 @@ Puppet::Type.type(:sensu_hook).provide(:sensuctl, :parent => Puppet::Provider::S
     begin
       sensuctl_delete('hook', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete hook #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete hook #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_mutator/sensuctl.rb
+++ b/lib/puppet/provider/sensu_mutator/sensuctl.rb
@@ -112,7 +112,7 @@ Puppet::Type.type(:sensu_mutator).provide(:sensuctl, :parent => Puppet::Provider
     begin
       sensuctl_delete('mutator', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete mutator #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete mutator #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_organization/sensuctl.rb
+++ b/lib/puppet/provider/sensu_organization/sensuctl.rb
@@ -112,7 +112,7 @@ Puppet::Type.type(:sensu_organization).provide(:sensuctl, :parent => Puppet::Pro
     begin
       sensuctl_delete('organization', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete organization #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete organization #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_role/sensuctl.rb
+++ b/lib/puppet/provider/sensu_role/sensuctl.rb
@@ -112,7 +112,7 @@ Puppet::Type.type(:sensu_role).provide(:sensuctl, :parent => Puppet::Provider::S
     begin
       sensuctl_delete('role', resource[:name])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete role #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete role #{resource[:name]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end

--- a/lib/puppet/provider/sensu_silenced/sensuctl.rb
+++ b/lib/puppet/provider/sensu_silenced/sensuctl.rb
@@ -119,7 +119,7 @@ Puppet::Type.type(:sensu_silenced).provide(:sensuctl, :parent => Puppet::Provide
     begin
       sensuctl_delete('silenced', @property_hash[:id])
     rescue Exception => e
-      raise Puppet::Error, "sensuctl delete silenced #{name} failed\nError message: #{e.message}"
+      raise Puppet::Error, "sensuctl delete silenced #{@property_hash[:id]} failed\nError message: #{e.message}"
     end
     @property_hash.clear
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
All provider destroy methods were referencing undefined variable in the exception message, this PR fixes that issue.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and acceptance tests.  The travis-ci acceptance tests will pass once rebased after #916 merged.

## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
