### PR TITLE
Add default sensu resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 3. [Usage - Configuration options and additional functionality](#usage)
     * [Basic Sensu backend](#basic-sensu-backend)
     * [Basic Sensu agent](#basic-sensu-agent)
+    * [Advanced agent](#advanced-agent)
     * [Advanced SSL](#advanced-ssl)
     * [Exported resources](#exported-resources)
     * [Resource purging](#resource-purging)
@@ -115,6 +116,22 @@ associated to `linux` and `apache-servers` subscriptions.
       'subscriptions => ['linux', 'apache-servers'],
     },
   }
+```
+
+### Advanced agent
+
+If you wish to change the `agent` password you must provide the new and old password.
+
+```puppet
+class { 'sensu::backend':
+  agent_password     => 'supersecret',
+  agent_old_password => 'P@ssw0rd!',
+}
+class { 'sensu::agent':
+  config_hash => {
+    'password' => 'supersecret',
+  },
+}
 ```
 
 ### Advanced SSL

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -36,6 +36,10 @@
 #   Sensu backend admin password used to confiure sensuctl.
 # @param old_password
 #   Sensu backend admin old password needed when changing password.
+# @param agent_password
+#   The sensu agent password
+# @param agent_old_password
+#   The sensu agent old password needed when changing agent_password
 # @param include_default_resources
 #   Sets if default sensu resources should be included
 #
@@ -54,6 +58,8 @@ class sensu::backend (
   String $ssl_key_source = $facts['puppet_hostprivkey'],
   String $password = 'P@ssw0rd!',
   Optional[String] $old_password = undef,
+  String $agent_password = 'P@ssw0rd!',
+  Optional[String] $agent_old_password = undef,
   Boolean $include_default_resources = true,
 ) {
 

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -36,6 +36,8 @@
 #   Sensu backend admin password used to confiure sensuctl.
 # @param old_password
 #   Sensu backend admin old password needed when changing password.
+# @param include_default_resources
+#   Sets if default sensu resources should be included
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -52,6 +54,7 @@ class sensu::backend (
   String $ssl_key_source = $facts['puppet_hostprivkey'],
   String $password = 'P@ssw0rd!',
   Optional[String] $old_password = undef,
+  Boolean $include_default_resources = true,
 ) {
 
   include ::sensu
@@ -82,6 +85,10 @@ class sensu::backend (
   $config = $default_config + $ssl_config + $config_hash
 
   $url = "${url_protocol}://${url_host}:${url_port}"
+
+  if $include_default_resources {
+    include ::sensu::backend::resources
+  }
 
   package { 'sensu-go-cli':
     ensure  => $_version,

--- a/manifests/backend/resources.pp
+++ b/manifests/backend/resources.pp
@@ -1,0 +1,149 @@
+# @summary Default sensu resources
+# @api private
+#
+class sensu::backend::resources {
+  sensu_namespace { 'default':
+    ensure => 'present',
+  }
+
+  sensu_user { 'agent':
+    ensure   => 'present',
+    disabled => false,
+    password => 'P@ssw0rd!',
+    groups   => ['system:agents'],
+  }
+
+  sensu_cluster_role { 'admin':
+    ensure => 'present',
+    rules  => [
+      {
+        'verbs'     => ['*'],
+        'resources' => [
+          'assets',
+          'checks',
+          'entities',
+          'extensions',
+          'events',
+          'filters',
+          'handlers',
+          'hooks',
+          'mutators',
+          'silenced',
+          'roles',
+          'rolebindings',
+        ],
+      },
+      {
+        'verbs'     => ['get', 'list'],
+        'resources' => ['namespaces'],
+      },
+    ],
+  }
+  sensu_cluster_role { 'cluster-admin':
+    ensure => 'present',
+    rules  => [
+      {
+        'verbs'     => ['*'],
+        'resources' => ['*'],
+      },
+    ],
+  }
+  sensu_cluster_role { 'edit':
+    ensure => 'present',
+    rules  => [
+      {
+        'verbs'     => ['*'],
+        'resources' => [
+          'assets',
+          'checks',
+          'entities',
+          'extensions',
+          'events',
+          'filters',
+          'handlers',
+          'hooks',
+          'mutators',
+          'silenced',
+        ],
+      },
+      {
+        'verbs'     => ['get', 'list'],
+        'resources' => ['namespaces'],
+      },
+    ],
+  }
+  sensu_cluster_role { 'system:agent':
+    ensure => 'present',
+    rules  => [
+      {
+        'verbs'     => ['*'],
+        'resources' => ['events'],
+      },
+    ],
+  }
+  sensu_cluster_role { 'system:user':
+    ensure => 'present',
+    rules  => [
+      {
+        'verbs'     => ['get', 'update'],
+        'resources' => ['localselfuser'],
+      },
+      {
+        'verbs'     => ['get', 'list'],
+        'resources' => ['namespaces'],
+      },
+    ],
+  }
+  sensu_cluster_role { 'view':
+    ensure => 'present',
+    rules  => [
+      {
+        'verbs'     => ['get', 'list'],
+        'resources' => [
+          'assets',
+          'checks',
+          'entities',
+          'extensions',
+          'events',
+          'filters',
+          'handlers',
+          'hooks',
+          'mutators',
+          'silenced',
+          'namespaces',
+        ],
+      },
+    ],
+  }
+
+  sensu_cluster_role_binding { 'cluster-admin':
+    ensure   => 'present',
+    role_ref => 'cluster-admin',
+    subjects => [
+      {
+        'type' => 'Group',
+        'name' => 'cluster-admins'
+      },
+    ],
+  }
+  sensu_cluster_role_binding { 'system:agent':
+    ensure   => 'present',
+    role_ref => 'system:agent',
+    subjects => [
+      {
+        'type' => 'Group',
+        'name' => 'system:agents'
+      },
+    ],
+  }
+  sensu_cluster_role_binding { 'system:user':
+    ensure   => 'present',
+    role_ref => 'system:user',
+    subjects => [
+      {
+        'type' => 'Group',
+        'name' => 'system:users'
+      },
+    ],
+  }
+}

--- a/manifests/backend/resources.pp
+++ b/manifests/backend/resources.pp
@@ -2,15 +2,18 @@
 # @api private
 #
 class sensu::backend::resources {
+  include ::sensu::backend
+
   sensu_namespace { 'default':
     ensure => 'present',
   }
 
   sensu_user { 'agent':
-    ensure   => 'present',
-    disabled => false,
-    password => 'P@ssw0rd!',
-    groups   => ['system:agents'],
+    ensure       => 'present',
+    disabled     => false,
+    password     => $::sensu::backend::agent_password,
+    old_password => $::sensu::backend::agent_old_password,
+    groups       => ['system:agents'],
   }
 
   sensu_cluster_role { 'admin':

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -1,0 +1,184 @@
+require 'spec_helper'
+
+describe 'sensu::backend::resources', :type => :class do
+  on_supported_os({facterversion: '3.8.0'}).each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      context 'with default values for all parameters' do
+        it { should compile }
+        it { should have_sensu_namespace_resource_count(1) }
+        it { should contain_sensu_namespace('default').with_ensure('present') }
+        it { should have_sensu_user_resource_count(1) }
+        it {
+          should contain_sensu_user('agent').with({
+            'ensure'   => 'present',
+            'disabled' => 'false',
+            'password' => 'P@ssw0rd!',
+            'groups'   => ['system:agents'],
+          })
+        }
+        it { should have_sensu_cluster_role_resource_count(6) }
+        it {
+          should contain_sensu_cluster_role('admin').with({
+            'ensure' => 'present',
+            'rules'  => [
+              {
+                'verbs'     => ['*'],
+                'resources' => [
+                  'assets',
+                  'checks',
+                  'entities',
+                  'extensions',
+                  'events',
+                  'filters',
+                  'handlers',
+                  'hooks',
+                  'mutators',
+                  'silenced',
+                  'roles',
+                  'rolebindings',
+                ],
+                'resource_names' => nil,
+              },
+              {
+                'verbs'     => ['get', 'list'],
+                'resources' => ['namespaces'],
+                'resource_names' => nil,
+              },
+            ],
+          })
+        }
+        it {
+          should contain_sensu_cluster_role('cluster-admin').with({
+            'ensure' => 'present',
+            'rules'  => [
+              {
+                'verbs'     => ['*'],
+                'resources' => ['*'],
+                'resource_names' => nil,
+              },
+            ],
+          })
+        }
+        it {
+          should contain_sensu_cluster_role('edit').with({
+            'ensure' => 'present',
+            'rules'  => [
+              {
+                'verbs'     => ['*'],
+                'resources' => [
+                  'assets',
+                  'checks',
+                  'entities',
+                  'extensions',
+                  'events',
+                  'filters',
+                  'handlers',
+                  'hooks',
+                  'mutators',
+                  'silenced',
+                ],
+                'resource_names' => nil,
+              },
+              {
+                'verbs'     => ['get', 'list'],
+                'resources' => ['namespaces'],
+                'resource_names' => nil,
+              },
+            ],
+          })
+        }
+        it {
+          should contain_sensu_cluster_role('system:agent').with({
+            'ensure' => 'present',
+            'rules'  => [
+              {
+                'verbs'     => ['*'],
+                'resources' => ['events'],
+                'resource_names' => nil,
+              },
+            ],
+          })
+        }
+        it {
+          should contain_sensu_cluster_role('system:user').with({
+            'ensure' => 'present',
+            'rules'  => [
+              {
+                'verbs'     => ['get', 'update'],
+                'resources' => ['localselfuser'],
+                'resource_names' => nil,
+              },
+              {
+                'verbs'     => ['get', 'list'],
+                'resources' => ['namespaces'],
+                'resource_names' => nil,
+              },
+            ],
+          })
+        }
+        it {
+          should contain_sensu_cluster_role('view').with({
+            'ensure' => 'present',
+            'rules'  => [
+              {
+                'verbs'     => ['get', 'list'],
+                'resources' => [
+                  'assets',
+                  'checks',
+                  'entities',
+                  'extensions',
+                  'events',
+                  'filters',
+                  'handlers',
+                  'hooks',
+                  'mutators',
+                  'silenced',
+                  'namespaces',
+                ],
+                'resource_names' => nil,
+              },
+            ],
+          })
+        }
+        it { should have_sensu_cluster_role_binding_resource_count(3) }
+        it {
+          should contain_sensu_cluster_role_binding('cluster-admin').with({
+            'ensure'   => 'present',
+            'role_ref' => 'cluster-admin',
+            'subjects' => [
+              {
+                'type' => 'Group',
+                'name' => 'cluster-admins'
+              },
+            ],
+          })
+        }
+        it {
+          should contain_sensu_cluster_role_binding('system:agent').with({
+            'ensure'   => 'present',
+            'role_ref' => 'system:agent',
+            'subjects' => [
+              {
+                'type' => 'Group',
+                'name' => 'system:agents'
+              },
+            ],
+          })
+        }
+        it {
+          should contain_sensu_cluster_role_binding('system:user').with({
+            'ensure'   => 'present',
+            'role_ref' => 'system:user',
+            'subjects' => [
+              {
+                'type' => 'Group',
+                'name' => 'system:users'
+              },
+            ],
+          })
+        }
+      end
+    end
+  end
+end

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -8,13 +8,14 @@ describe 'sensu::backend::resources', :type => :class do
         it { should compile }
         it { should have_sensu_namespace_resource_count(1) }
         it { should contain_sensu_namespace('default').with_ensure('present') }
-        it { should have_sensu_user_resource_count(1) }
+        it { should have_sensu_user_resource_count(2) }
         it {
           should contain_sensu_user('agent').with({
-            'ensure'   => 'present',
-            'disabled' => 'false',
-            'password' => 'P@ssw0rd!',
-            'groups'   => ['system:agents'],
+            'ensure'       => 'present',
+            'disabled'     => 'false',
+            'password'     => 'P@ssw0rd!',
+            'old_password' => nil,
+            'groups'       => ['system:agents'],
           })
         }
         it { should have_sensu_cluster_role_resource_count(6) }

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -12,6 +12,7 @@ describe 'sensu::backend', :type => :class do
         it { should contain_class('sensu') }
         it { should_not contain_class('sensu::agent') }
         it { should contain_class('sensu::ssl').that_comes_before('Sensu_configure[puppet]') }
+        it { should contain_class('sensu::backend::resources') }
 
         it {
           should contain_package('sensu-go-cli').with({


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add resources that are present on fresh install of sensu-go.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If someone does aggressive resource purging with something like `resources { 'sensu_user': purge => true }` they would break their install unless the default agent user is defined.  The same goes for other resources defined, some would break sensu-go if missing others may just cause loss of functionality like missing roles.

