### PR TITLE
Update to beta and add runtime_assets to sensu_handler and sensu_mutator

### DIFF
--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -73,6 +73,11 @@ DESC
     defaultto 'default'
   end
 
+  newproperty(:runtime_assets, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
+    desc "An array of Sensu assets (names), required at runtime for the execution of the command"
+    newvalues(/.*/, :absent)
+  end
+
   newproperty(:socket_host) do
     desc "The socket host address (IP or hostname) to connect to."
   end

--- a/lib/puppet/type/sensu_mutator.rb
+++ b/lib/puppet/type/sensu_mutator.rb
@@ -36,6 +36,11 @@ DESC
     newvalues(/^[0-9]+$/, :absent)
   end
 
+  newproperty(:runtime_assets, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
+    desc "An array of Sensu assets (names), required at runtime for the execution of the command"
+    newvalues(/.*/, :absent)
+  end
+
   newproperty(:env_vars, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
     desc "An array of environment variables to use with command execution."
     newvalues(/.*/, :absent)

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -12,32 +12,32 @@ class sensu::repo {
       } else {
         $repo_release = $facts['os']['release']['major']
       }
-      # TODO: change from nightly to stable once there are stable releases
+      # TODO: change from beta to stable once there are stable releases
       yumrepo { 'sensu':
         descr           => 'sensu',
-        baseurl         => "https://packagecloud.io/sensu/nightly/el/${repo_release}/\$basearch",
+        baseurl         => "https://packagecloud.io/sensu/beta/el/${repo_release}/\$basearch",
         repo_gpgcheck   => 1,
         gpgcheck        => 0,
         enabled         => 1,
-        gpgkey          => 'https://packagecloud.io/sensu/nightly/gpgkey',
+        gpgkey          => 'https://packagecloud.io/sensu/beta/gpgkey',
         sslverify       => 1,
         sslcacert       => '/etc/pki/tls/certs/ca-bundle.crt',
         metadata_expire => 300,
       }
     }
     'Debian': {
-      #TODO: change from nightly to stable once there are stable releases
+      #TODO: change from beta to stable once there are stable releases
       apt::source { 'sensu':
         ensure   => 'present',
-        location => "https://packagecloud.io/sensu/nightly/${downcase($facts['os']['name'])}/",
+        location => "https://packagecloud.io/sensu/beta/${downcase($facts['os']['name'])}/",
         repos    => 'main',
         release  => $facts['os']['distro']['codename'],
         include  => {
           'src' => true,
         },
         key      => {
-          'id'     => 'EB17E7F42AD4720A6679044309F9A5D85A56B390',
-          'source' => 'https://packagecloud.io/sensu/nightly/gpgkey',
+          'id'     => '0B3B86AFEF2D99B085BEDC6A4263180AAE8AAE03',
+          'source' => 'https://packagecloud.io/sensu/beta/gpgkey',
         },
       }
     }

--- a/spec/acceptance/sensu_handler_spec.rb
+++ b/spec/acceptance/sensu_handler_spec.rb
@@ -7,10 +7,11 @@ describe 'sensu_handler', if: RSpec.configuration.sensu_full do
       pp = <<-EOS
       include ::sensu::backend
       sensu_handler { 'test':
-        type          => 'pipe',
-        command       => 'notify.rb',
-        socket_host   => '127.0.0.1',
-        socket_port   => 1234,
+        type           => 'pipe',
+        command        => 'notify.rb',
+        socket_host    => '127.0.0.1',
+        socket_port    => 1234,
+        runtime_assets => ['test'],
       }
       EOS
 
@@ -24,6 +25,7 @@ describe 'sensu_handler', if: RSpec.configuration.sensu_full do
         data = JSON.parse(stdout)
         expect(data['command']).to eq('notify.rb')
         expect(data['socket']).to eq({'host' => '127.0.0.1', 'port' => 1234})
+        expect(data['runtime_assets']).to eq(['test'])
       end
     end
   end
@@ -33,11 +35,12 @@ describe 'sensu_handler', if: RSpec.configuration.sensu_full do
       pp = <<-EOS
       include ::sensu::backend
       sensu_handler { 'test':
-        type          => 'pipe',
-        command       => 'notify.rb',
-        filters       => ['production'],
-        socket_host   => 'localhost',
-        socket_port   => 5678,
+        type           => 'pipe',
+        command        => 'notify.rb',
+        filters        => ['production'],
+        socket_host    => 'localhost',
+        socket_port    => 5678,
+        runtime_assets => ['test2'],
       }
       EOS
 
@@ -51,6 +54,7 @@ describe 'sensu_handler', if: RSpec.configuration.sensu_full do
         data = JSON.parse(stdout)
         expect(data['filters']).to eq(['production'])
         expect(data['socket']).to eq({'host' => 'localhost', 'port' => 5678})
+        expect(data['runtime_assets']).to eq(['test2'])
       end
     end
   end

--- a/spec/acceptance/sensu_mutator_spec.rb
+++ b/spec/acceptance/sensu_mutator_spec.rb
@@ -7,7 +7,8 @@ describe 'sensu_mutator', if: RSpec.configuration.sensu_full do
       pp = <<-EOS
       include ::sensu::backend
       sensu_mutator { 'test':
-        command => 'test',
+        command        => 'test',
+        runtime_assets => ['test'],
       }
       EOS
 
@@ -20,6 +21,7 @@ describe 'sensu_mutator', if: RSpec.configuration.sensu_full do
       on node, 'sensuctl mutator info test --format json' do
         data = JSON.parse(stdout)
         expect(data['command']).to eq('test')
+        expect(data['runtime_assets']).to eq(['test'])
       end
     end
   end
@@ -29,8 +31,9 @@ describe 'sensu_mutator', if: RSpec.configuration.sensu_full do
       pp = <<-EOS
       include ::sensu::backend
       sensu_mutator { 'test':
-        command => 'test',
-        timeout => 60,
+        command        => 'test',
+        timeout        => 60,
+        runtime_assets => ['test2'],
       }
       EOS
 
@@ -43,6 +46,7 @@ describe 'sensu_mutator', if: RSpec.configuration.sensu_full do
       on node, 'sensuctl mutator info test --format json' do
         data = JSON.parse(stdout)
         expect(data['timeout']).to eq(60)
+        expect(data['runtime_assets']).to eq(['test2'])
       end
     end
   end

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -6,9 +6,9 @@ describe 'sensu::repo', :type => :class do
       let(:facts) { facts }
       case os
       when /(redhat-6|centos-6|amazon-2017|amazon-2018)-x86_64/
-        baseurl = "https://packagecloud.io/sensu/nightly/el/6/$basearch"
+        baseurl = "https://packagecloud.io/sensu/beta/el/6/$basearch"
       when /(redhat-7|centos-7|amazonlinux-2)-x86_64/
-        baseurl = "https://packagecloud.io/sensu/nightly/el/7/$basearch"
+        baseurl = "https://packagecloud.io/sensu/beta/el/7/$basearch"
       else
         baseurl = nil
       end
@@ -20,7 +20,7 @@ describe 'sensu::repo', :type => :class do
             'repo_gpgcheck'   => 1,
             'gpgcheck'        => 0,
             'enabled'         => 1,
-            'gpgkey'          => 'https://packagecloud.io/sensu/nightly/gpgkey',
+            'gpgkey'          => 'https://packagecloud.io/sensu/beta/gpgkey',
             'sslverify'       => 1,
             'sslcacert'       => '/etc/pki/tls/certs/ca-bundle.crt',
             'metadata_expire' => 300,
@@ -30,13 +30,13 @@ describe 'sensu::repo', :type => :class do
         it {
           should contain_apt__source('sensu').with({
             'ensure' => 'present',
-            'location' => "https://packagecloud.io/sensu/nightly/#{facts[:os]['name'].downcase}/",
+            'location' => "https://packagecloud.io/sensu/beta/#{facts[:os]['name'].downcase}/",
             'repos'    => 'main',
             'release'  => facts[:os]['distro']['codename'],
             'include'  => { 'src' => 'true' },
             'key'      => {
-              'id'     => 'EB17E7F42AD4720A6679044309F9A5D85A56B390',
-              'source' => 'https://packagecloud.io/sensu/nightly/gpgkey',
+              'id'     => '0B3B86AFEF2D99B085BEDC6A4263180AAE8AAE03',
+              'source' => 'https://packagecloud.io/sensu/beta/gpgkey',
             },
           })
         }

--- a/spec/unit/sensu_handler_spec.rb
+++ b/spec/unit/sensu_handler_spec.rb
@@ -81,6 +81,7 @@ describe Puppet::Type.type(:sensu_handler) do
     :filters,
     :env_vars,
     :handlers,
+    :runtime_assets,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = ['foo', 'bar']

--- a/spec/unit/sensu_mutator_spec.rb
+++ b/spec/unit/sensu_mutator_spec.rb
@@ -62,7 +62,8 @@ describe Puppet::Type.type(:sensu_mutator) do
 
   # Array properties
   [
-    :env_vars
+    :env_vars,
+    :runtime_assets,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = ['foo', 'bar']


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update repos to beta.
Add `runtime_assets` to `sensu_mutator` and `sensu_handler`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Latest RPMs are now going to beta repo and runtime_assets change only exists in beta.  Update sensu_handler and sensu_mutator to match upstream changes.