### PR TITLE
Remove support for operating systems that do not have sensu-go packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,17 +249,20 @@ Vagrant boxes and the intent of those platforms is to run in AWS, we
 will not maintain Vagrant systems for local development for Amazon
 Linux.
 
-### Support Platforms
+### Supported Platforms
 
 * EL 6
 * EL 7
-* Debian 8
-* Debian 9
-* Ubuntu 14.04 LTS
 * Ubuntu 16.04 LTS
 * Ubuntu 18.04 LTS
 * Amazon 2018.03
 * Amazon 2
+
+The following platforms will be supported again once packages are released.
+
+* Debian 8
+* Debian 9
+* Ubuntu 14.04
 
 ## Development
 

--- a/metadata.json
+++ b/metadata.json
@@ -27,16 +27,8 @@
       ]
     },
     {
-      "operatingsystem": "Debian",
-      "operatingsystemrelease": [
-        "8",
-        "9"
-      ]
-    },
-    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "14.04",
         "16.04",
         "18.04"
       ]


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove support for operating systems that do not have sensu-go packages

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Necessary to have proper release ready code for #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Upstream sensu-go does not have packages for Debian or Ubuntu 14.04 so remove them from this module's metadata and make a note in README.
