### PR TITLE
Fix Windows dsc_service when client=>false

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -28,10 +28,12 @@ class sensu::client (
       true: {
         $service_ensure = $client_service_ensure
         $service_enable = $client_service_enable
+        $dsc_ensure     = 'present'
       }
       default: {
         $service_ensure = 'stopped'
         $service_enable = false
+        $dsc_ensure     = 'absent'
       }
     }
     case $::osfamily {
@@ -68,7 +70,7 @@ class sensu::client (
         # are handled by Service[sensu-client]
         # See https://tickets.puppetlabs.com/browse/MODULES-4570
         dsc_service { 'sensu-client':
-          dsc_ensure      => present,
+          dsc_ensure      => $dsc_ensure,
           dsc_name        => 'sensu-client',
           dsc_credential  => $::sensu::windows_service_user,
           dsc_displayname => 'Sensu Client',

--- a/spec/classes/sensu_service_spec.rb
+++ b/spec/classes/sensu_service_spec.rb
@@ -156,6 +156,11 @@ describe 'sensu', :type => :class do
           let(:params) { {:windows_logrotate => true, :windows_log_number => '242' } }
           it { should contain_file('C:/opt/sensu/bin/sensu-client.xml').with_content(%r{^\s*<keepFiles>242</keepFiles>$}) }
         end
+
+        context 'client => false' do
+          let(:params) { {:client => false} }
+          it { should contain_dsc_service('sensu-client').with_dsc_ensure('absent') }
+        end
       end
     end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Set `dsc_service` to `absent` when `client => false`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1046

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Needed to pass current acceptance tests with Windows.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
beaker acceptance tests
