### PR TITLE
Support Puppet 6

### DIFF
--- a/.fixtures-puppet6.yml
+++ b/.fixtures-puppet6.yml
@@ -1,0 +1,19 @@
+fixtures:
+  repositories:
+    apt:
+      repo: git://github.com/puppetlabs/puppetlabs-apt.git
+      ref: 4.1.0
+    yumrepo_core:
+      repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
+      ref: 1.0.1
+    stdlib:
+      repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
+      ref: 4.24.0
+    remote_file:
+      repo: git://github.com/lwf/puppet-remote_file.git
+      ref: v1.1.3
+    powershell:
+      repo: git://github.com/puppetlabs/puppetlabs-powershell.git
+      ref: 2.1.0
+  symlinks:
+    sensu: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,46 +24,90 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
-  - rvm: 2.4.2
+  - rvm: 2.5.1
+    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-puppet6.yml"
+  - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="centos-6"
+    env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.5.1
     sudo: required
     services: docker
-    env: BEAKER_set="centos-7"
+    env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="debian-8"
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.5.1
     sudo: required
     services: docker
-    env: BEAKER_set="debian-9"
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="ubuntu-1404"
+    env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.5.1
     sudo: required
     services: docker
-    env: BEAKER_set="ubuntu-1604"
+    env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.2
+  - rvm: 2.4.4
     sudo: required
     services: docker
-    env: BEAKER_set="amazonlinux-201703"
+    env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.4.4
+    sudo: required
+    services: docker
+    env: BEAKER_set="ubuntu-1404" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="ubuntu-1404" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.4.4
+    sudo: required
+    services: docker
+    env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.4.4
+    sudo: required
+    services: docker
+    env: BEAKER_set="amazonlinux-201703" BEAKER_PUPPET_COLLECTION=puppet5
+    bundler_args:
+    script: bundle exec rake beaker
+  - rvm: 2.5.1
+    sudo: required
+    services: docker
+    env: BEAKER_set="amazonlinux-201703" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,6 @@ script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec 
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.1.9
-    env: PUPPET_GEM_VERSION="~> 4"
   - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
   - rvm: 2.5.1

--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ end
 
 group :development, :unit_tests do
   gem 'rake',                                             '< 11.0.0'
-  gem 'rspec-puppet', '~> 2.5.0',                         :require => false
+  gem 'rspec-puppet', '~> 2.6.0',                         :require => false
   gem 'rspec-mocks',                                      :require => false
   gem 'puppetlabs_spec_helper', '>= 2.7.0',               :require => false
   gem 'puppet-lint', "~> 2.0",                            :require => false

--- a/README.md
+++ b/README.md
@@ -57,11 +57,14 @@ See `metadata.json` for details.
 Soft dependencies if you use the corresponding technologies.
 
 - [puppetlabs/apt](https://github.com/puppetlabs/puppetlabs-apt)
+- [puppetlabs/yumrepo_core](https://github.com/puppetlabs/puppetlabs-yumrepo_core)
 - [puppetlabs/powershell](https://github.com/puppetlabs/puppetlabs-powershell)
 - [voxpupuli/rabbitmq](https://github.com/voxpupuli/puppet-rabbitmq)
 
 Note: While this module works with other versions of puppetlabs/apt, we
 test against and support what is listed in the `.fixtures.yml` file.
+
+Note: `puppetlabs/yumrepo_core` is only needed for Puppet `>= 6.0.0` for systems that use `yum`.
 
 Pluginsync should be enabled. Also, you will need the Ruby JSON library
 or gem on all your nodes.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -591,7 +591,8 @@ class sensu (
     $api_service = undef
   }
 
-  $check_notify = delete_undef_values([ $client_service, $server_service_class, $api_service, $enterprise_service ])
+  $_check_notify = [ $client_service, $server_service_class, $api_service, $enterprise_service ]
+  $check_notify = $_check_notify.filter |$val| { $val =~ NotUndef }
 
   # Because you can't reassign a variable in puppet and we need to set to
   # false if you specify a directory, we have to use another variable.

--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.0.0 < 6.0.0"
+      "version_requirement": ">=4.0.0 < 7.0.0"
     }
   ],
   "dependencies": [

--- a/metadata.json
+++ b/metadata.json
@@ -63,7 +63,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">=4.0.0 < 7.0.0"
+      "version_requirement": ">=5.0.0 < 7.0.0"
     }
   ],
   "dependencies": [

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,14 +1,11 @@
 require 'beaker-rspec'
-# Helper does not yet support Puppet 5
-#require 'beaker/puppet_install_helper'
+require 'beaker/puppet_install_helper'
 require 'beaker/module_install_helper'
 
-# Helper does not yet support Puppet 5
-#install_puppetlabs_release_repo_on(hosts, 'puppet5')
-install_puppet_agent_on(hosts, :puppet_collection => 'puppet5', :puppet_agent_version => ENV['PUPPET_INSTALL_VERSION'])
-#run_puppet_install_helper
-install_module_on(hosts)
-install_module_dependencies_on(hosts)
+run_puppet_install_helper
+install_module_dependencies
+install_module
+collection = ENV['BEAKER_PUPPET_COLLECTION'] || 'puppet5'
 
 UNSUPPORTED_PLATFORMS = ['Suse','AIX','Solaris']
 
@@ -28,6 +25,9 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'fsalum-redis'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-apt'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-powershell'), { :acceptable_exit_codes => [0,1] }
+      if collection == 'puppet6'
+        on hosts, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
+      end
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for Puppet 6.

Use `filter` function for `check_notify` because unit tests would fail as it seems `delete_undef_values` was returning `[nil,nil,nil,nil]` and not actually filtering `Undef`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #983 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Add support for Puppet 6.  Updated logic in acceptance tests setup to be simpler and more like sensu2 so that easy to use different Puppet collection in tests based on environment variables.
