### PR TITLE
Do not enable rabbitmq ssl for empty cert or key

### DIFF
--- a/manifests/rabbitmq/config.pp
+++ b/manifests/rabbitmq/config.pp
@@ -90,11 +90,14 @@ class sensu::rabbitmq::config {
     } else {
       $ssl_private_key = $::sensu::rabbitmq_ssl_private_key
     }
-
-    $enable_ssl = true
   } else {
     $ssl_cert_chain = undef
     $ssl_private_key = undef
+  }
+
+  if ($ssl_cert_chain and $ssl_cert_chain != '') or ($ssl_private_key and $ssl_private_key != '') {
+    $enable_ssl = true
+  } else {
     $enable_ssl = $::sensu::rabbitmq_ssl
   }
 

--- a/spec/classes/sensu_rabbitmq_spec.rb
+++ b/spec/classes/sensu_rabbitmq_spec.rb
@@ -63,6 +63,7 @@ describe 'sensu', :type => :class do
   context 'rabbitmq config' do
     context 'no ssl (default)' do
       it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
+        :ssl_transport   => nil,
         :ssl_cert_chain  => nil,
         :ssl_private_key => nil
       ) }
@@ -89,6 +90,7 @@ describe 'sensu', :type => :class do
         :user            => 'sensuuser',
         :password        => 'sensupass',
         :vhost           => 'myvhost',
+        :ssl_transport   => 'true',
         :ssl_cert_chain  => '/etc/private/ssl/cert.pem',
         :ssl_private_key => '/etc/private/ssl/key.pem'
       ) }
@@ -165,6 +167,23 @@ describe 'sensu', :type => :class do
         :ssl_private_key => '/etc/sensu/ssl/key.pem'
       ) }
     end # when using key in variable
+
+    context 'when key and chain are empty' do
+      let(:params) { {
+        :rabbitmq_ssl_cert_chain  => '',
+        :rabbitmq_ssl_private_key => '',
+      } }
+
+      it { should contain_file('/etc/sensu/ssl').with_ensure('directory') }
+      it { should_not contain_file('/etc/sensu/ssl/cert.pem') }
+      it { should_not contain_file('/etc/sensu/ssl/key.pem') }
+
+      it { should contain_sensu_rabbitmq_config('hostname.domain.com').with(
+        :ssl_transport   => nil,
+        :ssl_cert_chain  => '',
+        :ssl_private_key => '',
+      ) }
+    end # when key and chain are empty
 
     context 'when using rabbitmq cluster' do
       let(:cluster_config) {


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
If `sensu:: rabbitmq_ssl_private_key` and `sensu:: rabbitmq_ssl_cert_chain` are empty, do not enable rabbitmq ssl if `sensu::rabbitmq_ssl` is `false`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Resolves #1050 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This treats the module parameter values of empty strings for key and cert the same as if the `sensu_rabbitmq_config` type is used directly.  For that type empty cert and key will not enable SSL as those are the defaults.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
