### PR TITLE
(GH-945) Use vagrant-vbguest >= 0.16.0 in order to support Amazon 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,13 +211,6 @@ This module does not support adding `sensuctl` resources on a host other than th
 
 The type `sensu_asset` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#988](https://github.com/sensu/sensu-go/issues/988).
 
-To use Amazon 2 with Vagrant, the plugin
-[vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) must be
-at least version `0.16.0.beta1`, which can be installed with the
-following command.
-
-`vagrant plugin install vagrant-vbguest --verbose --plugin-version 0.16.0.beta1`
-
 ## Development
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,7 +15,7 @@
 if not Vagrant.has_plugin?('vagrant-vbguest')
   abort <<-EOM
 
-vagrant plugin vagrant-vbguest is required.
+vagrant plugin vagrant-vbguest >= 0.16.0 is required.
 https://github.com/dotless-de/vagrant-vbguest
 To install the plugin, please run, 'vagrant plugin install vagrant-vbguest'.
 


### PR DESCRIPTION
## Description
Now that commit to fix Amazon 2 is released in 0.16.0 and the plugin can be installed without hoops, we do not need to README information.

## Related Issue

See #945 

## Motivation and Context
Allow Amazon 2 to work with Vagrant and keep the vagrant setup simple.

## How Has This Been Tested?
Locally with Vagrant.