### PR TITLE
Support custom configurations in enterprise dashboard

### DIFF
--- a/lib/puppet/type/sensu_enterprise_dashboard_config.rb
+++ b/lib/puppet/type/sensu_enterprise_dashboard_config.rb
@@ -126,6 +126,33 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_config) do
     end
   end
 
+  newproperty(:custom) do
+    desc "Custom config variables"
+    include PuppetX::Sensu::ToType
+
+    def is_to_s(hash = @is)
+      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
+    end
+
+    def should_to_s(hash = @should)
+      hash.keys.sort.map {|key| "#{key} => #{hash[key]}"}.join(", ")
+    end
+
+    def insync?(is)
+      if defined? @should[0]
+        if is == @should[0].each { |k, v| value[k] = to_type(v) }
+          true
+        else
+          false
+        end
+      else
+        true
+      end
+    end
+
+    defaultto {}
+  end
+
   autorequire(:package) do
     ['sensu-enterprise-dashboard']
   end

--- a/manifests/enterprise/dashboard.pp
+++ b/manifests/enterprise/dashboard.pp
@@ -68,6 +68,7 @@ class sensu::enterprise::dashboard (
       gitlab    => $::sensu::enterprise_dashboard_gitlab,
       ldap      => $::sensu::enterprise_dashboard_ldap,
       oidc      => $::sensu::enterprise_dashboard_oidc,
+      custom    => $::sensu::enterprise_dashboard_custom,
       notify    => $file_notify,
     }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -261,6 +261,10 @@
 #
 # @param enterprise_dashboard_oidc Optional OIDC configuration for Enterprise Dashboard
 #
+# @param enterprise_dashboard_custom List of custom attributes to include in the check.
+#   You can use it to pass any attribute that is not listed here explicitly.
+#   Example: { 'usersOptions' => { 'requireSilencingReason' => true } }
+#
 # @param path Used to set PATH in /etc/default/sensu
 #
 # @param redact Use to redact passwords from checks on the client side
@@ -460,6 +464,7 @@ class sensu (
   Optional[Any]      $enterprise_dashboard_gitlab = undef,
   Optional[Any]      $enterprise_dashboard_ldap = undef,
   Optional[Any]      $enterprise_dashboard_oidc = undef,
+  Optional[Hash]     $enterprise_dashboard_custom = undef,
   Variant[Stdlib::Absolutepath,Pattern[/^\$PATH$/]] $path = '$PATH',
   Optional[Array]    $redact = undef,
   Boolean            $deregister_on_stop = false,

--- a/spec/classes/sensu_enterprise_spec.rb
+++ b/spec/classes/sensu_enterprise_spec.rb
@@ -208,6 +208,19 @@ describe 'sensu', :type => :class do
               'oidc' => { 'key' => 'value' }
             }) }
           end
+
+          context 'with enterprise_dashboard_custom defined' do
+            let(:params) { {
+              :enterprise                   => true,
+              :enterprise_user              => 'sensu',
+              :enterprise_pass              => 'sensu',
+              :enterprise_dashboard         => true,
+              :enterprise_dashboard_custom  => { 'key' => 'value' }
+            } }
+            it { should contain_sensu_enterprise_dashboard_config('testhost.domain.com').with({
+              'custom' => { 'key' => 'value' }
+            }) }
+          end
         end
 
         context 'with rabbitmq_ssl => true and rabbitmq_ssl_cert_chain => undef' do

--- a/spec/unit/sensu_enterprise_dashboard_config_spec.rb
+++ b/spec/unit/sensu_enterprise_dashboard_config_spec.rb
@@ -86,4 +86,11 @@ describe Puppet::Type.type(:sensu_enterprise_dashboard_config) do
       expect(type_instance[:oidc]).to be_a(Hash)
     end
   end
+
+  describe 'accepts Hash values for :custom' do
+    it do
+      type_instance[:custom] = { :key => :value }
+      expect(type_instance[:custom]).to be_a(Hash)
+    end
+  end
 end

--- a/tests/sensu-server-enterprise.pp
+++ b/tests/sensu-server-enterprise.pp
@@ -38,6 +38,9 @@ node 'sensu-server' {
     install_repo              => true,
     enterprise                => true,
     enterprise_dashboard      => true,
+    enterprise_dashboard_custom => {
+      'usersOptions' => { 'requireSilencingReason' => true },
+    },
     enterprise_user           => $facts['se_user'],
     enterprise_pass           => $facts['se_pass'],
     manage_services           => true,


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `enterprise_dashboard_custom` parameter to `sensu` class which required adding `custom` property to `sensu_enterprise_dashboard_config` type.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #842 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Dashboard config supporting custom key/value pairs will allow Puppet module to support configurations more easily without updates to Puppet code.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Vagrant `sensu-server-enterprise` box.

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
