### PR TITLE
Do not start sensu-backend cluster in Vagrant by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ vagrant ssh sensu-backend
 Multiple Vagrant boxes are available for testing a sensu-backend cluster
 
 ```bash
-vagrant up sensu-backend sensu-backend-peer1 sensu-backend-peer2
+vagrant up sensu-backend-peer1 sensu-backend-peer2
+vagrant provision sensu-backend-peer1 sensu-backend-peer2
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -69,6 +69,14 @@ vagrant up sensu-backend
 vagrant ssh sensu-backend
 ```
 
+#### Beginning with a Sensu cluster
+
+Multiple Vagrant boxes are available for testing a sensu-backend cluster
+
+```bash
+vagrant up sensu-backend sensu-backend-peer1 sensu-backend-peer2
+```
+
 ## Usage
 
 ### Basic Sensu backend

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -55,7 +55,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     backend.vm.network :forwarded_port, guest: 8080, host: 8082, auto_correct: true
     backend.vm.network :forwarded_port, guest: 8081, host: 8083, auto_correct: true
     backend.vm.provision :shell, :path => "tests/provision_basic_el.sh"
-    backend.vm.provision :shell, :inline => "puppet apply /vagrant/tests/sensu-backend.pp"
+    backend.vm.provision :shell, :inline => "puppet apply /vagrant/tests/sensu-backend-cluster.pp"
     backend.vm.provision :shell, :inline => "facter --custom-dir=/vagrant/lib/facter sensu_version"
   end
 
@@ -68,7 +68,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     backend.vm.network :forwarded_port, guest: 8080, host: 8084, auto_correct: true
     backend.vm.network :forwarded_port, guest: 8081, host: 8085, auto_correct: true
     backend.vm.provision :shell, :path => "tests/provision_basic_el.sh"
-    backend.vm.provision :shell, :inline => "puppet apply /vagrant/tests/sensu-backend.pp"
+    backend.vm.provision :shell, :inline => "puppet apply /vagrant/tests/sensu-backend-cluster.pp"
     backend.vm.provision :shell, :inline => "facter --custom-dir=/vagrant/lib/facter sensu_version"
   end
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -46,7 +46,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     backend.vm.provision :shell, :inline => "facter --custom-dir=/vagrant/lib/facter sensu_version"
   end
 
-  config.vm.define "sensu-backend-peer1", primary: true, autostart: true do |backend|
+  config.vm.define "sensu-backend-peer1", autostart: false  do |backend|
     backend.vm.box = "centos/7"
     backend.vm.hostname = 'sensu-backend-peer1.example.com'
     backend.vm.network :private_network, ip: ENV['ALTERNATE_IP'] || '192.168.52.21'
@@ -59,7 +59,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     backend.vm.provision :shell, :inline => "facter --custom-dir=/vagrant/lib/facter sensu_version"
   end
 
-  config.vm.define "sensu-backend-peer2", primary: true, autostart: true do |backend|
+  config.vm.define "sensu-backend-peer2", autostart: false do |backend|
     backend.vm.box = "centos/7"
     backend.vm.hostname = 'sensu-backend-peer2.example.com'
     backend.vm.network :private_network, ip: ENV['ALTERNATE_IP'] || '192.168.52.22'

--- a/tests/sensu-backend-cluster.pp
+++ b/tests/sensu-backend-cluster.pp
@@ -1,0 +1,20 @@
+case $facts['hostname'] {
+  /peer1/: {
+    $backend_name = 'backend1'
+  }
+  /peer2/: {
+    $backend_name = 'backend2'
+  }
+}
+
+class { '::sensu::backend':
+  config_hash => {
+    'listen-client-urls'          => 'http://0.0.0.0:2379',
+    'listen-peer-urls'            => 'http://0.0.0.0:2380',
+    'initial-cluster'             => 'backend1=http://192.168.52.21:2380,backend2=http://192.168.52.22:2380',
+    'initial-advertise-peer-urls' => "http://${facts['networking']['interfaces']['eth1']['ip']}:2380",
+    'initial-cluster-state'       => 'new',
+    'name'                        => $backend_name,
+  }
+}
+


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Do not autostart the sensu-backend cluster nodes.  Should also document or provision an actual cluster (WIP).

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #971 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Should not spawn multiple cluster backend vagrant boxes with simple `vagrant up`.  Also need to document and provision an actual cluster with vagrant.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
WIP testing still the second half of this PR which is provision or document setting up the cluster.

## General

- [x] Update `README.md` with any necessary configuration snippets

