### PR TITLE
Sensu Redis - Support boolean redis_tls parameter - #GH-900

### DIFF
--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -122,4 +122,16 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
   def auto_reconnect=(value)
     conf['redis']['auto_reconnect'] = value
   end
+
+  def tls
+    conf['redis']['tls'] == {}
+  end
+
+  def tls=(value)
+    if value
+      conf['redis']['tls'] = {}
+    else
+      conf['redis'].delete 'tls'
+    end
+  end
 end

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -99,6 +99,12 @@ Puppet::Type.newtype(:sensu_redis_config) do
     defaultto :true
   end
 
+  newproperty(:tls) do
+    desc "Use TLS encryption to connect to Redis"
+
+    defaultto :false
+  end
+
   newproperty(:sentinels, :array_matching => :all) do
     desc "Redis Sentinel configuration for HA clustering"
     defaultto []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,16 +55,16 @@
 # @param manage_services Manage the sensu services with puppet
 #
 # @param client_service_enable Set enable value for sensu client service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param client_service_ensure Set ensure value for sensu client service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param server_service_enable Set enable value for sensu server service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param server_service_ensure Set ensure value for sensu server service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param manage_user Manage the sensu user with puppet
 #
@@ -135,6 +135,8 @@
 #   In the end whatever sensu defaults to, which is "mymaster" currently.
 #
 # @param redis_auto_reconnect Reconnect to Redis in the event of a connection failure
+#
+# @param redis_tls Enable TLS encryption when connecting to Redis
 #
 # @param transport_type Transport type to be used by Sensu
 #
@@ -400,6 +402,7 @@ class sensu (
   Boolean            $redis_reconnect_on_error = true,
   Integer            $redis_db = 0,
   Boolean            $redis_auto_reconnect = true,
+  Boolean            $redis_tls = false,
   Optional[Array]    $redis_sentinels = undef,
   Optional[String]   $redis_master = undef,
   Enum['rabbitmq','redis'] $transport_type = 'rabbitmq',

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -36,5 +36,6 @@ class sensu::redis::config {
     auto_reconnect     => $::sensu::redis_auto_reconnect,
     sentinels          => $sentinels,
     master             => $master,
+    tls                => $::sensu::redis_tls,
   }
 }

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -132,5 +132,22 @@ describe 'sensu', :type => :class do
 
       it { should contain_file('/etc/sensu/conf.d/redis.json').with_ensure('absent') }
     end # purge configs
+
+    [true,false].each do |value|
+      context "with redis_tls specified as #{value}" do
+        let(:params) { { :redis_tls => value } }
+
+        if value
+          it { should contain_sensu_redis_config('testhost.domain.com').with(
+            :tls => {},
+          )}
+        else
+          it { should not contain_sensu_redis_config('testhost.domain.com').with(
+            :tls,
+          )}
+        end
+      end
+    end #redis_tls
+
   end #redis config
 end


### PR DESCRIPTION
# Pull Request Checklist

My initial work to help resolve https://github.com/sensu/sensu-puppet/issues/900 

## Description
I spoke to @ghoneycutt in person at the Sensu Summit about how this feature is the only reason I've forked the model. This is what I have so far but, could use some help getting some proper spec tests working (I gave it a shot) and review if this setup is correct as I don't have much experience with custom Puppet providers/types. 

The Sensu redis support was added in https://github.com/sensu/sensu-redis/commit/b35d3ef2c9d6123072349de537d5076314bcd9e3 technically, for this to work, all that needs to exist is:
```json
{
  "redis": {
    "tls": {}
  }
}
```
However, `tls` can also be `ssl` and can support the same TLS options that RabbitMQ supports (i.e. `private_key_file`and `cert_chain_file`.) however, those are not necessary and I don't have an environment to test if that'll actually work. 

## Related Issue
Fixes #900 

## Motivation and Context
Support a basic Boolean variable to enable/disable TLS encryption for Sensu when connecting to Redis. 

## How Has This Been Tested?
We use this provider/type code in production and it works. However, that's limited to CentOS 7. 

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] Tests pass - `bundle exec rake validate lint spec`
- [X] New parameters are documented

- [X] New parameters have tests

