### PR TITLE
Add sensu_config type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ matrix:
   - rvm: 2.4.2
     sudo: required
     services: docker
-    env: BEAKER_set="centos-7"
+    env: BEAKER_set="centos-7" BEAKER_sensu_full=yes
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.2

--- a/lib/puppet/provider/sensu_config/sensuctl.rb
+++ b/lib/puppet/provider/sensu_config/sensuctl.rb
@@ -1,0 +1,81 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sensuctl'))
+
+Puppet::Type.type(:sensu_config).provide(:sensuctl, :parent => Puppet::Provider::Sensuctl) do
+  desc "Provider sensu_config using sensuctl"
+
+  mk_resource_methods
+
+  def self.instances
+    configs = []
+
+    output = sensuctl('config', 'view', '--format', 'json')
+    Puppet.debug("sensu configs: #{output}")
+    begin
+      data = JSON.parse(output)
+    rescue JSON::ParserError => e
+      Puppet.debug('Unable to parse output from sensuctl config view')
+      data = []
+    end
+
+    data.each_pair do |k,v|
+Puppet.debug("#{k}=#{v}")
+      config = {}
+      config[:ensure] = :present
+      config[:name] = k
+      config[:value] = v
+Puppet.debug("config=#{config}")
+      configs << new(config)
+    end
+Puppet.debug("configs=#{configs}")
+    configs
+  end
+
+  def self.prefetch(resources)
+    configs = instances
+    resources.keys.each do |name|
+      if provider = configs.find { |c| c.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  type_properties.each do |prop|
+    define_method "#{prop}=".to_sym do |value|
+      @property_flush[prop] = value
+    end
+  end
+
+  def create
+    begin
+      sensuctl('config', "set-#{resource[:name]}", resource[:value])
+    rescue Exception => e
+      raise Puppet::Error, "sensuctl set-#{resource[:name]} failed\nError message: #{e.message}"
+    end
+    @property_hash[:ensure] = :present
+  end
+
+  def flush
+    if !@property_flush.empty?
+      begin
+        sensuctl('config', "set-#{resource[:name]}", @property_flush[:value])
+      rescue Exception => e
+        raise Puppet::Error, "sensuctl set-#{resource[:name]} failed\nError message: #{e.message}"
+      end
+    end
+    @property_hash = resource.to_hash
+  end
+
+  def destroy
+    Puppet.warning("sensu_config does not support ensure=absent")
+  end
+end
+

--- a/lib/puppet/type/sensu_config.rb
+++ b/lib/puppet/type/sensu_config.rb
@@ -1,0 +1,53 @@
+require_relative '../../puppet_x/sensu/type'
+require_relative '../../puppet_x/sensu/array_property'
+require_relative '../../puppet_x/sensu/hash_property'
+require_relative '../../puppet_x/sensu/integer_property'
+
+Puppet::Type.newtype(:sensu_config) do
+  desc <<-DESC
+Manages Sensu configs
+@example Manage a config
+  sensu_config { 'format':
+    value => 'json',
+  }
+DESC
+
+  extend PuppetX::Sensu::Type
+  add_autorequires()
+
+  ensurable do
+    defaultvalues
+    validate do |value|
+      if value.to_sym == :absent
+        raise ArgumentError, "sensu_config ensure does not support absent"
+      end
+    end
+  end
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the config."
+    validate do |value|
+      unless value =~ /^[\w\.\-\_]+$/
+        raise ArgumentError, "sensu_config name invalid"
+      end
+    end
+  end
+
+  newproperty(:value) do
+    desc "The value of the config."
+    munge do |value|
+      value.to_s
+    end
+  end
+
+  validate do
+    required_properties = [
+      :value,
+    ]
+    required_properties.each do |property|
+      if self[:ensure] == :present && self[property].nil?
+        fail "You must provide a #{property}"
+      end
+    end
+  end
+end

--- a/spec/acceptance/sensu_asset_spec.rb
+++ b/spec/acceptance/sensu_asset_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_asset' do
+describe 'sensu_asset', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_check' do
+describe 'sensu_check', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_config_spec.rb
+++ b/spec/acceptance/sensu_config_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu_config', if: RSpec.configuration.sensu_full do
+  node = only_host_with_role(hosts, 'sensu_backend')
+  context 'with updates' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_config { 'format':
+        value => 'json',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    it 'should have a valid config' do
+      on node, 'sensuctl config view --format json' do
+        data = JSON.parse(stdout)
+        expect(data['format']).to eq('json')
+      end
+    end
+  end
+
+  context 'ensure => absent' do
+    it 'should result in error as unsupported' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_config { 'format': ensure => 'absent' }
+      EOS
+
+      apply_manifest_on(node, pp, :expect_failures => true)
+    end
+  end
+end
+

--- a/spec/acceptance/sensu_entity_spec.rb
+++ b/spec/acceptance/sensu_entity_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_entity' do
+describe 'sensu_entity', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_environment_spec.rb
+++ b/spec/acceptance/sensu_environment_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_environment' do
+describe 'sensu_environment', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_event_spec.rb
+++ b/spec/acceptance/sensu_event_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_event' do
+describe 'sensu_event', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_extension_spec.rb
+++ b/spec/acceptance/sensu_extension_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_extension' do
+describe 'sensu_extension', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_filter_spec.rb
+++ b/spec/acceptance/sensu_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_filter' do
+describe 'sensu_filter', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_handler_spec.rb
+++ b/spec/acceptance/sensu_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_handler' do
+describe 'sensu_handler', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_hook_spec.rb
+++ b/spec/acceptance/sensu_hook_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_hook' do
+describe 'sensu_hook', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_mutator_spec.rb
+++ b/spec/acceptance/sensu_mutator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_mutator' do
+describe 'sensu_mutator', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_organization_spec.rb
+++ b/spec/acceptance/sensu_organization_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_organization' do
+describe 'sensu_organization', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_role_spec.rb
+++ b/spec/acceptance/sensu_role_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_role' do
+describe 'sensu_role', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_silenced_spec.rb
+++ b/spec/acceptance/sensu_silenced_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_silenced' do
+describe 'sensu_silenced', if: RSpec.configuration.sensu_full do
   node = only_host_with_role(hosts, 'sensu_backend')
   context 'default' do
     it 'should work without errors' do

--- a/spec/fixtures/unit/provider/sensu_config/sensuctl/config_list.json
+++ b/spec/fixtures/unit/provider/sensu_config/sensuctl/config_list.json
@@ -1,0 +1,7 @@
+{
+  "api-url": "http://localhost:8080",
+  "environment": "default",
+  "format": "tabular",
+  "organization": "default"
+}
+

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -11,6 +11,9 @@ end
 copy_module_to(hosts, :source => proj, :module_name => 'sensu', :target_module_path => modulepath)
 
 RSpec.configure do |c|
+  c.add_setting :sensu_full, default: false
+  c.sensu_full = (ENV['BEAKER_sensu_full'] == 'yes' || ENV['BEAKER_sensu_full'] == 'true')
+
   # Readable test descriptions
   c.formatter = :documentation
 

--- a/spec/unit/provider/sensu_config/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_config/sensuctl_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_config).provider(:sensuctl) do
+  before(:each) do
+    @provider = described_class
+    @type = Puppet::Type.type(:sensu_config)
+    @resource = @type.new({
+      :name => 'format',
+      :value => 'json',
+    })
+  end
+
+  describe 'self.instances' do
+    it 'should create instances' do
+      allow(@provider).to receive(:sensuctl).with('config','view','--format','json').and_return(my_fixture_read('config_list.json'))
+      expect(@provider.instances.length).to eq(4)
+    end
+
+    it 'should return the resource for a config' do
+      allow(@provider).to receive(:sensuctl).with('config','view','--format','json').and_return(my_fixture_read('config_list.json'))
+      property_hash = @provider.instances.select { |i| i.name == 'format' }[0].instance_variable_get("@property_hash")
+      expect(property_hash[:value]).to eq('tabular')
+    end
+  end
+
+  describe 'create' do
+    it 'should create a config' do
+      expect(@resource.provider).to receive(:sensuctl).with('config', 'set-format', 'json')
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+  end
+
+  describe 'flush' do
+    it 'should update a config' do
+      expect(@resource.provider).to receive(:sensuctl).with('config', 'set-format', 'foobar')
+      @resource.provider.value = 'foobar'
+      @resource.provider.flush
+    end
+  end
+
+  describe 'destroy' do
+    it 'should not support deleting a config' do
+      expect(Puppet).to receive(:warning).with(/sensu_config does not support ensure=absent/)
+      @resource.provider.destroy
+    end
+  end
+end
+

--- a/spec/unit/sensu_config_spec.rb
+++ b/spec/unit/sensu_config_spec.rb
@@ -1,0 +1,176 @@
+require 'spec_helper'
+require 'puppet/type/sensu_config'
+
+describe Puppet::Type.type(:sensu_config) do
+  let(:default_config) do
+    {
+      name: 'format',
+      value: 'json',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:sensu_config) do
+    described_class.new(config)
+  end
+
+  it 'should add to catalog without raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource sensu_config
+    }.to_not raise_error
+  end
+
+  it 'should require a name' do
+    expect {
+      described_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should not accept ensure => absent' do
+    config[:ensure] = 'absent'
+    expect { sensu_config[:ensure] = 'absent' }.to raise_error(Puppet::Error, /ensure does not support absent/)
+  end
+
+  defaults = {}
+
+  # String properties
+  [
+    :value,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 'foo'
+      expect(sensu_config[property]).to eq('foo')
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(sensu_config[property]).to eq(default)
+      end
+    end
+  end
+
+  # String regex validated properties
+  [
+    :name,
+  ].each do |property|
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo bar'
+      expect { sensu_config }.to raise_error(Puppet::Error, /#{property.to_s} invalid/)
+    end
+  end
+
+  # Array properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = ['foo', 'bar']
+      expect(sensu_config[property]).to eq(['foo', 'bar'])
+    end
+  end
+
+  # Integer properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 30
+      expect(sensu_config[property]).to eq(30)
+    end
+    it "should accept valid #{property} as string" do
+      config[property] = '30'
+      expect(sensu_config[property]).to eq(30)
+    end
+    it "should not accept invalid value for #{property}" do
+      config[property] = 'foo'
+      expect { sensu_config }.to raise_error(Puppet::Error, /should be an Integer/)
+    end
+  end
+
+  # Boolean properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = true
+      expect(sensu_config[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = false
+      expect(sensu_config[property]).to eq(:false)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'true'
+      expect(sensu_config[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'false'
+      expect(sensu_config[property]).to eq(:false)
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { sensu_config }.to raise_error(Puppet::Error, /Invalid value "foo". Valid values are true, false/)
+    end
+  end
+
+  # Hash properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      sensu_config[property] = { 'foo': 'bar' }
+      expect(sensu_config[property]).to eq({'foo': 'bar'})
+    end
+    it "should not accept invalid #{property}" do
+      sensu_config[property] = 'foo'
+      expect { sensu_config }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+  end
+
+  it 'should autorequire Package[sensu-cli]' do
+    package = Puppet::Type.type(:package).new(:name => 'sensu-cli')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource sensu_config
+    catalog.add_resource package
+    rel = sensu_config.autorequire[0]
+    expect(rel.source.ref).to eq(package.ref)
+    expect(rel.target.ref).to eq(sensu_config.ref)
+  end
+
+  it 'should autorequire Service[sensu-backend]' do
+    service = Puppet::Type.type(:service).new(:name => 'sensu-backend')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource sensu_config
+    catalog.add_resource service
+    rel = sensu_config.autorequire[0]
+    expect(rel.source.ref).to eq(service.ref)
+    expect(rel.target.ref).to eq(sensu_config.ref)
+  end
+
+  it 'should autorequire Exec[sensuctl_configure]' do
+    exec = Puppet::Type.type(:exec).new(:name => 'sensuctl_configure', :command => '/usr/bin/sensuctl')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource sensu_config
+    catalog.add_resource exec
+    rel = sensu_config.autorequire[0]
+    expect(rel.source.ref).to eq(exec.ref)
+    expect(rel.target.ref).to eq(sensu_config.ref)
+  end
+
+  it 'should autorequire sensu_api_validator' do
+    validator = Puppet::Type.type(:sensu_api_validator).new(:name => 'sensu')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource sensu_config
+    catalog.add_resource validator
+    rel = sensu_config.autorequire[0]
+    expect(rel.source.ref).to eq(validator.ref)
+    expect(rel.target.ref).to eq(sensu_config.ref)
+  end
+
+  [
+    :value,
+  ].each do |property|
+    it "should require property when ensure => present" do
+      config.delete(property)
+      config[:ensure] = :present
+      expect { sensu_config }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `sensu_config` type and provider to manage config settings for `sensuctl`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Should be able to modify `sensuctl config` values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and beaker tests on centos-7 nodeset.
