### PR TITLE
Update soft dependency on puppetlabs-apt to be '>= 5.0.1 < 6.0.0'

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
-      ref: 4.1.0
+      ref: 5.0.1
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
       ref: 4.25.1

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This module will install packages, create configuration and start services neces
 
 Plugin sync is required if the custom sensu types and providers are used.
 
-This module has a soft dependency on the [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module (`>= 4.0.0 < 5.0.0`) for systems using `apt`.
+This module has a soft dependency on the [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module (`>= 5.0.1 < 6.0.0`) for systems using `apt`.
 
 ### Beginning with sensu
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,6 +22,6 @@ RSpec.configure do |c|
   c.before :suite do
     # Install module dependencies
     on hosts, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
-    on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 4.0.0 < 5.0.0"'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
+    on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 6.0.0"'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bump the soft dependency to puppetlabs-apt to `>= 5.0.1 < 6.0.0`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #901.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Rather than depend on older versions of the apt module it seems worth depending on latest that fixes the bug that forced us to pin to 4.x.  5.0.1 fixes the bug we hit and should be the new minimum requirement for apt systems.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`BEAKER_set=debian-9 bundle exec rake beaker`

## General

- [x] Update `README.md` with any necessary configuration snippets
