### PR TITLE
Change sensu_api_validator default test_url

### DIFF
--- a/lib/puppet/type/sensu_api_validator.rb
+++ b/lib/puppet/type/sensu_api_validator.rb
@@ -36,7 +36,7 @@ DESC
 
   newparam(:test_url) do
     desc 'URL to use for testing if the Sensu backend is up'
-    defaultto '/info'
+    defaultto '/health'
   end
 
   newparam(:timeout) do

--- a/lib/puppet/util/sensu_api_validator.rb
+++ b/lib/puppet/util/sensu_api_validator.rb
@@ -10,7 +10,7 @@ module Puppet
       attr_reader :test_path
       attr_reader :test_headers
 
-      def initialize(sensu_api_server, sensu_api_port, use_ssl=false, test_path = "/info")
+      def initialize(sensu_api_server, sensu_api_port, use_ssl=false, test_path = "/health")
         @sensu_api_server = sensu_api_server
         @sensu_api_port   = sensu_api_port
         @use_ssl         = use_ssl


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Upstream removed /info: https://github.com/sensu/sensu-go/pull/2066

The /health endpoint allows unauthenticated queries:

```
[root@sensu-backend ~]# curl http://localhost:8080/health
{"Alarms":null,"ClusterHealth":[{"MemberID":9882886658148554927,"Name":"default","Err":"","Healthy":true}]}
```

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #979  .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ensure `sensu_api_validator` will work with latest sensu-go.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
```
[root@sensu-backend ~]# cat test.pp
sensu_api_validator { 'sensu': }
sensu_check { 'test2':
        command       => 'check-cpu.rb',
        subscriptions => ['demo'],
        handlers      => ['email'],
        interval      => 60,
      }
[root@sensu-backend ~]# puppet apply test.pp
Notice: Compiled catalog for sensu-backend.example.com in environment production in 0.12 seconds
Notice: Applied catalog in 0.12 seconds
```