### PR TITLE
Add sensu_user type

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,13 @@ vagrant provision sensu-backend-peer1 sensu-backend-peer2
 
 The following example will configure sensu-backend, sensu-agent on backend and add a check.
 By default this module will configure the backend to use Puppet's SSL certificate and CA.
+It's advisable to not rely on the default password. Changing the password requires providing the previous password via `old_password`.
 
 ```puppet
-  include sensu::backend
+  class { 'sensu::backend':
+    password     => 'supersecret',
+    old_password => 'P@ssw0rd!',
+  }
   include sensu::agent
   sensu_check { 'check-cpu':
     ensure        => 'present',
@@ -319,18 +323,6 @@ The Sensu v2 support is designed so that all resources managed by `sensuctl` are
 This module does not support adding `sensuctl` resources on a host other than the `sensu-backend` host.
 
 The type `sensu_asset` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#988](https://github.com/sensu/sensu-go/issues/988).
-
-The sensuctl username and password can not be configured by this module due to limitations with sensuctl.
-This module uses the default username `admin` and default password `P@ssw0rd!`.
-The checklist at [sensu-puppet#901](https://github.com/sensu/sensu-puppet/issues/901) will be updated as progress is made.
-
-To change the `admin` password used by sensuctl the following steps can be taken:
-```
-sensuctl user change-password admin --current-password 'P@ssw0rd!' --new-password 'changeme'
-sensuctl configure -n --username admin --password 'changeme'
-```
-Update the `sensu::backend::password` parameter to the new value in case `sensuctl configure` has to be run via `sensu_configure` type.
-
 
 ### Notes regarding support
 

--- a/README.md
+++ b/README.md
@@ -324,6 +324,8 @@ This module does not support adding `sensuctl` resources on a host other than th
 
 The type `sensu_asset` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#988](https://github.com/sensu/sensu-go/issues/988).
 
+The type `sensu_user` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#2540](https://github.com/sensu/sensu-go/issues/2540).
+
 ### Notes regarding support
 
 This module is built for use with Puppet versions 5 and 6 and the ruby

--- a/lib/puppet/provider/sensu_configure/sensuctl.rb
+++ b/lib/puppet/provider/sensu_configure/sensuctl.rb
@@ -3,21 +3,8 @@ require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sensuctl'))
 Puppet::Type.type(:sensu_configure).provide(:sensuctl, :parent => Puppet::Provider::Sensuctl) do
   desc "Provider sensu_configure using sensuctl"
 
-  def config_path
-    home = File.expand_path('~')
-    File.join(home, '.config/sensu/sensuctl/cluster')
-  end
-
   def exists?
     File.file?(config_path)
-  end
-
-  def load_config(path)
-    return {} unless File.file?(path)
-    file = File.read(path)
-    @config = JSON.parse(file)
-    Puppet.debug("CONFIG: #{@config}")
-    @config
   end
 
   def initialize(value = {})
@@ -26,8 +13,8 @@ Puppet::Type.type(:sensu_configure).provide(:sensuctl, :parent => Puppet::Provid
   end
 
   def url
-    @config = load_config(config_path)
-    @config['api-url']
+    config = load_config(config_path)
+    config['api-url']
   end
 
   def url=(value)

--- a/lib/puppet/provider/sensu_user/sensuctl.rb
+++ b/lib/puppet/provider/sensu_user/sensuctl.rb
@@ -1,0 +1,164 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sensuctl'))
+
+Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::Sensuctl) do
+  desc "Provider sensu_user using sensuctl"
+
+  mk_resource_methods
+
+  def self.instances
+    users = []
+
+    output = sensuctl_list('user')
+    Puppet.debug("sensu users: #{output}")
+    begin
+      data = JSON.parse(output)
+    rescue JSON::ParserError => e
+      Puppet.debug('Unable to parse output from sensuctl user list')
+      data = []
+    end
+
+    data.each do |d|
+      user = {}
+      user[:ensure] = :present
+      user[:name] = d['username']
+      d.each_pair do |key, value|
+        next if key == 'name'
+        if !!value == value
+          value = value.to_s.to_sym
+        end
+        if type_properties.include?(key.to_sym)
+          user[key.to_sym] = value
+        end
+      end
+      users << new(user)
+    end
+    users
+  end
+
+  def self.prefetch(resources)
+    users = instances
+    resources.keys.each do |name|
+      if provider = users.find { |c| c.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def password_insync?(user, password)
+    if password.is_a?(Array)
+      password = password[0]
+    end
+    # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
+    #ret = execute(['sensuctl', 'user', 'test-creds', user, '--password', password], failonfail: false)
+    #exitstatus = ret.exitstatus
+    #exitstatus == 0
+    config = load_config(config_path)
+    api_url = config['api-url']
+    if api_url =~ /^https/
+      use_ssl = true
+    else
+      use_ssl = false
+    end
+    uri = URI(api_url)
+    http = Net::HTTP.new(uri.hostname, uri.port)
+    if Puppet[:debug]
+      http.set_debug_output($stdout)
+    end
+    http.use_ssl = use_ssl
+    if use_ssl
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+    request = Net::HTTP::Get.new('/auth')
+    request.add_field("Accept", "application/json")
+    request.basic_auth(user, password)
+    response = http.request(request)
+    Puppet.debug("GET /auth returned #{response.code}")
+    response.kind_of?(Net::HTTPSuccess)
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  type_properties.each do |prop|
+    define_method "#{prop}=".to_sym do |value|
+      @property_flush[prop] = value
+    end
+  end
+
+  def create
+    cmd = ['user', 'create']
+    cmd << resource[:name]
+    cmd << '--password'
+    cmd << resource[:password]
+    if resource[:groups]
+      cmd << '--groups'
+      cmd << resource[:groups].join(',')
+    end
+    begin
+      sensuctl(cmd)
+    rescue Exception => e
+      raise Puppet::Error, "sensuctl user create #{resource[:name]} failed\nError message: #{e.message}"
+    end
+    if ! resource[:disabled].nil? && resource[:disabled].to_s == 'true'
+      sensuctl('user', 'disable', resource[:name], '--skip-confirm')
+    end
+    if resource[:configure] == :true
+      sensuctl('configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', resource[:password])
+    end
+    @property_hash[:ensure] = :present
+  end
+
+  def flush
+    if !@property_flush.empty?
+      if @property_flush[:password]
+        if ! resource[:old_password]
+          fail("old_password is manditory when changing a password")
+        end
+        sensuctl('user', 'change-password', resource[:name], '--current-password', resource[:old_password], '--new-password', @property_flush[:password])
+        if resource[:configure] == :true
+          sensuctl('configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password])
+        end
+      end
+      if @property_flush[:groups]
+        current_groups = @property_hash[:groups] || []
+        # Add groups not currently set
+        @property_flush[:groups].each do |group|
+          if ! current_groups.include?(group)
+            sensuctl('user', 'add-group', resource[:name], group)
+          end
+        end
+        # Remove current groups not set by Puppet
+        current_groups.each do |group|
+          if ! @property_flush[:groups].include?(group)
+            sensuctl('user', 'remove-group', resource[:name], group)
+          end
+        end
+      end
+      if ! @property_flush[:disabled].nil?
+        if @property_flush[:disabled].to_s == 'true'
+          sensuctl('user', 'disable', resource[:name], '--skip-confirm')
+        end
+        if @property_flush[:disabled].to_s == 'false'
+          sensuctl('user', 'reinstate', resource[:name])
+        end
+      end
+    end
+    @property_hash = resource.to_hash
+  end
+
+  def destroy
+    begin
+      sensuctl_delete('user', resource[:name])
+    rescue Exception => e
+      raise Puppet::Error, "sensuctl delete user #{name} failed\nError message: #{e.message}"
+    end
+    @property_hash.clear
+  end
+end
+

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -6,6 +6,19 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
 
   commands :sensuctl => 'sensuctl'
 
+  def config_path
+    home = File.expand_path('~')
+    File.join(home, '.config/sensu/sensuctl/cluster')
+  end
+
+  def load_config(path)
+    return {} unless File.file?(path)
+    file = File.read(path)
+    config = JSON.parse(file)
+    Puppet.debug("CONFIG: #{config}")
+    config
+  end
+
   def self.type_properties
     resource_type.validproperties.reject { |p| p.to_sym == :ensure }
   end

--- a/lib/puppet/type/sensu_role_binding.rb
+++ b/lib/puppet/type/sensu_role_binding.rb
@@ -23,6 +23,7 @@ Puppet::Type.newtype(:sensu_role_binding) do
 * `Sensu_api_validator[sensu]`
 * `sensu_role` - Puppet will autorequire `sensu_role` resource defined in `role_ref` property.
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
+* `sensu_user` - Puppet will autorequire `sensu_user` resources based on users and groups defined for the `subjects` property.
 DESC
 
   extend PuppetX::Sensu::Type
@@ -70,15 +71,30 @@ DESC
   end
 
   autorequire(:sensu_role) do
-    requires = []
+    [ self[:role_ref] ]
+  end
+
+  autorequire(:sensu_user) do
+    users = []
+    groups = []
+    (self[:subjects] || []).each do |subject|
+      if subject['type'] == 'User'
+        users << subject['name']
+      end
+      if subject['type'] == 'Group'
+        groups << subject['name']
+      end
+    end
     catalog.resources.each do |resource|
-      if resource.class.to_s == 'Puppet::Type::Sensu_role'
-        if self[:role_ref] == resource.name
-          requires << resource.name
+      if resource.class.to_s == 'Puppet::Type::Sensu_user'
+        (resource[:groups] || []).each do |group|
+          if groups.include?(group)
+            users << resource.name
+          end
         end
       end
     end
-    requires
+    users
   end
 
   validate do

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -1,0 +1,103 @@
+require_relative '../../puppet_x/sensu/type'
+require_relative '../../puppet_x/sensu/array_property'
+require_relative '../../puppet_x/sensu/hash_property'
+require_relative '../../puppet_x/sensu/integer_property'
+
+Puppet::Type.newtype(:sensu_user) do
+  desc <<-DESC
+@summary Manages Sensu users
+@example Create a user
+  sensu_user { 'test':
+    ensure   => 'present',
+    password => 'supersecret',
+    groups   => ['users'],
+  }
+
+@example Change a user's password
+  sensu_user { 'test'
+    ensure       => 'present',
+    password     => 'newpassword',
+    old_password => 'supersecret',
+    groups       => ['users'],
+  }
+
+**Autorequires**:
+* `Package[sensu-cli]`
+* `Service[sensu-backend]`
+* `Sensu_configure[puppet]`
+* `Sensu_api_validator[sensu]`
+DESC
+
+  extend PuppetX::Sensu::Type
+  add_autorequires(false)
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the user."
+    validate do |value|
+      unless value =~ /^[\w\.\-]+$/
+        raise ArgumentError, "sensu_user name invalid"
+      end
+    end
+  end
+
+  newproperty(:password) do
+    desc "The user's password."
+
+    def insync?(is)
+      if @resource.provider
+        if @resource[:disabled].to_sym == :true
+          return true
+        end
+        @resource.provider.password_insync?(@resource[:name], @should)
+      end
+    end
+
+    def change_to_s(currentvalue, newvalue)
+      return "changed password"
+    end
+    def is_to_s(currentvalue)
+      return '[old password redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new password redacted]'
+    end
+  end
+
+  newparam(:old_password) do
+    desc "The user's old password, needed in order to change a user's password"
+  end
+
+  newproperty(:groups, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
+    desc "Groups to which the user belongs."
+  end
+
+  newproperty(:disabled, :boolean => true) do
+    desc "The state of the user’s account."
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newparam(:configure, :boolean => true) do
+    desc "Run sensuctl configure for this user"
+    newvalues(:true, :false)
+    defaultto :false
+  end
+
+  newparam(:configure_url) do
+    desc "URL to use with 'sensuctl configure'"
+    defaultto 'http://127.0.0.1:8080'
+  end
+
+  validate do
+    required_properties = [
+      :password
+    ]
+    required_properties.each do |property|
+      if self[:ensure] == :present && self[property].nil?
+        fail "You must provide a #{property}"
+      end
+    end
+  end
+end

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -31,7 +31,15 @@ DESC
   extend PuppetX::Sensu::Type
   add_autorequires(false)
 
-  ensurable
+  ensurable do
+    desc "The basic property that the resource should be in."
+    defaultvalues
+    validate do |value|
+      if value.to_sym == :absent
+        raise ArgumentError, "sensu_user ensure does not support absent"
+      end
+    end
+  end
 
   newparam(:name, :namevar => true) do
     desc "The name of the user."

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -33,8 +33,9 @@
 # @param ssl_key_source
 #   The SSL private key source
 # @param password
-#   Sensu admin password. Does not change admin password but is used when
-#   running `sensuctl configure` after initial bootstrap.
+#   Sensu backend admin password used to confiure sensuctl.
+# @param old_password
+#   Sensu backend admin old password needed when changing password.
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -50,6 +51,7 @@ class sensu::backend (
   String $ssl_cert_source = $facts['puppet_hostcert'],
   String $ssl_key_source = $facts['puppet_hostprivkey'],
   String $password = 'P@ssw0rd!',
+  Optional[String] $old_password = undef,
 ) {
 
   include ::sensu
@@ -99,6 +101,15 @@ class sensu::backend (
     username           => 'admin',
     password           => $password,
     bootstrap_password => 'P@ssw0rd!',
+  }
+  sensu_user { 'admin':
+    ensure        => 'present',
+    password      => $password,
+    old_password  => $old_password,
+    groups        => ['cluster-admins'],
+    disabled      => false,
+    configure     => true,
+    configure_url => $url,
   }
 
   if $use_ssl {

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -6,7 +6,10 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu': }
-      class { '::sensu::backend': }
+      class { '::sensu::backend':
+        password     => 'supersecret',
+        old_password => 'P@ssw0rd!',
+      }
       EOS
 
       # Run it twice and test for idempotency
@@ -27,7 +30,10 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu': }
-      class { '::sensu::backend': }
+      class { '::sensu::backend':
+        password     => 'supersecret',
+        old_password => 'P@ssw0rd!',
+      }
       class { '::sensu::agent':
         backends => ['sensu_backend:8081'],
       }
@@ -43,6 +49,26 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
       it { should be_running }
     end
     describe service('sensu-agent'), :node => node do
+      it { should be_enabled }
+      it { should be_running }
+    end
+  end
+
+  context 'reset admin password' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      class { '::sensu::backend':
+        password     => 'P@ssw0rd!',
+        old_password => 'supersecret',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    describe service('sensu-backend'), :node => node do
       it { should be_enabled }
       it { should be_running }
     end

--- a/spec/acceptance/02_backend_cluster_spec.rb
+++ b/spec/acceptance/02_backend_cluster_spec.rb
@@ -36,7 +36,7 @@ describe 'sensu::backend cluster class', if: RSpec.configuration.sensu_cluster d
       EOS
 
       # First run will fail to run sensuctl configure
-      apply_manifest_on(node1, node1_pp, :catch_failures => false)
+      apply_manifest_on(node1, node1_pp, :acceptable_exit_codes => [0,1])
       #on node1, 'curl http://127.0.0.1:8080/info', :accept_all_exit_codes => true
       apply_manifest_on(node2, node2_pp, :catch_failures => true)
       # first node has to have agent started back up

--- a/spec/acceptance/sensu_user_spec.rb
+++ b/spec/acceptance/sensu_user_spec.rb
@@ -109,46 +109,13 @@ describe 'sensu_user', if: RSpec.configuration.sensu_full do
   end
 
   context 'ensure => absent' do
-    it 'should remove without errors' do
+    it 'should result in error as unsupported' do
       pp = <<-EOS
       include ::sensu::backend
       sensu_user { 'test': ensure => 'absent' }
       EOS
 
-      # Run it twice and test for idempotency
-      apply_manifest_on(node, pp, :catch_failures => true)
-      apply_manifest_on(node, pp, :catch_changes  => true)
-    end
-
-    it 'should not have user removed' do
-      on node, 'sensuctl user list --format json' do
-        data = JSON.parse(stdout)
-        d = data.select { |o| o['username'] == 'test' }
-        expect(d.size).to eq(0)
-      end
-    end
-  end
-
-  context 'resources purge' do
-    it 'should remove without errors' do
-      pp = <<-EOS
-      include ::sensu::backend
-      resources { 'sensu_user':
-        purge => true,
-      }
-      EOS
-
-      # Run it twice and test for idempotency
-      apply_manifest_on(node, pp, :catch_failures => true)
-      apply_manifest_on(node, pp, :catch_changes  => true)
-    end
-
-    it 'should have 1 user' do
-      on node, 'sensuctl user list --format json' do
-        data = JSON.parse(stdout)
-        expect(data.size).to eq(1)
-      end
+      apply_manifest_on(node, pp, :expect_failures => true)
     end
   end
 end
-

--- a/spec/acceptance/sensu_user_spec.rb
+++ b/spec/acceptance/sensu_user_spec.rb
@@ -1,0 +1,154 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu_user', if: RSpec.configuration.sensu_full do
+  node = hosts_as('sensu_backend')[0]
+  context 'default' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_user { 'test':
+        password => 'password',
+        groups   => ['read-only'],
+      }
+      sensu_user { 'test2':
+        password => 'password',
+        groups   => ['read-only'],
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    it 'should have a valid user' do
+      on node, 'sensuctl user list --format json' do
+        data = JSON.parse(stdout)
+        d = data.select { |o| o['username'] == 'test' }[0]
+        expect(d['groups']).to eq(['read-only'])
+        expect(d['disabled']).to eq(false)
+      end
+    end
+
+    it 'should have valid password' do
+      # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
+      #exit_code = on(node, 'sensuctl user test-creds test --password password').exit_code
+      #expect(exit_code).to eq(0)
+      on node, 'curl -k -u test:password https://sensu_backend:8080/auth' do
+        data = JSON.parse(stdout)
+        expect(data.keys).to include('access_token')
+      end
+    end
+  end
+
+  context 'updates user' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_user { 'test':
+        password     => 'password2',
+        old_password => 'password',
+        groups       => ['read-only'],
+      }
+      sensu_user { 'test2':
+        password => 'password',
+        groups   => ['read-only','admin'],
+        disabled => true,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    it 'should have an updated user' do
+      on node, 'sensuctl user list --format json' do
+        data = JSON.parse(stdout)
+        d = data.select { |o| o['username'] == 'test2' }[0]
+        expect(d['groups']).to eq(['read-only','admin'])
+        expect(d['disabled']).to eq(true)
+      end
+    end
+    it 'should have valid password' do
+      # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
+      #exit_code = on(node, 'sensuctl user test-creds test --password password2').exit_code
+      #expect(exit_code).to eq(0)
+      on node, 'curl -k -u test:password2 https://sensu_backend:8080/auth' do
+        data = JSON.parse(stdout)
+        expect(data.keys).to include('access_token')
+      end
+    end
+  end
+
+  context 'updates user password' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_user { 'test':
+        password     => 'password3',
+        old_password => 'password2',
+        groups       => ['read-only'],
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    it 'should have valid password' do
+      # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
+      #exit_code = on(node, 'sensuctl user test-creds test --password password2').exit_code
+      #expect(exit_code).to eq(0)
+      on node, 'curl -k -u test:password3 https://sensu_backend:8080/auth' do
+        data = JSON.parse(stdout)
+        expect(data.keys).to include('access_token')
+      end
+    end
+  end
+
+  context 'ensure => absent' do
+    it 'should remove without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_user { 'test': ensure => 'absent' }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    it 'should not have user removed' do
+      on node, 'sensuctl user list --format json' do
+        data = JSON.parse(stdout)
+        d = data.select { |o| o['username'] == 'test' }
+        expect(d.size).to eq(0)
+      end
+    end
+  end
+
+  context 'resources purge' do
+    it 'should remove without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      resources { 'sensu_user':
+        purge => true,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    it 'should have 1 user' do
+      on node, 'sensuctl user list --format json' do
+        data = JSON.parse(stdout)
+        expect(data.size).to eq(1)
+      end
+    end
+  end
+end
+

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -40,6 +40,18 @@ describe 'sensu::backend', :type => :class do
         }
 
         it {
+          should contain_sensu_user('admin').with({
+            'ensure'        => 'present',
+            'password'      => 'P@ssw0rd!',
+            'old_password'  => nil,
+            'groups'        => ['cluster-admins'],
+            'disabled'      => 'false',
+            'configure'     => 'true',
+            'configure_url' => 'https://test.example.com:8080',
+          })
+        }
+
+        it {
           should contain_file('sensu_ssl_cert').with({
             'ensure'    => 'file',
             'path'      => '/etc/sensu/ssl/cert.pem',

--- a/spec/fixtures/unit/provider/sensu_user/sensuctl/user_list.json
+++ b/spec/fixtures/unit/provider/sensu_user/sensuctl/user_list.json
@@ -1,0 +1,16 @@
+[
+  {
+    "username": "admin",
+    "groups": [
+      "cluster-admins"
+    ],
+    "disabled": false
+  },
+  {
+    "username": "agent",
+    "groups": [
+      "system:agents"
+    ],
+    "disabled": false
+  }
+]

--- a/spec/unit/provider/sensu_user/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_user/sensuctl_spec.rb
@@ -1,0 +1,103 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_user).provider(:sensuctl) do
+  before(:each) do
+    @provider = described_class
+    @type = Puppet::Type.type(:sensu_user)
+    @resource = @type.new({
+      :name => 'test',
+      :password => 'P@ssw0rd!',
+      :groups => ['test'],
+    })
+  end
+
+  describe 'self.instances' do
+    it 'should create instances' do
+      allow(@provider).to receive(:sensuctl_list).with('user').and_return(my_fixture_read('user_list.json'))
+      expect(@provider.instances.length).to eq(2)
+    end
+
+    it 'should return the resource for a user' do
+      allow(@provider).to receive(:sensuctl_list).with('user').and_return(my_fixture_read('user_list.json'))
+      property_hash = @provider.instances.select {|i| i.name == 'admin'}[0].instance_variable_get("@property_hash")
+      expect(property_hash[:name]).to eq('admin')
+      expect(property_hash[:groups]).to eq(['cluster-admins'])
+    end
+  end
+
+  describe 'create' do
+    it 'should create a user' do
+      expect(@resource.provider).to receive(:sensuctl).with(['user', 'create', 'test', '--password', 'P@ssw0rd!', '--groups', 'test'])
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should create user and reconfigure sensuctl' do
+      @resource[:configure] = true
+      expect(@resource.provider).to receive(:sensuctl).with(['user', 'create', 'test', '--password', 'P@ssw0rd!', '--groups', 'test'])
+      expect(@resource.provider).to receive(:sensuctl).with('configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','P@ssw0rd!')
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+  end
+
+  describe 'flush' do
+    before(:each) do
+      hash = @resource.provider.instance_variable_get(:@property_hash)
+      hash[:groups] = ['admin']
+      @resource.provider.instance_variable_set(:@property_hash, hash)
+    end
+
+    it 'should update a user password' do
+      @resource[:old_password] = 'foo'
+      expect(@resource.provider).to receive(:sensuctl).with('user', 'change-password', 'test', '--current-password', 'foo', '--new-password', 'foobar')
+      @resource.provider.password = 'foobar'
+      @resource.provider.flush
+    end
+    it 'should update a user password and reconfigure' do
+      @resource[:configure] = true
+      @resource[:old_password] = 'foo'
+      expect(@resource.provider).to receive(:sensuctl).with('user', 'change-password', 'test', '--current-password', 'foo', '--new-password', 'foobar')
+      expect(@resource.provider).to receive(:sensuctl).with('configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','foobar')
+      @resource.provider.password = 'foobar'
+      @resource.provider.flush
+    end
+    it 'should require old_password to update a user password' do
+      @resource.provider.password = 'foobar'
+      expect { @resource.provider.flush }.to raise_error(Puppet::Error, /old_password is manditory when changing a password/)
+    end
+    it 'should add missing groups' do
+      expect(@resource.provider).to receive(:sensuctl).with('user','add-group','test','test')
+      @resource.provider.groups = ['admin','test']
+      @resource.provider.flush
+    end
+    it 'should remove groups' do
+      expect(@resource.provider).to receive(:sensuctl).with('user','remove-group','test','admin')
+      @resource.provider.groups = []
+      @resource.provider.flush
+    end
+    it 'should disable a user' do
+      @resource[:disabled] = false
+      expect(@resource.provider).to receive(:sensuctl).with('user','disable','test','--skip-confirm')
+      @resource.provider.disabled = true
+      @resource.provider.flush
+    end
+    it 'should disable a user' do
+      @resource[:disabled] = true
+      expect(@resource.provider).to receive(:sensuctl).with('user','reinstate','test')
+      @resource.provider.disabled = false
+      @resource.provider.flush
+    end
+  end
+
+  describe 'destroy' do
+    it 'should delete a user' do
+      expect(@resource.provider).to receive(:sensuctl_delete).with('user', 'test')
+      @resource.provider.destroy
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash).to eq({})
+    end
+  end
+end
+

--- a/spec/unit/sensu_cluster_role_binding_spec.rb
+++ b/spec/unit/sensu_cluster_role_binding_spec.rb
@@ -157,6 +157,28 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
     expect(rel.target.ref).to eq(binding.ref)
   end
 
+  it 'should autorequire sensu_user by user' do
+    config[:subjects] = [{'type' => 'User', 'name' => 'test'}]
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource binding
+    catalog.add_resource user
+    rel = binding.autorequire[0]
+    expect(rel.source.ref).to eq(user.ref)
+    expect(rel.target.ref).to eq(binding.ref)
+  end
+
+  it 'should autorequire sensu_user by group' do
+    config[:subjects] = [{'type' => 'Group', 'name' => 'group'}]
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource binding
+    catalog.add_resource user
+    rel = binding.autorequire[0]
+    expect(rel.source.ref).to eq(user.ref)
+    expect(rel.target.ref).to eq(binding.ref)
+  end
+
   include_examples 'autorequires', false do
     let(:res) { binding }
   end

--- a/spec/unit/sensu_role_binding_spec.rb
+++ b/spec/unit/sensu_role_binding_spec.rb
@@ -159,6 +159,28 @@ describe Puppet::Type.type(:sensu_role_binding) do
     expect(rel.target.ref).to eq(binding.ref)
   end
 
+  it 'should autorequire sensu_user by user' do
+    config[:subjects] = [{'type' => 'User', 'name' => 'test'}]
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource binding
+    catalog.add_resource user
+    rel = binding.autorequire[0]
+    expect(rel.source.ref).to eq(user.ref)
+    expect(rel.target.ref).to eq(binding.ref)
+  end
+
+  it 'should autorequire sensu_user by group' do
+    config[:subjects] = [{'type' => 'Group', 'name' => 'group'}]
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource binding
+    catalog.add_resource user
+    rel = binding.autorequire[0]
+    expect(rel.source.ref).to eq(user.ref)
+    expect(rel.target.ref).to eq(binding.ref)
+  end
+
   include_examples 'autorequires' do
     let(:res) { binding }
   end

--- a/spec/unit/sensu_user_spec.rb
+++ b/spec/unit/sensu_user_spec.rb
@@ -1,0 +1,183 @@
+require 'spec_helper'
+require 'puppet/type/sensu_user'
+
+describe Puppet::Type.type(:sensu_user) do
+  let(:default_config) do
+    {
+      name: 'test',
+      password: 'foobar',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:user) do
+    described_class.new(config)
+  end
+
+  it 'should add to catalog without raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource user
+    }.to_not raise_error
+  end
+
+  it 'should require a name' do
+    expect {
+      described_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  defaults = {
+    'disabled': :false,
+    'configure': :false,
+    'configure_url': 'http://127.0.0.1:8080',
+  }
+
+  # String properties
+  [
+    :password,
+    :old_password,
+    :configure_url
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 'foo'
+      expect(user[property]).to eq('foo')
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(user[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(user[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # String regex validated properties
+  [
+  ].each do |property|
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo bar'
+      expect { user }.to raise_error(Puppet::Error)
+    end
+  end
+
+  # Array properties
+  [
+    :groups,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = ['foo', 'bar']
+      expect(user[property]).to eq(['foo', 'bar'])
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(user[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(user[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Integer properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 30
+      expect(user[property]).to eq(30)
+    end
+    it "should accept valid #{property} as string" do
+      config[property] = '30'
+      expect(user[property]).to eq(30)
+    end
+    it "should not accept invalid value for #{property}" do
+      config[property] = 'foo'
+      expect { user }.to raise_error(Puppet::Error, /should be an Integer/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(user[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(user[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Boolean properties
+  [
+    :disabled,
+    :configure
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = true
+      expect(user[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = false
+      expect(user[property]).to eq(:false)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'true'
+      expect(user[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'false'
+      expect(user[property]).to eq(:false)
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { user }.to raise_error(Puppet::Error)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(user[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(user[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Hash properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = { 'foo': 'bar' }
+      expect(user[property]).to eq({'foo': 'bar'})
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { user }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(user[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(user[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  include_examples 'autorequires', false do
+    let(:res) { user }
+  end
+
+  [
+    :password,
+  ].each do |property|
+    it "should require property when ensure => present" do
+      config.delete(property)
+      config[:ensure] = :present
+      expect { user }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+    end
+  end
+end

--- a/spec/unit/sensu_user_spec.rb
+++ b/spec/unit/sensu_user_spec.rb
@@ -28,6 +28,11 @@ describe Puppet::Type.type(:sensu_user) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should not accept ensure => absent' do
+    config[:ensure] = 'absent'
+    expect { user[:ensure] = 'absent' }.to raise_error(Puppet::Error, /ensure does not support absent/)
+  end
+
   defaults = {
     'disabled': :false,
     'configure': :false,


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `sensu_user` type and fix support for changing sensuctl credentials.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #928 , relates to #901.  Will obsolete #1002

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This module needs a way to use something other than the default `admin` password and also add additional users.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests and some ad-hoc tests using Vagrant.
