### PR TITLE
Use beaker 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,61 +22,61 @@ matrix:
   include:
   - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="centos-6"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="centos-7" BEAKER_sensu_full=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="debian-9"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1604"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="debian-8"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1404"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1804"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-2"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201803"
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201703"

--- a/Gemfile
+++ b/Gemfile
@@ -44,8 +44,10 @@ group :documentation do
 end
 
 group :system_tests do
-  gem 'beaker', '~> 3.x',             :require => false
+  gem 'beaker', '~> 4.x',             :require => false
   gem 'beaker-rspec',                 :require => false
+  gem 'beaker-puppet',                :require => false
+  gem 'beaker-docker',                :require => false
   gem 'serverspec',                   :require => false
   gem 'beaker-puppet_install_helper', :require => false
   gem 'beaker-module_install_helper', :require => false

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,4 +1,5 @@
 require 'beaker-rspec'
+require 'beaker-puppet'
 require 'beaker/module_install_helper'
 
 install_puppet_agent_on(hosts, :puppet_collection => 'puppet5', :puppet_agent_version => ENV['PUPPET_INSTALL_VERSION'], :run_in_parallel => true)


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use beaker 4
Use Ruby 2.4.4 for beaker tests

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #949 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Use same Ruby as unit tests and support latest beaker.  Unfortunately re-using running docker containers still doesn't work: https://tickets.puppetlabs.com/browse/BKR-1457.  This just means every beaker test has to start from a fresh container, can't use `BEAKER_destroy=no` then `BEAKER_destroy=no BEAKER_provision=no`.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`BEAKER_set=centos-7 bundle exec rake beaker`