### PR TITLE
Add show_diff parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ associated to `linux` and `apache-servers` subscriptions.
 ### Advanced agent
 
 If you wish to change the `agent` password you must provide the new and old password.
+It's advisable to set `show_diff` to `false` to avoid exposing the agent password.
 
 ```puppet
 class { 'sensu::backend':
@@ -131,6 +132,7 @@ class { 'sensu::agent':
   config_hash => {
     'password' => 'supersecret',
   },
+  show_diff   => false,
 }
 ```
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -28,6 +28,8 @@
 #   The protocol prefix of `ws://` or `wss://` are optional and will be determined
 #   based on `sensu::use_ssl` parameter by default.
 #   Passing `backend-url` as part of `config_hash` takes precedence.
+# @param show_diff
+#   Sets show_diff parameter for agent.yml configuration file
 #
 class sensu::agent (
   Optional[String] $version = undef,
@@ -37,6 +39,7 @@ class sensu::agent (
   Boolean $service_enable = true,
   Hash $config_hash = {},
   Array[Sensu::Backend_URL] $backends = ['localhost:8081'],
+  Boolean $show_diff = true,
 ) {
 
   include ::sensu
@@ -73,11 +76,12 @@ class sensu::agent (
   }
 
   file { 'sensu_agent_config':
-    ensure  => 'file',
-    path    => "${etc_dir}/agent.yml",
-    content => to_yaml($config),
-    require => Package['sensu-go-agent'],
-    notify  => Service['sensu-agent'],
+    ensure    => 'file',
+    path      => "${etc_dir}/agent.yml",
+    content   => to_yaml($config),
+    show_diff => $show_diff,
+    require   => Package['sensu-go-agent'],
+    notify    => Service['sensu-agent'],
   }
 
   service { 'sensu-agent':

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -42,6 +42,8 @@
 #   The sensu agent old password needed when changing agent_password
 # @param include_default_resources
 #   Sets if default sensu resources should be included
+# @param show_diff
+#   Sets show_diff parameter for backend.yml configuration file
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -61,6 +63,7 @@ class sensu::backend (
   String $agent_password = 'P@ssw0rd!',
   Optional[String] $agent_old_password = undef,
   Boolean $include_default_resources = true,
+  Boolean $show_diff = true,
 ) {
 
   include ::sensu
@@ -166,11 +169,12 @@ class sensu::backend (
   }
 
   file { 'sensu_backend_config':
-    ensure  => 'file',
-    path    => "${etc_dir}/backend.yml",
-    content => to_yaml($config),
-    require => Package['sensu-go-backend'],
-    notify  => Service['sensu-backend'],
+    ensure    => 'file',
+    path      => "${etc_dir}/backend.yml",
+    content   => to_yaml($config),
+    show_diff => $show_diff,
+    require   => Package['sensu-go-backend'],
+    notify    => Service['sensu-backend'],
   }
 
   service { 'sensu-backend':

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -58,15 +58,21 @@ describe 'sensu::agent', :type => :class do
 
         it {
           should contain_file('sensu_agent_config').with({
-            'ensure'  => 'file',
-            'path'    => '/etc/sensu/agent.yml',
-            'content' => agent_content,
-            'require' => 'Package[sensu-go-agent]',
-            'notify'  => 'Service[sensu-agent]',
+            'ensure'    => 'file',
+            'path'      => '/etc/sensu/agent.yml',
+            'content'   => agent_content,
+            'show_diff' => 'true',
+            'require'   => 'Package[sensu-go-agent]',
+            'notify'    => 'Service[sensu-agent]',
           })
         }
 
         it { should contain_service('sensu-agent').without_notify }
+      end
+
+      context 'with show_diff => false' do
+        let(:params) {{ :show_diff => false }}
+        it { should contain_file('sensu_agent_config').with_show_diff('false') }
       end
 
       # Test various backend values

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -108,11 +108,12 @@ describe 'sensu::backend', :type => :class do
 
         it {
           should contain_file('sensu_backend_config').with({
-            'ensure'  => 'file',
-            'path'    => '/etc/sensu/backend.yml',
-            'content' => backend_content,
-            'require' => 'Package[sensu-go-backend]',
-            'notify'  => 'Service[sensu-backend]',
+            'ensure'    => 'file',
+            'path'      => '/etc/sensu/backend.yml',
+            'content'   => backend_content,
+            'show_diff' => 'true',
+            'require'   => 'Package[sensu-go-backend]',
+            'notify'    => 'Service[sensu-backend]',
           })
         }
 
@@ -168,6 +169,11 @@ describe 'sensu::backend', :type => :class do
         }
 
         it { should contain_service('sensu-backend').without_notify }
+      end
+
+      context 'with show_diff => false' do
+        let(:params) {{ :show_diff => false }}
+        it { should contain_file('sensu_backend_config').with_show_diff('false') }
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `show_diff` that defaults to `false`. Diffs can be re-enabled globally via `sensu` class or for a specific role in either `sensu::agent` or `sensu::backend`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `agent.yml` file can contain a password and thus by default a diff should be suppressed.
