### PR TITLE
Do not manage the version of facter used for testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,12 +6,6 @@ else
   gem 'puppet', :require => false
 end
 
-if facterversion = ENV['FACTER_GEM_VERSION'] || "~> 3.x"
-  gem 'facter', facterversion, :require => false
-else
-  gem 'facter', :require => false
-end
-
 group :development, :unit_tests do
   gem 'rake',                                             '< 11.0.0'
   gem 'rspec-puppet', '~> 2.5.0',                         :require => false


### PR DESCRIPTION
# Pull Request Checklist

This allows testing to use the ruby based facter so it can run. Without
this patch, tests cannot use facter 3 and will fail.

## Description
Remove facter bits from `Gemfile`

## Related Issue

PR #977 is failing and this PR is meant to fix that.