### PR TITLE
Use newer ruby (2.4.4) for testing Puppet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
   include:
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4"
-  - rvm: 2.4.3
+  - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
   - rvm: 2.4.2
     sudo: required

--- a/Gemfile
+++ b/Gemfile
@@ -46,7 +46,7 @@ group :documentation do
 end
 
 group :system_tests do
-  gem 'beaker',                       :require => false
+  gem 'beaker', '~> 3.x',             :require => false
   gem 'beaker-rspec',                 :require => false
   gem 'serverspec',                   :require => false
   gem 'beaker-puppet_install_helper', :require => false


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
Ruby 2.4.4 is used as of Puppet v5.5.2

## Motivation and Context
Use correct version of ruby with latest puppet version

## How Has This Been Tested?
TravisCI

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
