### PR TITLE
Use sensu for repo names

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -13,7 +13,7 @@ class sensu::repo {
         $repo_release = $facts['os']['release']['major']
       }
       # TODO: change from nightly to stable once there are stable releases
-      yumrepo { 'sensu_nightly':
+      yumrepo { 'sensu':
         baseurl         => "https://packagecloud.io/sensu/nightly/el/${repo_release}/\$basearch",
         repo_gpgcheck   => 1,
         gpgcheck        => 0,
@@ -26,7 +26,7 @@ class sensu::repo {
     }
     'Debian': {
       #TODO: change from nightly to stable once there are stable releases
-      apt::source { 'sensu_nightly':
+      apt::source { 'sensu':
         ensure   => 'present',
         location => "https://packagecloud.io/sensu/nightly/${downcase($facts['os']['name'])}/",
         repos    => 'main',

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -14,7 +14,7 @@ describe 'sensu::repo', :type => :class do
       end
       if facts[:osfamily] == 'RedHat'
         it {
-          should contain_yumrepo('sensu_nightly').with({
+          should contain_yumrepo('sensu').with({
             'baseurl'         => baseurl,
             'repo_gpgcheck'   => 1,
             'gpgcheck'        => 0,
@@ -27,7 +27,7 @@ describe 'sensu::repo', :type => :class do
         }
       elsif facts[:osfamily] == 'Debian'
         it {
-          should contain_apt__source('sensu_nightly').with({
+          should contain_apt__source('sensu').with({
             'ensure' => 'present',
             'location' => "https://packagecloud.io/sensu/nightly/#{facts[:os]['name'].downcase}/",
             'repos'    => 'main',


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use just `sensu` for repo names

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This will allow someone to go from nightly to beta to production without leaving unmanaged repos files on disk that would cause conflicts with the managed repo.  This will ensure that changes to repo URLs update the same file on the filesystem.  This should allow smooth transition from nightly to beta to production.

