### PR TITLE
Pin acceptance tests version of puppetlabs/apt

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -21,6 +21,6 @@ RSpec.configure do |c|
   c.before :suite do
     # Install module dependencies
     on hosts, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
-    on hosts, puppet('module', 'install', 'puppetlabs-apt'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
+    on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 4.0.0 < 5.0.0"'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Avoid puppetlabs/apt 5.0.0 in acceptance tests as it has a regression that affects ability to add sensu2 apt repos.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #943 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`BEAKER_set=debian-9 bundle exec rake beaker`

## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
