### PR TITLE
Fix Amazon 2 to use EL7 repos

### DIFF
--- a/manifests/repo/yum.pp
+++ b/manifests/repo/yum.pp
@@ -8,9 +8,14 @@ class sensu::repo::yum {
     if $::sensu::repo_source {
       $url = $::sensu::repo_source
     } else {
-      $releasever = $::operatingsystem ? {
-        'Amazon' => '6',
-        default  => '$releasever',
+      if $::operatingsystem == 'Amazon' {
+        if $facts['os']['release']['major'] =~ /^201\d$/ {
+          $releasever = '6'
+        } else {
+          $releasever = '7'
+        }
+      } else {
+        $releasever = '$releasever'
       }
       $url = $::sensu::repo ? {
         'unstable'  => "https://sensu.global.ssl.fastly.net/yum-unstable/${releasever}/\$basearch/",

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
       "operatingsystem": "Amazon",
       "operatingsystemrelease": [
         "2018.03",
-        "2.0"
+        "2"
       ]
     }
   ],

--- a/spec/classes/sensu_repo_yum_spec.rb
+++ b/spec/classes/sensu_repo_yum_spec.rb
@@ -24,9 +24,12 @@ describe 'sensu' do
     ) }
   end
 
-  context 'on Amazon Linux' do
+  context 'on Amazon Linux 2018.x' do
     let(:facts) do
       {
+        :os              => {
+          :release  => { :major => '2018' },
+        },
         :operatingsystem => 'Amazon',
         :kernel          => 'Linux',
       }
@@ -36,6 +39,28 @@ describe 'sensu' do
     it { should contain_yumrepo('sensu').with(
       :enabled  => '1',
       :baseurl  => 'https://sensu.global.ssl.fastly.net/yum/6/$basearch/',
+      :gpgcheck => '0',
+      :name     => 'sensu',
+      :descr    => 'sensu',
+      :before   => 'Package[sensu]',
+    ) }
+  end
+
+  context 'on Amazon Linux 2' do
+    let(:facts) do
+      {
+        :os              => {
+          :release  => { :major => '2' },
+        },
+        :operatingsystem => 'Amazon',
+        :kernel          => 'Linux',
+      }
+    end
+
+    it { should create_class('sensu::repo::yum') }
+    it { should contain_yumrepo('sensu').with(
+      :enabled  => '1',
+      :baseurl  => 'https://sensu.global.ssl.fastly.net/yum/7/$basearch/',
       :gpgcheck => '0',
       :name     => 'sensu',
       :descr    => 'sensu',


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use EL7 repo for Amazon 2.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Amazon 2 is systemd so should use EL7 RPMs.  The logic matches logic used in sensu2 branch.
