### PR TITLE
removing agent from init.pp

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -28,7 +28,6 @@ class sensu (
   if $manage_repo {
     include ::sensu::repo
   }
-  include ::sensu::agent
 
   file { 'sensu_etc_dir':
     ensure  => 'directory',


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The include statement in init.pp for sensu::agent does not allow for configuration of the agent on the backend server.  Removing it from init.pp allows for "resource-like class declarations" in the user's pp file for the backend server.  This allows for configuration customizations like adding subscriptions .  

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes # .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

