### PR TITLE
Improvements to acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,67 +25,67 @@ matrix:
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="centos-6"
+    env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="centos-7" BEAKER_sensu_full=yes
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="centos-7-cluster" BEAKER_sensu_cluster=yes
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.2
     sudo: required
     services: docker
-    env: BEAKER_set="debian-9"
+    env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="ubuntu-1604"
+    env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="debian-8"
+    env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="ubuntu-1404"
+    env: BEAKER_set="ubuntu-1404" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="ubuntu-1804"
+    env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="amazonlinux-2"
+    env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="amazonlinux-201803"
+    env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="amazonlinux-201703"
+    env: BEAKER_set="amazonlinux-201703" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
 

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,15 +1,11 @@
 require 'beaker-rspec'
 require 'beaker-puppet'
 require 'beaker/module_install_helper'
+require 'beaker/puppet_install_helper'
 
-install_puppet_agent_on(hosts, :puppet_collection => 'puppet5', :puppet_agent_version => ENV['PUPPET_INSTALL_VERSION'], :run_in_parallel => true)
-proj = File.join(File.dirname(__FILE__), '..')
-if fact('osfamily') == 'windows'
-  modulepath = 'C:/ProgramData/PuppetLabs/code/modules'
-else
-  modulepath = '/etc/puppetlabs/code/modules'
-end
-copy_module_to(hosts, :source => proj, :module_name => 'sensu', :target_module_path => modulepath)
+run_puppet_install_helper
+install_module_dependencies
+install_module
 
 RSpec.configure do |c|
   c.add_setting :sensu_full, default: false
@@ -22,8 +18,7 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    # Install module dependencies
-    on hosts, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
-    on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 6.0.0"'), { :acceptable_exit_codes => [0,1], :run_in_parallel => true }
+    # Install soft module dependencies
+    on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 6.0.0"'), { :acceptable_exit_codes => [0,1] }
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Do not run parts of acceptance test setup in parallel
Rely on helpers and let travis tests set puppet collection version


## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #981  .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The parallel tests cause problems and no longer really needed.  Also use helpers which would allow for tests to be targeted at puppet6 collection when the time comes just by updating travis test matrix.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`BEAKER_set=centos-7 BEAKER_PUPPET_COLLECTION=puppet5 bundle exec rake beaker`

This fails fast as puppet-agent RPM is broken which is expected.
