### PR TITLE
Replace deprecated Fixnum with Integer

### DIFF
--- a/lib/puppet/parser/functions/sensu_sorted_json.rb
+++ b/lib/puppet/parser/functions/sensu_sorted_json.rb
@@ -42,7 +42,7 @@ module JSON
 
     def sorted_generate(obj)
       case obj
-        when Fixnum, Float, TrueClass, FalseClass, NilClass
+        when Integer, Float, TrueClass, FalseClass, NilClass
           return obj.to_json
         when String
           # Convert quoted integers (string) to int
@@ -71,7 +71,7 @@ module JSON
 
       case obj
 
-        when Fixnum, Float, TrueClass, FalseClass, NilClass
+        when Integer, Float, TrueClass, FalseClass, NilClass
           return obj.to_json
 
         when String


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace `Fixnum` with `Integer`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Ruby 2.4 deprecated `Fixnum` in favor of `Integer`.  All versions of Puppet supported use versions of Ruby that produce deprecation warnings with `Fixnum`:

```
/etc/puppetlabs/code/environments/production/modules/sensu/lib/puppet/parser/functions/sensu_sorted_json.rb:74: warning: constant ::Fixnum is deprecated
```

https://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html