### PR TITLE
Sensu Redis - Support boolean redis_tls parameter (cont #967)

### DIFF
--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -122,4 +122,16 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
   def auto_reconnect=(value)
     conf['redis']['auto_reconnect'] = value
   end
+
+  def tls
+    conf['redis']['tls'] == {}
+  end
+
+  def tls=(value)
+    if value
+      conf['redis']['tls'] = {}
+    else
+      conf['redis'].delete 'tls'
+    end
+  end
 end

--- a/lib/puppet/provider/sensu_redis_config/json.rb
+++ b/lib/puppet/provider/sensu_redis_config/json.rb
@@ -124,11 +124,11 @@ Puppet::Type.type(:sensu_redis_config).provide(:json) do
   end
 
   def tls
-    conf['redis']['tls'] == {}
+    conf['redis'].key?('tls') ? :true : :false
   end
 
   def tls=(value)
-    if value
+    if value == :true
       conf['redis']['tls'] = {}
     else
       conf['redis'].delete 'tls'

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -99,9 +99,9 @@ Puppet::Type.newtype(:sensu_redis_config) do
     defaultto :true
   end
 
-  newproperty(:tls) do
+  newproperty(:tls, :boolean => true) do
     desc "Use TLS encryption to connect to Redis"
-
+    newvalues(:true, :false)
     defaultto :false
   end
 

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -99,6 +99,12 @@ Puppet::Type.newtype(:sensu_redis_config) do
     defaultto :true
   end
 
+  newproperty(:tls) do
+    desc "Use TLS encryption to connect to Redis"
+
+    defaultto :false
+  end
+
   newproperty(:sentinels, :array_matching => :all) do
     desc "Redis Sentinel configuration for HA clustering"
     defaultto []

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,16 +55,16 @@
 # @param manage_services Manage the sensu services with puppet
 #
 # @param client_service_enable Set enable value for sensu client service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param client_service_ensure Set ensure value for sensu client service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param server_service_enable Set enable value for sensu server service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param server_service_ensure Set ensure value for sensu server service
-#   (applies when manage_services is set to true) 
+#   (applies when manage_services is set to true)
 #
 # @param manage_user Manage the sensu user with puppet
 #
@@ -135,6 +135,8 @@
 #   In the end whatever sensu defaults to, which is "mymaster" currently.
 #
 # @param redis_auto_reconnect Reconnect to Redis in the event of a connection failure
+#
+# @param redis_tls Enable TLS encryption when connecting to Redis
 #
 # @param transport_type Transport type to be used by Sensu
 #
@@ -400,6 +402,7 @@ class sensu (
   Boolean            $redis_reconnect_on_error = true,
   Integer            $redis_db = 0,
   Boolean            $redis_auto_reconnect = true,
+  Boolean            $redis_tls = false,
   Optional[Array]    $redis_sentinels = undef,
   Optional[String]   $redis_master = undef,
   Enum['rabbitmq','redis'] $transport_type = 'rabbitmq',

--- a/manifests/redis/config.pp
+++ b/manifests/redis/config.pp
@@ -36,5 +36,6 @@ class sensu::redis::config {
     auto_reconnect     => $::sensu::redis_auto_reconnect,
     sentinels          => $sentinels,
     master             => $master,
+    tls                => $::sensu::redis_tls,
   }
 }

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -137,15 +137,7 @@ describe 'sensu', :type => :class do
       context "with redis_tls specified as #{value}" do
         let(:params) { { :redis_tls => value } }
 
-        if value
-          it { should contain_sensu_redis_config('testhost.domain.com').with(
-            :tls => {},
-          )}
-        else
-          it { should not contain_sensu_redis_config('testhost.domain.com').with(
-            :tls,
-          )}
-        end
+        it { should contain_sensu_redis_config('testhost.domain.com').with_tls(value) }
       end
     end #redis_tls
 

--- a/spec/classes/sensu_redis_spec.rb
+++ b/spec/classes/sensu_redis_spec.rb
@@ -132,5 +132,22 @@ describe 'sensu', :type => :class do
 
       it { should contain_file('/etc/sensu/conf.d/redis.json').with_ensure('absent') }
     end # purge configs
+
+    [true,false].each do |value|
+      context "with redis_tls specified as #{value}" do
+        let(:params) { { :redis_tls => value } }
+
+        if value
+          it { should contain_sensu_redis_config('testhost.domain.com').with(
+            :tls => {},
+          )}
+        else
+          it { should not contain_sensu_redis_config('testhost.domain.com').with(
+            :tls,
+          )}
+        end
+      end
+    end #redis_tls
+
   end #redis config
 end

--- a/spec/unit/sensu_redis_config_spec.rb
+++ b/spec/unit/sensu_redis_config_spec.rb
@@ -50,6 +50,42 @@ describe Puppet::Type.type(:sensu_redis_config) do
 
   end
 
+  describe "tls" do
+    context "with defaults (no tls)" do
+      it { expect(type_instance.parameter(:tls).value).to eq(:false) }
+    end
+
+    [true, 'true'].each do |v|
+      context "should set tls to #{v}" do
+        let :inst do
+          create_type_instance(resource_hash.merge({:tls => v}))
+        end
+
+        it { expect(inst.parameter(:tls).value).to eq(:true) }
+      end
+    end
+
+    [false, 'false'].each do |v|
+      context "should set tls to #{v}" do
+        let :inst do
+          create_type_instance(resource_hash.merge({:tls => v}))
+        end
+
+        it { expect(inst.parameter(:tls).value).to eq(:false) }
+      end
+    end
+
+    context 'invalid value' do
+      let :inst do
+        create_type_instance(resource_hash.merge({:tls => 'foo'}))
+      end
+
+      it 'should raise an error' do
+        expect { inst }.to raise_error(Puppet::ResourceError, /Invalid value "foo". Valid values are true, false/)
+      end
+    end
+  end
+
   describe "sentinels" do
     context "with defaults (no sentinels)" do
       it "no sentinels" do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add on to work in #967 

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #900 and extends #967 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure `redis_tls` is a proper boolean property and ensure the provider is checking the symbol value.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I modified `tests/sensu-server.pp` to add `redis_tls => true`:

```
[root@sensu-server ~]# puppet apply sensu-server.pp
Notice: Compiled catalog for sensu-server.example.com in environment production in 1.87 seconds
Notice: /Stage[main]/Sensu::Redis::Config/Sensu_redis_config[sensu-server.example.com]/tls: tls changed 'false' to 'true'
Notice: /Stage[main]/Sensu::Api/Service[sensu-api]: Triggered 'refresh' from 2 events
Notice: /Stage[main]/Sensu::Server::Service/Service[sensu-server]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 3.21 seconds
```

Resulting config:

```
[root@sensu-server ~]# cat /etc/sensu/conf.d/redis.json
{
  "redis": {
    "port": 6379,
    "host": "127.0.0.1",
    "reconnect_on_error": true,
    "db": 0,
    "auto_reconnect": true,
    "tls": {
    }
  }
}
```

## General

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
