### PR TITLE
Amazon Linux 2 shows up as 2 not 2.0, fix unit tests

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -38,7 +38,7 @@
       "operatingsystem": "Amazon",
       "operatingsystemrelease": [
         "2018.03",
-        "2.0"
+        "2"
       ]
     }
   ],

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -7,7 +7,7 @@ describe 'sensu::repo', :type => :class do
       case os
       when /(redhat-6|centos-6|amazon-2017|amazon-2018)-x86_64/
         baseurl = "https://packagecloud.io/sensu/stable/el/6/$basearch"
-      when /(redhat-7|centos-7|amazonlinux-2)-x86_64/
+      when /(redhat-7|centos-7|amazon-2)-x86_64/
         baseurl = "https://packagecloud.io/sensu/stable/el/7/$basearch"
       else
         baseurl = nil


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure we are actually unit testing against Amazon Linux 2 and not 2.0.  Verified that it reports as version 2 , not 2.0.  Also fix unit tests to actually test against Amazon 2, it was never actually getting tested.