### PR TITLE
Use newer ruby (2.4.4) for testing Puppet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec 
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
   - rvm: 2.4.2
     sudo: required


### PR DESCRIPTION
Ruby 2.4.4 is used as of Puppet v5.5.2


# Pull Request Checklist

## Motivation and Context
Use correct version of ruby with latest puppet version

## How Has This Been Tested?
TravisCI

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
