### PR TITLE
Support Puppet 6

### DIFF
--- a/.fixtures-puppet6.yml
+++ b/.fixtures-puppet6.yml
@@ -1,0 +1,13 @@
+fixtures:
+  repositories:
+    apt:
+      repo: git://github.com/puppetlabs/puppetlabs-apt.git
+      ref: 5.0.1
+    stdlib:
+      repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
+      ref: 4.25.1
+    yumrepo_core:
+      repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
+      ref: 1.0.1
+  symlinks:
+    sensu: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,10 +22,18 @@ matrix:
   include:
   - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
+  - rvm: 2.5.1
+    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-puppet6.yml"
   - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
@@ -34,16 +42,34 @@ matrix:
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes
     bundler_args:
     script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes
+    bundler_args:
+    script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
@@ -52,10 +78,22 @@ matrix:
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
@@ -64,10 +102,22 @@ matrix:
     env: BEAKER_set="ubuntu-1404" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="ubuntu-1404" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
   - rvm: 2.4.4
@@ -76,16 +126,34 @@ matrix:
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
   - rvm: 2.4.4
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201703" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="amazonlinux-201703" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ end
 
 group :development, :unit_tests do
   gem 'rake',                                             '< 11.0.0'
-  gem 'rspec-puppet', '~> 2.5.0',                         :require => false
+  gem 'rspec-puppet', '~> 2.6.0',                         :require => false
   gem 'rspec-puppet-facts',                               :require => false
   gem 'rspec-mocks',                                      :require => false
   gem 'puppetlabs_spec_helper', '>= 2.7.0',               :require => false

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Plugin sync is required if the custom sensu types and providers are used.
 
 This module has a soft dependency on the [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module (`>= 5.0.1 < 6.0.0`) for systems using `apt`.
 
+If using Puppet >= 6.0.0 there is a soft dependency on the [puppetlabs/yumrepo_core](https://forge.puppet.com/puppetlabs/yumrepo_core) module (`>= 1.0.1 < 2.0.0`) for systems using `yum`.
+
 ### Beginning with sensu
 
 This module provides Vagrant definitions that can be used to get started with Sensu.

--- a/metadata.json
+++ b/metadata.json
@@ -51,7 +51,7 @@
     }
   ],
   "requirements": [
-    { "name": "puppet", "version_requirement": ">= 5.0.0 < 6.0.0" }
+    { "name": "puppet", "version_requirement": ">= 5.0.0 < 7.0.0" }
   ],
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.1 < 5.0.0" }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,6 +6,7 @@ require 'beaker/puppet_install_helper'
 run_puppet_install_helper
 install_module_dependencies
 install_module
+collection = ENV['BEAKER_PUPPET_COLLECTION'] || 'puppet5'
 
 RSpec.configure do |c|
   c.add_setting :sensu_full, default: false
@@ -20,5 +21,8 @@ RSpec.configure do |c|
   c.before :suite do
     # Install soft module dependencies
     on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 6.0.0"'), { :acceptable_exit_codes => [0,1] }
+    if collection == 'puppet6'
+      on hosts, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
+    end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support Puppet 6
Use net/http for sensu_api_validator

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #983 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support Puppet 6.  In order to support Puppet 6 the `sensu_api_validator` provider needs to use standard `net/http`.  Using the Puppet version of `net/http` would cause Puppet to try and generate SSL certs and this seems to now be broken with SSL changes in Puppet 6.  Using `net/http` simplifies the provider and doesn't change the behavior.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
