### PR TITLE
Remove sensu::backend username and password parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,12 +84,10 @@ vagrant provision sensu-backend-peer1 sensu-backend-peer2
 
 ### Basic Sensu backend
 
-The following example will configure sensu-backend and add a check.  It's advisable to not rely on the default password.
+The following example will configure sensu-backend and add a check.
 
 ```puppet
-  class { 'sensu::backend':
-    password => 'P@ssw0rd!',
-  }
+  include sensu::backend
   sensu_check { 'check-cpu':
     ensure        => 'present',
     command       => 'check-cpu.sh -w 75 -c 90',
@@ -221,6 +219,17 @@ The Sensu v2 support is designed so that all resources managed by `sensuctl` are
 This module does not support adding `sensuctl` resources on a host other than the `sensu-backend` host.
 
 The type `sensu_asset` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#988](https://github.com/sensu/sensu-go/issues/988).
+
+The sensuctl username and password can not be configured by this module due to limitations with sensuctl.
+This module uses the default username `admin` and default password `P@ssw0rd!`.
+The checklist at [sensu-puppet#901](https://github.com/sensu/sensu-puppet/issues/901) will be updated as progress is made.
+
+To change the `admin` password used by sensuctl the following steps can be taken:
+```
+sensuctl user change-password admin --current-password 'P@ssw0rd!' --new-password 'changeme'
+sensuctl configure -n --username admin --password 'changeme'
+```
+
 
 ### Notes regarding support
 

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -26,10 +26,6 @@
 #   Sensu backend host used to configure sensuctl and verify API access.
 # @param url_port
 #   Sensu backend port used to configure sensuctl and verify API access.
-# @param username
-#   Sensu backend admin username used to confiure sensuctl.
-# @param password
-#   Sensu backend admin password used to confiure sensuctl.
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -41,8 +37,6 @@ class sensu::backend (
   Hash $config_hash = {},
   String $url_host = '127.0.0.1',
   Stdlib::Port $url_port = 8080,
-  String $username = 'admin',
-  String $password = 'P@ssw0rd!',
 ) {
 
   include ::sensu
@@ -71,7 +65,7 @@ class sensu::backend (
   # Ensure sensu-backend is up before starting sensu-agent
   Sensu_api_validator['sensu'] -> Service['sensu-agent']
 
-  $sensuctl_configure = "sensuctl configure -n --url '${url}' --username '${username}' --password '${password}'"
+  $sensuctl_configure = "sensuctl configure -n --url '${url}' --username 'admin' --password 'P@ssw0rd!'"
   $sensuctl_configure_creates = '/root/.config/sensu/sensuctl/cluster'
   exec { 'sensuctl_configure':
     command => "${sensuctl_configure} || rm -f ${sensuctl_configure_creates}",


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove `username` and `password` parameters from `sensu::backend`.  Document limitation.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Changing either of these parameters would break the bootstrap of sensuctl.  These options will be added back once upstream supports better management of users which will allow this module to properly manage user resources.
