### PR TITLE
Do not expose changed password and pass properties

### DIFF
--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -58,6 +58,15 @@ Puppet::Type.newtype(:sensu_api_config) do
 
   newproperty(:password) do
     desc "The password use for client authentication against the Sensu API"
+    def change_to_s(currentvalue, newvalue)
+      return "changed password"
+    end
+    def is_to_s(currentvalue)
+      return '[old password redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new password redacted]'
+    end
   end
 
   newproperty(:ssl_port) do
@@ -73,6 +82,15 @@ Puppet::Type.newtype(:sensu_api_config) do
 
   newproperty(:ssl_keystore_password) do
     desc "The SSL certificate keystore password. Enterprise only feature."
+    def change_to_s(currentvalue, newvalue)
+      return "changed ssl_keystore_password"
+    end
+    def is_to_s(currentvalue)
+      return '[old ssl_keystore_password redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new ssl_keystore_password redacted]'
+    end
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/sensu_enterprise_dashboard_api_config.rb
+++ b/lib/puppet/type/sensu_enterprise_dashboard_api_config.rb
@@ -84,6 +84,16 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_api_config) do
     desc "The password of the Sensu API. Leave empty for no authentication."
 
     newvalues(/.+/)
+
+    def change_to_s(currentvalue, newvalue)
+      return "changed pass"
+    end
+    def is_to_s(currentvalue)
+      return '[old pass redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new pass redacted]'
+    end
   end
 
   autorequire(:package) do

--- a/lib/puppet/type/sensu_enterprise_dashboard_config.rb
+++ b/lib/puppet/type/sensu_enterprise_dashboard_config.rb
@@ -54,6 +54,15 @@ Puppet::Type.newtype(:sensu_enterprise_dashboard_config) do
 
   newproperty(:pass) do
     desc "A password to enable simple authentication and restrict access to the dashboard. Leave blank along with user to disable simple authentication."
+    def change_to_s(currentvalue, newvalue)
+      return "changed pass"
+    end
+    def is_to_s(currentvalue)
+      return '[old pass redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new pass redacted]'
+    end
   end
 
   newproperty(:auth) do

--- a/lib/puppet/type/sensu_rabbitmq_config.rb
+++ b/lib/puppet/type/sensu_rabbitmq_config.rb
@@ -91,6 +91,15 @@ Puppet::Type.newtype(:sensu_rabbitmq_config) do
 
   newproperty(:password) do
     desc 'The password to use when connecting to RabbitMQ'
+    def change_to_s(currentvalue, newvalue)
+      return "changed password"
+    end
+    def is_to_s(currentvalue)
+      return '[old password redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new password redacted]'
+    end
   end
 
   newproperty(:vhost) do

--- a/lib/puppet/type/sensu_redis_config.rb
+++ b/lib/puppet/type/sensu_redis_config.rb
@@ -80,6 +80,15 @@ Puppet::Type.newtype(:sensu_redis_config) do
 
   newproperty(:password) do
     desc "The password used to connect to Redis"
+    def change_to_s(currentvalue, newvalue)
+      return "changed password"
+    end
+    def is_to_s(currentvalue)
+      return '[old password redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new password redacted]'
+    end
   end
 
   newproperty(:reconnect_on_error, :parent => PuppetX::Sensu::BooleanProperty) do

--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -59,13 +59,14 @@ class sensu::rabbitmq::config {
     # URI provided
     if $::sensu::rabbitmq_ssl_private_key and $::sensu::rabbitmq_ssl_private_key =~ /^puppet:\/\// {
       file { "${ssl_dir}/key.pem":
-        ensure  => file,
-        source  => $::sensu::rabbitmq_ssl_private_key,
-        owner   => $::sensu::user,
-        group   => $::sensu::group,
-        mode    => $::sensu::file_mode,
-        require => File[$ssl_dir],
-        before  => Sensu_rabbitmq_config[$::fqdn],
+        ensure    => file,
+        source    => $::sensu::rabbitmq_ssl_private_key,
+        owner     => $::sensu::user,
+        group     => $::sensu::group,
+        mode      => $::sensu::file_mode,
+        show_diff => false,
+        require   => File[$ssl_dir],
+        before    => Sensu_rabbitmq_config[$::fqdn],
       }
 
       $ssl_private_key = "${ssl_dir}/key.pem"
@@ -73,13 +74,14 @@ class sensu::rabbitmq::config {
     # create file with contents of the variable
     } elsif $::sensu::rabbitmq_ssl_private_key and $::sensu::rabbitmq_ssl_private_key =~ /BEGIN RSA PRIVATE KEY/ {
       file { "${ssl_dir}/key.pem":
-        ensure  => file,
-        content => $::sensu::rabbitmq_ssl_private_key,
-        owner   => $::sensu::user,
-        group   => $::sensu::group,
-        mode    => $::sensu::file_mode,
-        require => File[$ssl_dir],
-        before  => Sensu_rabbitmq_config[$::fqdn],
+        ensure    => file,
+        content   => $::sensu::rabbitmq_ssl_private_key,
+        owner     => $::sensu::user,
+        group     => $::sensu::group,
+        mode      => $::sensu::file_mode,
+        show_diff => false,
+        require   => File[$ssl_dir],
+        before    => Sensu_rabbitmq_config[$::fqdn],
       }
 
       $ssl_private_key = "${ssl_dir}/key.pem"

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -117,7 +117,12 @@ describe 'sensu', :type => :class do
 
       it { should contain_file('/etc/sensu/ssl').with_ensure('directory') }
       it { should contain_file('/etc/sensu/ssl/cert.pem').with_source('puppet:///modules/sensu/cert.pem') }
-      it { should contain_file('/etc/sensu/ssl/key.pem').with_source('puppet:///modules/sensu/key.pem') }
+      it {
+        should contain_file('/etc/sensu/ssl/key.pem').with({
+          :source    => 'puppet:///modules/sensu/key.pem',
+          :show_diff => false,
+        })
+      }
 
       it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
         :port            => '1234',
@@ -143,7 +148,12 @@ describe 'sensu', :type => :class do
 
       it { should contain_file('/etc/sensu/ssl').with_ensure('directory') }
       it { should contain_file('/etc/sensu/ssl/cert.pem').with_content(rabbitmq_ssl_cert_chain_test) }
-      it { should contain_file('/etc/sensu/ssl/key.pem').with_content(rabbitmq_ssl_private_key_test) }
+      it {
+        should contain_file('/etc/sensu/ssl/key.pem').with({
+          :content   => rabbitmq_ssl_private_key_test,
+          :show_diff => 'false',
+        })
+      }
 
       it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
         :port            => '1234',
@@ -188,7 +198,12 @@ describe 'sensu', :type => :class do
 
       it { should contain_file('/etc/sensu/ssl').with_ensure('directory') }
       it { should contain_file('/etc/sensu/ssl/cert.pem').with_content(rabbitmq_ssl_cert_chain_test) }
-      it { should contain_file('/etc/sensu/ssl/key.pem').with_content(rabbitmq_ssl_private_key_test) }
+      it {
+        should contain_file('/etc/sensu/ssl/key.pem').with({
+          :content    => rabbitmq_ssl_private_key_test,
+          :show_diff  => 'false',
+        })
+      }
       it { should contain_sensu_rabbitmq_config('hostname.domain.com').with_cluster(cluster_config) }
 
       context 'with rabbitmq_* class parameters also specified (#598)' do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Do not expose changed password and pass properties
Disable show_diff for private keys

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #886 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Passwords should not be logged when changed to avoid exposure and private keys should not log a diff.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Using vagrant `sensu-server`.  Example output when I changed passwords:

```
    sensu-server: Notice: /Stage[main]/Sensu::Rabbitmq::Config/Sensu_rabbitmq_config[sensu-server.example.com]/password: changed password
    sensu-server: Notice: /Stage[main]/Sensu::Api/Sensu_api_config[sensu-server.example.com]/password: changed password
```