### PR TITLE
Fix acceptance tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -44,7 +44,7 @@ group :documentation do
 end
 
 group :system_tests do
-  gem 'beaker',                       :require => false
+  gem 'beaker', '~> 3.x',             :require => false
   gem 'beaker-rspec',                 :require => false
   gem 'serverspec',                   :require => false
   gem 'beaker-puppet_install_helper', :require => false


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Pin beaker-rspec to avoid travis-ci pulling in really ancient versions that don't work

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Will fix tests for #947 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Something with Travis CI recently changed where bundler installs a really old versions of `beaker-rspec` that doesn't work with the version of `serverspec` that gets installed.  This change will force the version of `beaker-rspec` that is known to work with this module's acceptance tests.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I only see this problem in Travis CI, can't reproduce locally.