### PR TITLE
Require tempfile to fix puppet resource command

### DIFF
--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'tempfile'
 
 class Puppet::Provider::Sensuctl < Puppet::Provider
   initvars


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Explicitly require `tempfile`.  I'm guessing `tempfile` is loaded by Puppet for `puppet apply` but not `puppet resource` which is why this didn't show up in tests.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of sensu2 work for #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Without this change:

```
[root@sensu-backend ~]# puppet resource sensu_environment test ensure=present
Error: sensuctl create test failed
Error message: uninitialized constant Puppet::Provider::Sensuctl::Tempfile
Error: /Sensu_environment[test]/ensure: change from 'absent' to 'present' failed: sensuctl create test failed
Error message: uninitialized constant Puppet::Provider::Sensuctl::Tempfile
sensu_environment { 'test':
  ensure => 'absent',
}
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using `sensu-backend` Vagrant box:

```
[root@sensu-backend ~]# puppet resource sensu_environment test ensure=present
Notice: /Sensu_environment[test]/ensure: created
sensu_environment { 'test':
  ensure       => 'present',
  organization => 'default',
}
```

## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
