### PR TITLE
Fix sensu_check check_hooks property

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -122,7 +122,7 @@ DESC
       type_valid = false
       if ['ok','warning','critical','unknown','non-zero'].include?(type)
         type_valid = true
-      elsif type.to_s =~ /^\d+$/ && type.to_i.between?(1,255)
+      elsif type.to_s =~ /^\d+$/ && type.to_i.between?(0,255)
         type_valid = true
       end
       if ! type_valid
@@ -131,6 +131,11 @@ DESC
       if ! hooks.is_a?(Array)
         raise ArgumentError, "check_hooks hooks must be an Array"
       end
+    end
+    munge do |value|
+      type = value.keys[0]
+      hooks = value[type]
+      { type.to_s => hooks }
     end
   end
 

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -12,6 +12,8 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
         handlers                         => ['email'],
         interval                         => 60,
         check_hooks                      => [
+          { '0'        => ['always.sh'] },
+          { 1          => ['test.sh'] },
           { 'critical' => ['httpd-restart'] },
         ],
         proxy_requests_entity_attributes => ["entity.Class == 'proxy'"],
@@ -37,7 +39,7 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
         expect(data['command']).to eq('check-http.rb')
         expect(data['publish']).to eq(true)
         expect(data['stdin']).to eq(false)
-        expect(data['check_hooks']).to eq([{'critical' => ['httpd-restart']}])
+        expect(data['check_hooks']).to eq([{'0' => ['always.sh']},{'1' => ['test.sh']},{'critical' => ['httpd-restart']}])
         expect(data['proxy_requests']['entity_attributes']).to eq(["entity.Class == 'proxy'"])
         expect(data['output_metric_format']).to eq('nagios_perfdata')
         expect(data['metadata']['labels']['foo']).to eq('baz')

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -237,6 +237,8 @@ describe Puppet::Type.type(:sensu_check) do
 
   describe 'check_hooks' do
     [
+      0,
+      '0',
       1,
       '1',
       'ok',
@@ -247,7 +249,7 @@ describe Puppet::Type.type(:sensu_check) do
     ].each do |type|
       it "accepts valid values for type #{type} #{type.class}" do
         config[:check_hooks] = [{type => ['test']}]
-        expect(check[:check_hooks]).to eq([{type => ['test']}])
+        expect(check[:check_hooks]).to eq([{type.to_s => ['test']}])
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix check_hooks to ensure numeric range accepted includes 0
Munge integer keys to strings as sensuctl does not allow integer keys for check_hooks

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The docs for sensu-go show examples that `0` is valid type for `check_hooks` and confirmed this with vagrant.
Given Integer and not numeric strings also results in errors so munge all keys to strings:

```
[root@sensu-backend ~]# cat check.json
{
  "command": "check-http.rb",
  "handlers": [
    "email"
  ],
  "high_flap_threshold": 0,
  "interval": 60,
  "low_flap_threshold": 0,
  "publish": false,
  "runtime_assets": null,
  "subscriptions": [
    "demo"
  ],
  "proxy_entity_name": "",
  "check_hooks": [
    {
      '0': [
        "test"
      ]
    }
  ],
  "stdin": false,
  "subdue": null,
  "ttl": 0,
  "timeout": 0,
  "round_robin": false,
  "output_metric_format": "",
  "output_metric_handlers": null,
  "env_vars": null,
  "metadata": {
    "name": "test",
    "namespace": "default"
  }
}
[root@sensu-backend ~]# sensuctl create -f check.json
resource 0: invalid character '0' looking for beginning of object key string
resource 1: invalid character '0' looking for beginning of object key string
resource 2: invalid character '0' looking for beginning of object key string
resource 3: invalid character '0' looking for beginning of object key string
resource 4: invalid character '0' looking for beginning of object key string
resource 5: invalid character '0' looking for beginning of object key string
resource 6: invalid character '0' looking for beginning of object key string
resource 7: invalid character '0' looking for beginning of object key string
resource 8: invalid character '0' looking for beginning of object key string
resource 9: invalid character '0' looking for beginning of object key string
resource 10: invalid character '0' looking for beginning of object key string
Error: too many errors
```
