### PR TITLE
Fixing invalid multibyte char error

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -98,7 +98,7 @@ DESC
   end
 
   newproperty(:stdin, :boolean => true) do
-    desc "If the Sensu agent writes JSON serialized Sensu entity and check data to the command process’ STDIN"
+    desc "If the Sensu agent writes JSON serialized Sensu entity and check data to the command process' STDIN"
     newvalues(:true, :false)
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This fixes and error that occurs during puppet agent run. There is a non-standard quote that puppet fails on.  Replacing the character allows puppet agent run to continue.  

Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Could not autoload puppet/type/sensu_check: /etc/puppetlabs/code/environments/pete_testing/modules/sensu/lib/puppet/type/sensu_check.rb:73: invalid multibyte char (US-ASCII)

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes # .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

