### PR TITLE
Document name handling for sensu_silenced

### DIFF
--- a/lib/puppet/type/sensu_silenced.rb
+++ b/lib/puppet/type/sensu_silenced.rb
@@ -7,7 +7,12 @@ Puppet::Type.newtype(:sensu_silenced) do
   desc <<-DESC
 @summary Manages Sensu silencing
 
-The name of `sensu_silenced` can be used to define `check` and `subscription`.
+The name of a `sensu_silenced` resource may not match the name returned by sensuctl.
+The name from sensuctl will take the form of `subscription:check`.
+If you wish to have a `sensu_silenced` resource name match sensuctl then define the name
+using the `subscription:check` format and do not define `subscription` or `check` properties.
+
+The `subscription` and `check` properties take precedence over value in the name if name takes the form `subscription:check`.
 
 @example Create a silencing for all checks with subscription entity:sensu_agent
   sensu_silenced { 'test':
@@ -23,6 +28,18 @@ The name of `sensu_silenced` can be used to define `check` and `subscription`.
 @example Define silencing using composite name where `subscription=linux` and `check=check-http`.
   sensu_silenced { 'linux:check-http':
     ensure => 'present',
+  }
+
+@example Define silencing where subscription is linux and check is check-http. The `subscription` property overrides the value from name.
+  sensu_silenced { 'test:check-http':
+    ensure       => 'present',
+    subscription => 'linux',
+  }
+
+@example Define silencing where subscription is linux and check is test. The `check` property overrides the value from name.
+  sensu_silenced { 'linux:check-http':
+    ensure => 'present',
+    check  => 'test',
   }
 
 **Autorequires**:

--- a/spec/unit/sensu_silenced_spec.rb
+++ b/spec/unit/sensu_silenced_spec.rb
@@ -47,6 +47,30 @@ describe Puppet::Type.type(:sensu_silenced) do
     expect(silenced[:check]).to eq('mysql_status')
   end
 
+  it 'should ignore name if subscription and check defined' do
+    config[:name] = 'linux:ping'
+    config[:subscription] = 'test'
+    config[:check] = 'foo'
+    expect(silenced[:subscription]).to eq('test')
+    expect(silenced[:check]).to eq('foo')
+  end
+
+  it 'should ignore name subscription if subscription is defined' do
+    config[:name] = 'linux:ping'
+    config[:subscription] = 'test'
+    config.delete(:check)
+    expect(silenced[:subscription]).to eq('test')
+    expect(silenced[:check]).to eq('ping')
+  end
+
+  it 'should ignore name check if check is defined' do
+    config[:name] = 'linux:ping'
+    config[:check] = 'test'
+    config.delete(:subscription)
+    expect(silenced[:subscription]).to eq('linux')
+    expect(silenced[:check]).to eq('test')
+  end
+
   defaults = {
     'namespace': 'default',
     'expire': -1,


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update docs for `sensu_silenced` to describe when name is used and when it's not used.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1015 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Try to document that the name in Puppet may not match sensuctl output.