### PR TITLE
(GH-945) Document version of vagrant-vbguest plugin for Amazon2

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,13 @@ This module does not support adding `sensuctl` resources on a host other than th
 
 The type `sensu_asset` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#988](https://github.com/sensu/sensu-go/issues/988).
 
+To use Amazon 2 with Vagrant, the plugin
+[vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) must be
+at least version `0.16.0.beta1`, which can be installed with the
+following command.
+
+`vagrant plugin install vagrant-vbguest --verbose --plugin-version 0.16.0.beta1`
+
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)


### PR DESCRIPTION
Without this specific version of the Vagrant plugin, vagrant-vbguest,
the Amazon2 platform will not work with Vagrant.


# Pull Request Checklist

Use a different plugin version of vagrant-vbguest that supports Amazon 2

## Description
Documentation only

## Related Issue

Fixes #945 

## Motivation and Context
Allows Amazon2 to work with Vagrant testing

## How Has This Been Tested?
Vagrant

## General

- [x] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
