### PR TITLE
Remove metric_format and metric_handlers properties for sensu_check

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -200,16 +200,6 @@ DESC
     desc "The splay coverage percentage use for proxy check request splay calculation."
   end
 
-  newproperty(:metric_format) do
-    #desc
-    newvalues(/.*/, :absent)
-  end
-
-  newproperty(:metric_handlers, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
-    #desc
-    newvalues(/.*/, :absent)
-  end
-
   newproperty(:output_metric_format) do
     #desc
     newvalues(/.*/, :absent)

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -40,7 +40,6 @@ describe Puppet::Type.type(:sensu_check) do
     :command,
     :cron,
     :proxy_entity_id,
-    :metric_format,
     :output_metric_format
   ].each do |property|
     it "should accept valid #{property}" do
@@ -71,7 +70,6 @@ describe Puppet::Type.type(:sensu_check) do
     :handlers,
     :runtime_assets,
     :proxy_requests_entity_attributes,
-    :metric_handlers,
     :output_metric_handlers,
     :env_vars
   ].each do |property|


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove `metric_format` and `metric_handlers` from `sensu_check`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Relates to #901.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Upstream removed the metric_format and metric_handlers here: https://github.com/sensu/sensu-go/pull/1454.  This change removes the values which don't exist for checks.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [ ] Tests pass - `bundle exec rake validate lint spec`
