### PR TITLE
Use module hiera data to set sensu::etc_dir for Windows

### DIFF
--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -1,0 +1,2 @@
+---
+sensu::etc_dir: 'C:/opt/sensu'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,10 +16,7 @@
 #
 class sensu (
   String $version = 'installed',
-  Stdlib::Absolutepath $etc_dir = $::osfamily ? {
-    'windows' => 'C:/opt/sensu',
-    default   => '/etc/sensu',
-  },
+  Stdlib::Absolutepath $etc_dir = '/etc/sensu',
   Boolean $etc_dir_purge = true,
   Boolean $manage_repo = true,
 ) {
@@ -42,7 +39,7 @@ class sensu (
     'Debian': {
     }
     default: {
-      fail("Detected osfamily <${::osfamily}>. Only RedHat is supported.")
+      fail("Detected osfamily <${::osfamily}>. Only RedHat and Debian are supported.")
     }
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use module hiera data to set sensu::etc_dir for Windows.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make parameters simpler and have hiera data handle OS specific parameter default changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unable to test as module does not yet officially support Windows.
