### PR TITLE
Ignore sensuctl check key of output

### DIFF
--- a/lib/puppet/provider/sensu_check/sensuctl.rb
+++ b/lib/puppet/provider/sensu_check/sensuctl.rb
@@ -8,7 +8,7 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
   def self.ignore_keys
     [
       'duration', 'history', 'issued', 'status', 'total_state_change', 'total_state-change',
-      'executed', 'last_ok', 'occurrences', 'occurrences_watermark',
+      'executed', 'last_ok', 'occurrences', 'occurrences_watermark', 'output'
     ]
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Filter out the `output` key for checks.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes test failures for #980 and #982 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We still rely on filtering unused keys from sensuctl to support `extended_attributes`.  It appears upstream made a new one show up when listing checks.

https://github.com/sensu/sensu-go/pull/2082

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->