### PR TITLE
Use Different Fact

### DIFF
--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -20,7 +20,7 @@ class sensu::repo::apt {
     # ignoring the puppet-lint plugin because of a bug that warns on the next
     # line.
     if $::sensu::repo_release == undef { #lint:ignore:undef_in_function
-      $release = $facts['os']['distro']['codename']
+      $release = $facts['lsbdistcodename']
     } else {
       $release = $::sensu::repo_release
     }

--- a/manifests/repo/apt.pp
+++ b/manifests/repo/apt.pp
@@ -20,7 +20,7 @@ class sensu::repo::apt {
     # ignoring the puppet-lint plugin because of a bug that warns on the next
     # line.
     if $::sensu::repo_release == undef { #lint:ignore:undef_in_function
-      $release = $::facts['os']['distro']['codename']
+      $release = $facts['os']['distro']['codename']
     } else {
       $release = $::sensu::repo_release
     }

--- a/spec/classes/sensu_enterprise_spec.rb
+++ b/spec/classes/sensu_enterprise_spec.rb
@@ -259,6 +259,7 @@ describe 'sensu', :type => :class do
         :osfamily        => 'Debian',
         :kernel          => 'Linux',
         :lsbdistid       => 'ubuntu',
+        :lsbdistcodename => 'trusty',
         :lsbdistrelease  => '14.04',
         :os              => {
           :name    => 'ubuntu',

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -115,6 +115,7 @@ describe 'sensu' do
             :kernel          => 'Linux',
             :osfamily        => 'Debian',
             :lsbdistid       => 'ubuntu',
+            :lsbdistcodename => 'trusty',
             :lsbdistrelease  => '14.04',
             :os              => {
               :name    => 'ubuntu',
@@ -200,6 +201,7 @@ describe 'sensu' do
               :kernel          => 'Linux',
               :osfamily        => 'Debian',
               :lsbdistid       => 'Debian',
+              :lsbdistcodename => 'jessie',
               :lsbdistrelease  => '8.6',
               :os => {
                 :name    => 'Debian',
@@ -232,6 +234,7 @@ describe 'sensu' do
               :kernel          => 'Linux',
               :osfamily        => 'Debian',
               :lsbdistid       => 'Debian',
+              :lsbdistcodename => 'stretch',
               :lsbdistrelease  => '9.3',
               :os => {
                 :name    => 'Debian',


### PR DESCRIPTION
# Pull Request Checklist

## Description
     Failure/Error: it { is_expected.to compile }
       error during compilation: Evaluation Error: Operator '[]' is not applicable to an Undef Value. (file: /Users/csoleimani/git/puppet-control/spec/fixtures/modules/r10k/sensu/manifests/repo/apt.pp, line: 23, column: 18)

I was getting this error when doing pdk tests
## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes # .
#941
## Motivation and Context
I started seeing rspec errors after updating to the latest version of the module, so I made a minor change.

## How Has This Been Tested?
PDK tests pass now. This is in our environment too.

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
