### PR TITLE
Fix/backend ssl (cont.)

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -28,6 +28,8 @@
 #   Sensu backend host used to configure sensuctl and verify API access.
 # @param url_port
 #   Sensu backend port used to configure sensuctl and verify API access.
+# @param use_ssl
+#   Sensu backend service uses SSL
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -40,6 +42,7 @@ class sensu::backend (
   Hash $config_hash = {},
   String $url_host = '127.0.0.1',
   Stdlib::Port $url_port = 8080,
+  Boolean $use_ssl = false,
 ) {
 
   include ::sensu
@@ -51,7 +54,14 @@ class sensu::backend (
   }
   $config = $default_config + $config_hash
 
-  $url = "http://${url_host}:${url_port}"
+  if $use_ssl {
+    $url_protocol = 'https'
+  }
+  else {
+    $url_protocol = 'http'
+  }
+
+  $url = "${url_protocol}://${url_host}:${url_port}"
 
   if $version == undef {
     $_version = $::sensu::version
@@ -68,6 +78,7 @@ class sensu::backend (
   sensu_api_validator { 'sensu':
     sensu_api_server => $url_host,
     sensu_api_port   => $url_port,
+    use_ssl          => $use_ssl,
     require          => Service['sensu-backend'],
   }
   # Ensure sensu-backend is up before starting sensu-agent
@@ -76,10 +87,11 @@ class sensu::backend (
   $sensuctl_configure = "sensuctl configure -n --url '${url}' --username 'admin' --password 'P@ssw0rd!'"
   $sensuctl_configure_creates = '/root/.config/sensu/sensuctl/cluster'
   exec { 'sensuctl_configure':
-    command => "${sensuctl_configure} || rm -f ${sensuctl_configure_creates}",
-    creates => $sensuctl_configure_creates,
-    path    => '/bin:/sbin:/usr/bin:/usr/sbin',
-    require => Sensu_api_validator['sensu'],
+    command   => "${sensuctl_configure} || rm -f ${sensuctl_configure_creates}",
+    creates   => $sensuctl_configure_creates,
+    path      => '/bin:/sbin:/usr/bin:/usr/sbin',
+    logoutput => true,
+    require   => Sensu_api_validator['sensu'],
   }
 
   package { 'sensu-go-backend':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,6 +43,7 @@ class sensu (
     path    => $etc_dir,
     purge   => $etc_dir_purge,
     recurse => $etc_dir_purge,
+    force   => $etc_dir_purge,
   }
 
   case $facts['os']['family'] {

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -13,14 +13,81 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
       apply_manifest_on(node, pp, :catch_changes  => true)
     end
 
-    it do
-      on node, "/opt/puppetlabs/bin/facter os" do
-        puts stdout
-      end
-    end
     describe service('sensu-backend'), :node => node do
       it { should be_enabled }
       it { should be_running }
+    end
+  end
+
+  context 'with SSL' do
+    it 'should bootstrap certs' do
+      on node, 'mkdir -p /root/ssl'
+      on node, 'openssl req -newkey rsa:2048 -nodes -keyout /root/ssl/ca_key.pem -x509 -days 365 -out /root/ssl/ca.pem -subj "/CN=localhost"'
+      on node, 'openssl req -newkey rsa:2048 -nodes -keyout /root/ssl/key.pem -out /root/ssl/localhost.csr -subj "/CN=localhost"'
+      on node, 'openssl x509 -req -in /root/ssl/localhost.csr -CA /root/ssl/ca.pem -CAkey /root/ssl/ca_key.pem -CAcreateserial -out /root/ssl/cert.pem -days 365 -sha256'
+      if fact_on(node, 'os.family') == 'Debian'
+        on node, 'apt-get install ca-certificates'
+        on node, 'cp /root/ssl/ca.pem /usr/local/share/ca-certificates/ca.crt'
+        on node, 'PATH=/usr/bin:/bin:/usr/sbin:/sbin update-ca-certificates'
+      elsif fact_on(node, 'os.family') == 'RedHat'
+        on node, 'cat /root/ssl/ca.pem >> /etc/pki/tls/certs/ca-bundle.crt'
+      end
+      # Force sensuctl configure to re-run
+      on node, 'rm -f /root/.config/sensu/sensuctl/cluster'
+    end
+    it 'should work without errors' do
+      pp = <<-EOS
+      file { '/etc/sensu/ssl':
+        ensure  => 'directory',
+        source  => '/root/ssl',
+        recurse => true,
+        notify  => Service['sensu-backend'],
+      }
+      class { '::sensu::backend':
+        url_host    => 'localhost',
+        use_ssl     => true,
+        config_hash => {
+          'cert-file'       => '/etc/sensu/ssl/cert.pem',
+          'key-file'        => '/etc/sensu/ssl/key.pem',
+          'trusted-ca-file' => '/etc/sensu/ssl/ca.pem',
+        },
+      }
+      EOS
+
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    describe service('sensu-backend'), :node => node do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe command('sensuctl entity list'), :node => node do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+
+  context 'reset to default' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      EOS
+
+      # Force re-run of sensuctl configure
+      on node, 'rm -f /root/.config/sensu/sensuctl/cluster'
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    describe service('sensu-backend'), :node => node do
+      it { should be_enabled }
+      it { should be_running }
+    end
+
+    describe command('sensuctl entity list'), :node => node do
+      its(:exit_status) { should eq 0 }
     end
   end
 end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -4,7 +4,7 @@ describe 'sensu::backend', :type => :class do
   on_supported_os({facterversion: '3.8.0'}).each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
-      describe 'with default values for all parameters' do
+      context 'with default values for all parameters' do
         it { should compile.with_all_deps }
 
         it { should contain_class('sensu::backend')}
@@ -21,16 +21,18 @@ describe 'sensu::backend', :type => :class do
           should contain_sensu_api_validator('sensu').with({
             'sensu_api_server' => '127.0.0.1',
             'sensu_api_port'   => 8080,
+            'use_ssl'          => 'false',
             'require'          => 'Service[sensu-backend]',
           })
         }
 
         it {
           should contain_exec('sensuctl_configure').with({
-            'command' => "sensuctl configure -n --url 'http://127.0.0.1:8080' --username 'admin' --password 'P@ssw0rd!' || rm -f /root/.config/sensu/sensuctl/cluster",
-            'creates' => '/root/.config/sensu/sensuctl/cluster',
-            'path'    => '/bin:/sbin:/usr/bin:/usr/sbin',
-            'require' => 'Sensu_api_validator[sensu]',
+            'command'   => "sensuctl configure -n --url 'http://127.0.0.1:8080' --username 'admin' --password 'P@ssw0rd!' || rm -f /root/.config/sensu/sensuctl/cluster",
+            'creates'   => '/root/.config/sensu/sensuctl/cluster',
+            'path'      => '/bin:/sbin:/usr/bin:/usr/sbin',
+            'logoutput' => 'true',
+            'require'   => 'Sensu_api_validator[sensu]',
           })
         }
 
@@ -74,6 +76,29 @@ describe 'sensu::backend', :type => :class do
             'ensure' => 'running',
             'enable' => true,
             'name'   => 'sensu-backend',
+          })
+        }
+      end
+
+      context 'with use_ssl => true' do
+        let(:params) { { :use_ssl => true } }
+
+        it {
+          should contain_sensu_api_validator('sensu').with({
+            'sensu_api_server' => '127.0.0.1',
+            'sensu_api_port'   => 8080,
+            'use_ssl'          => 'true',
+            'require'          => 'Service[sensu-backend]',
+          })
+        }
+
+        it {
+          should contain_exec('sensuctl_configure').with({
+            'command'   => "sensuctl configure -n --url 'https://127.0.0.1:8080' --username 'admin' --password 'P@ssw0rd!' || rm -f /root/.config/sensu/sensuctl/cluster",
+            'creates'   => '/root/.config/sensu/sensuctl/cluster',
+            'path'      => '/bin:/sbin:/usr/bin:/usr/sbin',
+            'logoutput' => 'true',
+            'require'   => 'Sensu_api_validator[sensu]',
           })
         }
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -17,6 +17,7 @@ describe 'sensu', :type => :class do
             'path'    => '/etc/sensu',
             'purge'   => true,
             'recurse' => true,
+            'force'   => true,
           })
         }
       end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Continuation of #1024.
Expose $use_ssl flag for backend
Add force to /etc/sensu to ensure directories can be removed
Log output from 'sensuctl configure' Exec


## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1023 and replaces #1024.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better support for SSL backend.  The acceptance tests have to resort to removing configuration generated from `sensuctl configure` to ensure `sensuctl` functions switch to and from SSL.  This is something that will be eventually handled once #1025 is implemented.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Beaker.
