### PR TITLE
support stdlib 5.x (sensu2)

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -2,12 +2,13 @@ fixtures:
   repositories:
     apt:
       repo: git://github.com/puppetlabs/puppetlabs-apt.git
-      ref: 5.0.1
+      ref: 6.1.1
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.25.1
+      ref: 5.1.0
     yumrepo_core:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1
+      puppet_version: ">= 6.0.0"
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -6,5 +6,9 @@ fixtures:
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
       ref: 4.25.1
+    yumrepo_core:
+      repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
+      ref: 1.0.1
+      puppet_version: ">= 6.0.0"
   symlinks:
     sensu: "#{source_dir}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,12 @@ matrix:
   include:
   - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5"
+  - rvm: 2.4.4
+    env: PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.1
-    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-puppet6.yml"
+    env: PUPPET_GEM_VERSION="~> 6"
+  - rvm: 2.5.1
+    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.4.4
     sudo: required
     services: docker

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ group :development, :unit_tests do
   gem 'rspec-puppet', '~> 2.6.0',                         :require => false
   gem 'rspec-puppet-facts',                               :require => false
   gem 'rspec-mocks',                                      :require => false
-  gem 'puppetlabs_spec_helper', '>= 2.7.0',               :require => false
+  gem 'puppetlabs_spec_helper', '>= 2.11.0',               :require => false
   gem 'puppet-lint', "~> 2.0",                            :require => false
   gem 'json', "~> 1.8.3",                                 :require => false
   gem 'json_pure', "~> 1.8.3",                            :require => false

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ This module will install packages, create configuration and start services neces
 
 Plugin sync is required if the custom sensu types and providers are used.
 
-This module has a soft dependency on the [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module (`>= 5.0.1 < 6.0.0`) for systems using `apt`.
+This module has a soft dependency on the [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module (`>= 5.0.1 < 7.0.0`) for systems using `apt`.
 
 If using Puppet >= 6.0.0 there is a soft dependency on the [puppetlabs/yumrepo_core](https://forge.puppet.com/puppetlabs/yumrepo_core) module (`>= 1.0.1 < 2.0.0`) for systems using `yum`.
 

--- a/metadata.json
+++ b/metadata.json
@@ -53,6 +53,6 @@
     { "name": "puppet", "version_requirement": ">= 5.0.0 < 7.0.0" }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.1 < 5.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.1 < 6.0.0" }
   ]
 }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -20,7 +20,7 @@ RSpec.configure do |c|
   # Configure all nodes in nodeset
   c.before :suite do
     # Install soft module dependencies
-    on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 6.0.0"'), { :acceptable_exit_codes => [0,1] }
+    on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 7.0.0"'), { :acceptable_exit_codes => [0,1] }
     if collection == 'puppet6'
       on hosts, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
     end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support stdlib 5.x
Support apt 6.x
Move puppet6 fixtures into main fixtures file


## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #989 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support latest versions of both hard and soft dependencies and no need to have puppet 6 specific fixtures file with latest puppetlabs_spec_helper.