### PR TITLE
Document and test resource purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 3. [Usage - Configuration options and additional functionality](#usage)
     * [Basic Sensu backend](#basic-sensu-backend)
     * [Basic Sensu agent](#basic-sensu-agent)
+    * [Exported resources](#exported-resources)
+    * [Resource purging](#resource-purging)
 4. [Reference](#reference)
     * [Facts](#facts)
 5. [Limitations - OS compatibility, etc.](#limitations)
@@ -116,6 +118,17 @@ The backend system would collect all `sensu_check` resources.
 
 ```puppet
   Sensu_check <<||>>
+```
+
+### Resource purging
+
+All the types provided by this module support purging except `sensu_config`.
+This example will remove all unmanaged Sensu checks:
+
+```puppet
+resources { 'sensu_check':
+  purge => true,
+}
 ```
 
 ## Reference


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Document that all types (except `sensu_config`) support being purged.  Add some tests to verify what was documented in README.  Worth noting that `sensu_asset` doesn't yet support purging because deleting assets with sensuctl is not yet supported but the code in this module supports the operation.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Documenting the already supported ability to purge resources seems useful especially in the context of checks.  I only added tests for the documented example of purging checks since that seemed most likely what people would deploy.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`BEAKER_set=centos-7 BEAKER_sensu_full=yes  bundle exec rake beaker`

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] Tests pass - `bundle exec rake validate lint spec`
