### PR TITLE
Only run type/provider acceptance tests on centos-7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   - rvm: 2.4.2
     sudo: required
     services: docker
-    env: BEAKER_set="centos-7"
+    env: BEAKER_set="centos-7" BEAKER_sensu_full=yes
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.2

--- a/spec/acceptance/sensu_asset_spec.rb
+++ b/spec/acceptance/sensu_asset_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_asset' do
+describe 'sensu_asset', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_check' do
+describe 'sensu_check', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_entity_spec.rb
+++ b/spec/acceptance/sensu_entity_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_entity' do
+describe 'sensu_entity', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_environment_spec.rb
+++ b/spec/acceptance/sensu_environment_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_environment' do
+describe 'sensu_environment', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_event_spec.rb
+++ b/spec/acceptance/sensu_event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_event' do
+describe 'sensu_event', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_extension_spec.rb
+++ b/spec/acceptance/sensu_extension_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_extension' do
+describe 'sensu_extension', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_filter_spec.rb
+++ b/spec/acceptance/sensu_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_filter' do
+describe 'sensu_filter', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_handler_spec.rb
+++ b/spec/acceptance/sensu_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_handler' do
+describe 'sensu_handler', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_hook_spec.rb
+++ b/spec/acceptance/sensu_hook_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_hook' do
+describe 'sensu_hook', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_mutator_spec.rb
+++ b/spec/acceptance/sensu_mutator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_mutator' do
+describe 'sensu_mutator', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_organization_spec.rb
+++ b/spec/acceptance/sensu_organization_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_organization' do
+describe 'sensu_organization', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_role_spec.rb
+++ b/spec/acceptance/sensu_role_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_role' do
+describe 'sensu_role', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_silenced_spec.rb
+++ b/spec/acceptance/sensu_silenced_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_silenced' do
+describe 'sensu_silenced', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -11,6 +11,9 @@ end
 copy_module_to(hosts, :source => proj, :module_name => 'sensu', :target_module_path => modulepath)
 
 RSpec.configure do |c|
+  c.add_setting :sensu_full, default: false
+  c.sensu_full = (ENV['BEAKER_sensu_full'] == 'yes' || ENV['BEAKER_sensu_full'] == 'true')
+
   # Readable test descriptions
   c.formatter = :documentation
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Only run type/provider acceptance tests if `BEAKER_sensu_full=yes`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #901 and replaces need for #929 .  Fixes #918 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This should stop acceptance test timeouts as only one platform will run the full suite.  The puppet-agent install helps ensure types/providers behave the same across various platforms so only a real need to test agent/backend functionality on all platforms.

Using an environment variable helps make this more obvious when viewing the travis-ci test matrix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Verify only agent and backend are tested with `BEAKER_set=centos-7 bundle exec rake beaker` then verified full suite with `BEAKER_set=centos-7 BEAKER_sensu_full=yes bundle exec rake beaker`.