### PR TITLE
Do not include sensu::agent class in main sensu

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ vagrant provision sensu-backend-peer1 sensu-backend-peer2
 
 ### Basic Sensu backend
 
-The following example will configure sensu-backend and add a check.
+The following example will configure sensu-backend, sensu-agent on backend and add a check.
 
 ```puppet
   include sensu::backend
+  include sensu::agent
   sensu_check { 'check-cpu':
     ensure        => 'present',
     command       => 'check-cpu.sh -w 75 -c 90',

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -70,8 +70,6 @@ class sensu::backend (
     sensu_api_port   => $url_port,
     require          => Service['sensu-backend'],
   }
-  # Ensure sensu-backend is up before starting sensu-agent
-  Sensu_api_validator['sensu'] -> Service['sensu-agent']
 
   $sensuctl_configure = "sensuctl configure -n --url '${url}' --username 'admin' --password 'P@ssw0rd!'"
   $sensuctl_configure_creates = '/root/.config/sensu/sensuctl/cluster'
@@ -111,6 +109,5 @@ class sensu::backend (
     ensure => $service_ensure,
     enable => $service_enable,
     name   => $service_name,
-    before => Service['sensu-agent'],
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,7 +36,6 @@ class sensu (
   if $manage_repo {
     include ::sensu::repo
   }
-  include ::sensu::agent
 
   file { 'sensu_etc_dir':
     ensure  => 'directory',

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -22,5 +22,34 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
       it { should be_enabled }
       it { should be_running }
     end
+    describe package('sensu-go-agent'), :node => node do
+      it { should_not be_installed }
+    end
+  end
+
+  context 'backend and agent' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      class { '::sensu::agent':
+        config_hash => {
+          'backend-url' => 'ws://localhost:8081',
+        },
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    describe service('sensu-backend'), :node => node do
+      it { should be_enabled }
+      it { should be_running }
+    end
+    describe service('sensu-agent'), :node => node do
+      it { should be_enabled }
+      it { should be_running }
+    end
   end
 end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -7,7 +7,9 @@ describe 'sensu::backend', :type => :class do
       describe 'with default values for all parameters' do
         it { should compile.with_all_deps }
 
-        it { should contain_class('sensu::backend')}
+        it { should contain_class('sensu::backend') }
+        it { should contain_class('sensu') }
+        it { should_not contain_class('sensu::agent') }
 
         it {
           should contain_package('sensu-go-cli').with({

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,7 +9,6 @@ describe 'sensu', :type => :class do
 
         it { should contain_class('sensu')}
         it { should contain_class('sensu::repo')}
-        it { should contain_class('sensu::agent')}
 
         it {
           should contain_file('sensu_etc_dir').with({


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Do not include `sensu::agent` in `sensu` class.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows the usage of resource-like declaration of classes like the following without being order dependent:
```puppet
class { 'sensu::agent':
...
}
class { 'sensu::backend':
...
}
```

The usage examples in README already describe directly calling `sensu::agent` and `sensu::backend` classes.
