### PR TITLE
Refactor sensu_check check_hooks property

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -15,6 +15,17 @@ Manages Sensu checks
     interval      => 60,
   }
 
+@example Create a check that has a hook
+  sensu_check { 'test':
+    ensure        => 'present',
+    command       => 'check-cpu.sh -w 75 -c 90',
+    subscriptions => ['linux'],
+    check_hooks   => [
+      { 'critical' => ['ps'] },
+    ],
+    interval      => 60,
+  }
+
 @example Create a check that is subdued
   sensu_check { 'test':
     ensure        => 'present',
@@ -105,8 +116,26 @@ DESC
   end
 
   newproperty(:check_hooks, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
-    desc "An array of Sensu hooks (names), which are commands run by the Sensu agent in response to the result of the check command execution."
-    newvalues(/.*/, :absent)
+    desc "An array of Sensu hooks, which are commands run by the Sensu agent in response to the result of the check command execution."
+    validate do |value|
+      if ! value.is_a?(Hash)
+        raise ArgumentError, "check_hooks elements must be a Hash"
+      end
+      type = value.keys[0]
+      hooks = value[type]
+      type_valid = false
+      if ['ok','warning','critical','unknown','non-zero'].include?(type)
+        type_valid = true
+      elsif type.to_s =~ /^\d+$/ && type.to_i.between?(0,256)
+        type_valid = true
+      end
+      if ! type_valid
+        raise ArgumentError, "check_hooks type value is invalid"
+      end
+      if ! hooks.is_a?(Array)
+        raise ArgumentError, "check_hooks hooks must be an Array"
+      end
+    end
   end
 
   newproperty(:subdue_days, :parent => PuppetX::Sensu::HashProperty) do

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -70,7 +70,6 @@ describe Puppet::Type.type(:sensu_check) do
     :subscriptions,
     :handlers,
     :runtime_assets,
-    :check_hooks,
     :proxy_requests_entity_attributes,
     :metric_handlers,
     :output_metric_handlers,
@@ -177,6 +176,28 @@ describe Puppet::Type.type(:sensu_check) do
     it 'should verify time range keys' do
       config[:subdue_days] = {'all' => [{'start' => '5:00 PM', 'end' => '8:00 AM'}]}
       expect { check }.to raise_error(Puppet::Error, /subdue_days day time window must be a hash containing keys 'begin' and 'end'/)
+    end
+  end
+
+  describe 'check_hooks' do
+    [
+      1,
+      '1',
+      'ok',
+      'warning',
+      'critical',
+      'unknown',
+      'non-zero',
+    ].each do |type|
+      it "accepts valid values for type #{type} #{type.class}" do
+        config[:check_hooks] = [{type => ['test']}]
+        expect(check[:check_hooks]).to eq([{type => ['test']}])
+      end
+    end
+
+    it 'should require Hash elements' do
+      config[:check_hooks] = ['foo']
+      expect { check }.to raise_error(Puppet::Error, /check_hooks elements must be a Hash/)
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make sensu_check `check_hooks` property match what is actually output by sensuctl.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901.  Upstream documentation bug here: https://github.com/sensu/sensu-docs/issues/678

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The type `sensu_check` needs to treat `check_hooks` property the way it's handled by sensuctl.  Previously it was just expecting an array of hooks which isn't correct as hooks associated to a check also have a type like critical or warning.  This change ensures valid `check_hooks` are defined.