### PR TITLE
Improve type autorequires

### DIFF
--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -19,6 +19,7 @@ Puppet::Type.newtype(:sensu_asset) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -33,6 +33,10 @@ Puppet::Type.newtype(:sensu_check) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
+* `sensu_handler` - Puppet will autorequie `sensu_handler` resources defined in `handlers` property.
+* `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.
+* `sensu_hook` - Puppet will autorequire `sensu_hook` resources defined in `check_hooks` property.
 DESC
 
   extend PuppetX::Sensu::Type
@@ -193,6 +197,26 @@ DESC
 
   newproperty(:annotations, :parent => PuppetX::Sensu::HashProperty) do
     desc "Arbitrary, non-identifying metadata to include with event data."
+  end
+
+  autorequire(:sensu_handler) do
+    self[:handlers]
+  end
+
+  autorequire(:sensu_asset) do
+    self[:runtime_assets]
+  end
+
+  autorequire(:sensu_hook) do
+    check_hooks = []
+    (self[:check_hooks] || []).each do |check_hook|
+      check_hook.each_pair do |severity, hooks|
+        hooks.each do |hook|
+          check_hooks << hook
+        end
+      end
+    end
+    check_hooks
   end
 
   validate do

--- a/lib/puppet/type/sensu_cluster_member.rb
+++ b/lib/puppet/type/sensu_cluster_member.rb
@@ -20,7 +20,7 @@ Puppet::Type.newtype(:sensu_cluster_member) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires()
+  add_autorequires(false)
 
   ensurable
 

--- a/lib/puppet/type/sensu_cluster_role.rb
+++ b/lib/puppet/type/sensu_cluster_role.rb
@@ -21,7 +21,7 @@ Puppet::Type.newtype(:sensu_cluster_role) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires()
+  add_autorequires(false)
 
   ensurable
 

--- a/lib/puppet/type/sensu_cluster_role_binding.rb
+++ b/lib/puppet/type/sensu_cluster_role_binding.rb
@@ -25,7 +25,7 @@ Puppet::Type.newtype(:sensu_cluster_role_binding) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires()
+  add_autorequires(false)
 
   ensurable
 

--- a/lib/puppet/type/sensu_config.rb
+++ b/lib/puppet/type/sensu_config.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:sensu_config) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires()
+  add_autorequires(false)
 
   ensurable do
     desc "The basic property that the resource should be in."

--- a/lib/puppet/type/sensu_configure.rb
+++ b/lib/puppet/type/sensu_configure.rb
@@ -14,7 +14,7 @@ Puppet::Type.newtype(:sensu_configure) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires(false)
+  add_autorequires(false, false)
 
   ensurable
 

--- a/lib/puppet/type/sensu_entity.rb
+++ b/lib/puppet/type/sensu_entity.rb
@@ -17,6 +17,8 @@ Puppet::Type.newtype(:sensu_entity) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
+* `sensu_handler` - Puppet will autorequie `sensu_handler` resource defined in `deregistration_handler` property.
 DESC
 
   extend PuppetX::Sensu::Type
@@ -85,6 +87,10 @@ DESC
 
   newproperty(:annotations, :parent => PuppetX::Sensu::HashProperty) do
     desc "Arbitrary, non-identifying metadata to include with event data."
+  end
+
+  autorequire(:sensu_handler) do
+    [ self[:deregistration_handler] ]
   end
 
   validate do

--- a/lib/puppet/type/sensu_event.rb
+++ b/lib/puppet/type/sensu_event.rb
@@ -21,6 +21,7 @@ Puppet::Type.newtype(:sensu_event) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -18,6 +18,8 @@ Puppet::Type.newtype(:sensu_filter) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
+* `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.
 DESC
 
   extend PuppetX::Sensu::Type
@@ -59,6 +61,10 @@ DESC
 
   newproperty(:annotations, :parent => PuppetX::Sensu::HashProperty) do
     desc "Arbitrary, non-identifying metadata to include with event data."
+  end
+
+  autorequire(:sensu_asset) do
+    self[:runtime_assets]
   end
 
   validate do

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -18,6 +18,11 @@ Puppet::Type.newtype(:sensu_handler) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
+* `sensu_filter` - Puppet will autorequire `sensu_filter` resources defined in `filters` property.
+* `sensu_mutator` - Puppet will autorequire `sensu_mutator` resource defined for `mutator` property.
+* `sensu_handler` - Puppet will autorequire `sensu_handler` resources defined for `handlers` property.
+* `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.
 DESC
 
   extend PuppetX::Sensu::Type
@@ -100,6 +105,22 @@ DESC
 
   newproperty(:annotations, :parent => PuppetX::Sensu::HashProperty) do
     desc "Arbitrary, non-identifying metadata to include with event data."
+  end
+
+  autorequire(:sensu_filter) do
+    self[:filters]
+  end
+
+  autorequire(:sensu_mutator) do
+    [ self[:mutator] ]
+  end
+
+  autorequire(:sensu_handler) do
+    self[:handlers]
+  end
+
+  autorequire(:sensu_asset) do
+    self[:runtime_assets]
   end
 
   validate do

--- a/lib/puppet/type/sensu_hook.rb
+++ b/lib/puppet/type/sensu_hook.rb
@@ -17,6 +17,7 @@ Puppet::Type.newtype(:sensu_hook) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_mutator.rb
+++ b/lib/puppet/type/sensu_mutator.rb
@@ -17,6 +17,8 @@ Puppet::Type.newtype(:sensu_mutator) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
+* `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.
 DESC
 
   extend PuppetX::Sensu::Type
@@ -63,6 +65,10 @@ DESC
 
   newproperty(:annotations, :parent => PuppetX::Sensu::HashProperty) do
     desc "Arbitrary, non-identifying metadata to include with event data."
+  end
+
+  autorequire(:sensu_asset) do
+    self[:runtime_assets]
   end
 
   validate do

--- a/lib/puppet/type/sensu_namespace.rb
+++ b/lib/puppet/type/sensu_namespace.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:sensu_namespace) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires()
+  add_autorequires(false)
 
   ensurable
 

--- a/lib/puppet/type/sensu_role.rb
+++ b/lib/puppet/type/sensu_role.rb
@@ -18,6 +18,7 @@ Puppet::Type.newtype(:sensu_role) do
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_role_binding.rb
+++ b/lib/puppet/type/sensu_role_binding.rb
@@ -22,6 +22,7 @@ Puppet::Type.newtype(:sensu_role_binding) do
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
 * `sensu_role` - Puppet will autorequire `sensu_role` resource defined in `role_ref` property.
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_silenced.rb
+++ b/lib/puppet/type/sensu_silenced.rb
@@ -30,6 +30,7 @@ The name of `sensu_silenced` can be used to define `check` and `subscription`.
 * `Service[sensu-backend]`
 * `Exec[sensuctl_configure]`
 * `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet_x/sensu/type.rb
+++ b/lib/puppet_x/sensu/type.rb
@@ -2,7 +2,7 @@ module PuppetX
   module Sensu
     module Type
 
-      def add_autorequires(require_configure=true)
+      def add_autorequires(namespace=true, require_configure=true)
         autorequire(:package) do
           ['sensu-go-cli']
         end
@@ -18,13 +18,13 @@ module PuppetX
         end
 
         autorequire(:sensu_api_validator) do
-          requires = []
-          catalog.resources.each do |resource|
-            if resource.class.to_s == 'Puppet::Type::Sensu_api_validator'
-              requires << resource.name if resource.name == 'sensu'
-            end
+          [ 'sensu' ]
+        end
+
+        if namespace
+          autorequire(:sensu_namespace) do
+            [ self[:namespace] ]
           end
-          requires
         end
       end
     end

--- a/spec/shared_examples/types.rb
+++ b/spec/shared_examples/types.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
-RSpec.shared_examples 'autorequires' do
+RSpec.shared_examples 'autorequires' do |namespace, configure|
+  namespace = true if namespace.nil?
+  configure = true if configure.nil?
+
   it 'should autorequire Package[sensu-go-cli]' do
     package = Puppet::Type.type(:package).new(:name => 'sensu-go-cli')
     catalog = Puppet::Resource::Catalog.new
@@ -21,14 +24,16 @@ RSpec.shared_examples 'autorequires' do
     expect(rel.target.ref).to eq(res.ref)
   end
 
-  it 'should autorequire Sensu_configure[puppet]' do
-    c = Puppet::Type.type(:sensu_configure).new(:name => 'puppet', :username => 'admin', :password => 'P@ssw0rd!', :url => 'http://127.0.0.1:8080')
-    catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource res
-    catalog.add_resource c
-    rel = res.autorequire[0]
-    expect(rel.source.ref).to eq(c.ref)
-    expect(rel.target.ref).to eq(res.ref)
+  if configure
+    it 'should autorequire Sensu_configure[puppet]' do
+      c = Puppet::Type.type(:sensu_configure).new(:name => 'puppet', :username => 'admin', :password => 'P@ssw0rd!', :url => 'http://127.0.0.1:8080')
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource res
+      catalog.add_resource c
+      rel = res.autorequire[0]
+      expect(rel.source.ref).to eq(c.ref)
+      expect(rel.target.ref).to eq(res.ref)
+    end
   end
 
   it 'should autorequire sensu_api_validator' do
@@ -39,5 +44,18 @@ RSpec.shared_examples 'autorequires' do
     rel = res.autorequire[0]
     expect(rel.source.ref).to eq(validator.ref)
     expect(rel.target.ref).to eq(res.ref)
+  end
+
+  if namespace
+    it 'should autorequire sensu_namespace' do
+      namespace = Puppet::Type.type(:sensu_namespace).new(:name => 'sensu')
+      res[:namespace] = 'sensu'
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource res
+      catalog.add_resource namespace
+      rel = res.autorequire[0]
+      expect(rel.source.ref).to eq(namespace.ref)
+      expect(rel.target.ref).to eq(res.ref)
+    end
   end
 end

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -308,6 +308,39 @@ describe Puppet::Type.type(:sensu_check) do
     let(:res) { check }
   end
 
+  it 'should autorequire sensu_handler' do
+    handler = Puppet::Type.type(:sensu_handler).new(:name => 'test', :type => 'pipe', :command => 'test')
+    catalog = Puppet::Resource::Catalog.new
+    config[:handlers] = ['test']
+    catalog.add_resource check
+    catalog.add_resource handler
+    rel = check.autorequire[0]
+    expect(rel.source.ref).to eq(handler.ref)
+    expect(rel.target.ref).to eq(check.ref)
+  end
+
+  it 'should autorequire sensu_asset' do
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    catalog = Puppet::Resource::Catalog.new
+    config[:runtime_assets] = ['test']
+    catalog.add_resource check
+    catalog.add_resource asset
+    rel = check.autorequire[0]
+    expect(rel.source.ref).to eq(asset.ref)
+    expect(rel.target.ref).to eq(check.ref)
+  end
+
+  it 'should autorequire sensu_hook' do
+    hook = Puppet::Type.type(:sensu_hook).new(:name => 'test', :command => 'test')
+    catalog = Puppet::Resource::Catalog.new
+    config[:check_hooks] = [{1 => ['test']},{'critical' => ['test2']}]
+    catalog.add_resource check
+    catalog.add_resource hook
+    rel = check.autorequire[0]
+    expect(rel.source.ref).to eq(hook.ref)
+    expect(rel.target.ref).to eq(check.ref)
+  end
+
   [
     :command,
     :subscriptions,

--- a/spec/unit/sensu_cluster_member_spec.rb
+++ b/spec/unit/sensu_cluster_member_spec.rb
@@ -118,7 +118,7 @@ describe Puppet::Type.type(:sensu_cluster_member) do
     end
   end
 
-  include_examples 'autorequires' do
+  include_examples 'autorequires', false do
     let(:res) { cluster_member }
   end
 

--- a/spec/unit/sensu_cluster_role_binding_spec.rb
+++ b/spec/unit/sensu_cluster_role_binding_spec.rb
@@ -157,7 +157,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
     expect(rel.target.ref).to eq(binding.ref)
   end
 
-  include_examples 'autorequires' do
+  include_examples 'autorequires', false do
     let(:res) { binding }
   end
 

--- a/spec/unit/sensu_cluster_role_spec.rb
+++ b/spec/unit/sensu_cluster_role_spec.rb
@@ -149,7 +149,7 @@ describe Puppet::Type.type(:sensu_cluster_role) do
     end
   end
 
-  include_examples 'autorequires' do
+  include_examples 'autorequires', false do
     let(:res) { cluster_role }
   end
 

--- a/spec/unit/sensu_config_spec.rb
+++ b/spec/unit/sensu_config_spec.rb
@@ -124,7 +124,7 @@ describe Puppet::Type.type(:sensu_config) do
     end
   end
 
-  include_examples 'autorequires' do
+  include_examples 'autorequires', false do
     let(:res) { sensu_config }
   end
 

--- a/spec/unit/sensu_configure_spec.rb
+++ b/spec/unit/sensu_configure_spec.rb
@@ -129,34 +129,8 @@ describe Puppet::Type.type(:sensu_configure) do
     end
   end
 
-  it 'should autorequire Package[sensu-go-cli]' do
-    package = Puppet::Type.type(:package).new(:name => 'sensu-go-cli')
-    catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource configure
-    catalog.add_resource package
-    rel = configure.autorequire[0]
-    expect(rel.source.ref).to eq(package.ref)
-    expect(rel.target.ref).to eq(configure.ref)
-  end
-
-  it 'should autorequire Service[sensu-backend]' do
-    service = Puppet::Type.type(:service).new(:name => 'sensu-backend')
-    catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource configure
-    catalog.add_resource service
-    rel = configure.autorequire[0]
-    expect(rel.source.ref).to eq(service.ref)
-    expect(rel.target.ref).to eq(configure.ref)
-  end
-
-  it 'should autorequire sensu_api_validator' do
-    validator = Puppet::Type.type(:sensu_api_validator).new(:name => 'sensu')
-    catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource configure
-    catalog.add_resource validator
-    rel = configure.autorequire[0]
-    expect(rel.source.ref).to eq(validator.ref)
-    expect(rel.target.ref).to eq(configure.ref)
+  include_examples 'autorequires', false, false do
+    let(:res) { configure }
   end
 
   [

--- a/spec/unit/sensu_entity_spec.rb
+++ b/spec/unit/sensu_entity_spec.rb
@@ -184,6 +184,17 @@ describe Puppet::Type.type(:sensu_entity) do
     let(:res) { entity }
   end
 
+  it 'should autorequire sensu_handler' do
+    handler = Puppet::Type.type(:sensu_handler).new(:name => 'test', :type => 'pipe', :command => 'test')
+    catalog = Puppet::Resource::Catalog.new
+    config[:deregistration_handler] = ['test']
+    catalog.add_resource entity
+    catalog.add_resource handler
+    rel = entity.autorequire[0]
+    expect(rel.source.ref).to eq(handler.ref)
+    expect(rel.target.ref).to eq(entity.ref)
+  end
+
   [
     :entity_class,
   ].each do |property|

--- a/spec/unit/sensu_filter_spec.rb
+++ b/spec/unit/sensu_filter_spec.rb
@@ -186,6 +186,17 @@ describe Puppet::Type.type(:sensu_filter) do
     let(:res) { filter }
   end
 
+  it 'should autorequire sensu_asset' do
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    catalog = Puppet::Resource::Catalog.new
+    config[:runtime_assets] = ['test']
+    catalog.add_resource filter
+    catalog.add_resource asset
+    rel = filter.autorequire[0]
+    expect(rel.source.ref).to eq(asset.ref)
+    expect(rel.target.ref).to eq(filter.ref)
+  end
+
   [
     :action,
     :expressions,

--- a/spec/unit/sensu_handler_spec.rb
+++ b/spec/unit/sensu_handler_spec.rb
@@ -202,6 +202,50 @@ describe Puppet::Type.type(:sensu_handler) do
     let(:res) { handler }
   end
 
+  it 'should autorequire sensu_filter' do
+    filter = Puppet::Type.type(:sensu_filter).new(:name => 'test', :action => 'allow', :expressions => ['event.Check.Occurrences == 1'])
+    catalog = Puppet::Resource::Catalog.new
+    config[:filters] = ['test']
+    catalog.add_resource handler
+    catalog.add_resource filter
+    rel = handler.autorequire[0]
+    expect(rel.source.ref).to eq(filter.ref)
+    expect(rel.target.ref).to eq(handler.ref)
+  end
+
+  it 'should autorequire sensu_mutator' do
+    mutator = Puppet::Type.type(:sensu_mutator).new(:name => 'test', :command => 'test')
+    catalog = Puppet::Resource::Catalog.new
+    config[:mutator] = 'test'
+    catalog.add_resource handler
+    catalog.add_resource mutator
+    rel = handler.autorequire[0]
+    expect(rel.source.ref).to eq(mutator.ref)
+    expect(rel.target.ref).to eq(handler.ref)
+  end
+
+  it 'should autorequire sensu_handler' do
+    h = Puppet::Type.type(:sensu_handler).new(:name => 'test2', :type => 'pipe', :command => 'test')
+    catalog = Puppet::Resource::Catalog.new
+    config[:handlers] = ['test2']
+    catalog.add_resource handler
+    catalog.add_resource h
+    rel = handler.autorequire[0]
+    expect(rel.source.ref).to eq(h.ref)
+    expect(rel.target.ref).to eq(handler.ref)
+  end
+
+  it 'should autorequire sensu_asset' do
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    catalog = Puppet::Resource::Catalog.new
+    config[:runtime_assets] = ['test']
+    catalog.add_resource handler
+    catalog.add_resource asset
+    rel = handler.autorequire[0]
+    expect(rel.source.ref).to eq(asset.ref)
+    expect(rel.target.ref).to eq(handler.ref)
+  end
+
   [
     :type,
   ].each do |property|

--- a/spec/unit/sensu_mutator_spec.rb
+++ b/spec/unit/sensu_mutator_spec.rb
@@ -171,6 +171,17 @@ describe Puppet::Type.type(:sensu_mutator) do
     let(:res) { mutator }
   end
 
+  it 'should autorequire sensu_asset' do
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    catalog = Puppet::Resource::Catalog.new
+    config[:runtime_assets] = ['test']
+    catalog.add_resource mutator
+    catalog.add_resource asset
+    rel = mutator.autorequire[0]
+    expect(rel.source.ref).to eq(asset.ref)
+    expect(rel.target.ref).to eq(mutator.ref)
+  end
+
   [
     :command,
   ].each do |property|

--- a/spec/unit/sensu_namespace_spec.rb
+++ b/spec/unit/sensu_namespace_spec.rb
@@ -122,7 +122,7 @@ describe Puppet::Type.type(:sensu_namespace) do
     end
   end
 
-  include_examples 'autorequires' do
+  include_examples 'autorequires', false do
     let(:res) { namespace }
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Types with a namespace will autorequire sensu_namespace matching namespace property
sensu_check will autorequire configured hooks, handlers and assets
sensu_filter, sensu_handler and sensu_mutator will autorequire assets
sensu_entity should auto require sensu_handler defined in deregistration_handler
sensu_handler will autorequire configure mutator, filters and handlers

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of fix for #1009.  Will implement the other necessary changes in #1011.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
While sensu-go doesn't seem to enforce order of adding something like handlers before checks with handlers it seems logical to ensure we're adding something like an asset before adding a check that is configured to use an asset.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests