### PR TITLE
Support stdlib 5.x

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -2,18 +2,19 @@ fixtures:
   repositories:
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
-      ref: 4.1.0
+      ref: 6.1.1
     yumrepo_core:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1
+      puppet_version: ">= 6.0.0"
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.24.0
+      ref: 5.1.0
     remote_file:
       repo: git://github.com/lwf/puppet-remote_file.git
       ref: v1.1.3
     powershell:
       repo: git://github.com/puppetlabs/puppetlabs-powershell.git
-      ref: 2.1.0
+      ref: 2.1.5
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,6 +3,10 @@ fixtures:
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
       ref: 4.1.0
+    yumrepo_core:
+      repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
+      ref: 1.0.1
+      puppet_version: ">= 6.0.0"
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
       ref: 4.24.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ matrix:
   include:
   - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
+  - rvm: 2.4.4
+    env: PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.1
-    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-puppet6.yml"
+    env: PUPPET_GEM_VERSION="~> 6"
+  - rvm: 2.5.1
+    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.4.4
     sudo: required
     services: docker

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ group :development, :unit_tests do
   gem 'rake',                                             '< 11.0.0'
   gem 'rspec-puppet', '~> 2.6.0',                         :require => false
   gem 'rspec-mocks',                                      :require => false
-  gem 'puppetlabs_spec_helper', '>= 2.7.0',               :require => false
+  gem 'puppetlabs_spec_helper', '>= 2.11.0',               :require => false
   gem 'puppet-lint', "~> 2.0",                            :require => false
   gem 'json', "~> 1.8.3",                                 :require => false
   gem 'json_pure', "~> 1.8.3",                            :require => false

--- a/metadata.json
+++ b/metadata.json
@@ -75,7 +75,7 @@
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=4.24.0 <5.0.0"
+      "version_requirement": ">=4.24.0 <6.0.0"
     }
   ]
 }

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -119,7 +119,8 @@ describe 'sensu' do
             :os              => {
               :name    => 'ubuntu',
               :release => {
-                :full => '14.04'
+                :full  => '14.04',
+                :major => '14',
               },
               :distro => {
                 :codename => 'trusty',
@@ -204,7 +205,8 @@ describe 'sensu' do
               :os => {
                 :name    => 'Debian',
                 :release => {
-                  :full => '8.6',
+                  :full  => '8.6',
+                  :major => '8',
                 },
                 :distro => {
                   :codename => 'jessie',
@@ -236,7 +238,8 @@ describe 'sensu' do
               :os => {
                 :name    => 'Debian',
                 :release => {
-                  :full => '9.3',
+                  :full  => '9.3',
+                  :major => '9',
                 },
                 :distro => {
                   :codename => 'stretch',
@@ -268,7 +271,8 @@ describe 'sensu' do
               :os => {
                 :name    => 'Debian',
                 :release => {
-                  :full => '9.3',
+                  :full  => '9.3',
+                  :major => '9',
                 },
                 :distro => {
                   :codename => 'wheezy',


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support stdlib 5.x
Move puppet6 specific fixtures into main fixtures


## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #989 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support new versions of modules and no need to have puppet 6 specific fixtures file by using latest puppetlabs_spec_helper.