### PR TITLE
Make sensu_check handlers not mandatory which matches behavior of sensuctl

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -201,7 +201,6 @@ DESC
     required_properties = [
       :command,
       :subscriptions,
-      :handlers,
     ]
     required_properties.each do |property|
       if self[:ensure] == :present && self[property].nil?

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -9,7 +9,6 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
       sensu_check { 'test':
         command       => 'check-http.rb',
         subscriptions => ['demo'],
-        handlers      => ['email'],
         interval      => 60,
       }
       EOS
@@ -34,7 +33,6 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
       sensu_check { 'test':
         command             => 'check-http.rb',
         subscriptions       => ['demo'],
-        handlers            => ['email'],
         interval            => 60,
         extended_attributes => { 'foo' => 'bar' }
       }

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -223,7 +223,6 @@ describe Puppet::Type.type(:sensu_check) do
   [
     :command,
     :subscriptions,
-    :handlers
   ].each do |property|
     it "should require property when ensure => present" do
       config.delete(property)


### PR DESCRIPTION


# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make sensu_check handler property optional.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current sensu docs (https://docs.sensu.io/sensu-core/2.0/guides/monitor-server-resources/) use examples where handler is not defined and I verified a check can be defined without a handler.
