### PR TITLE
Add description to resources that don't use default ensurable

### DIFF
--- a/lib/puppet/type/sensu_config.rb
+++ b/lib/puppet/type/sensu_config.rb
@@ -16,6 +16,7 @@ DESC
   add_autorequires()
 
   ensurable do
+    desc "The basic property that the resource should be in."
     defaultvalues
     validate do |value|
       if value.to_sym == :absent

--- a/lib/puppet/type/sensu_event.rb
+++ b/lib/puppet/type/sensu_event.rb
@@ -21,6 +21,7 @@ DESC
   add_autorequires()
 
   ensurable do
+    desc "The basic property that the resource should be in."
     nodefault
     newvalue(:present)
     newvalue(:resolve) do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure all properties have a description when generating strings documentation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Resolves strings:generate warnings

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`bundle exec rake strings:generate`
