### PR TITLE
Use sensu-go test-creds subcommand to test user passwords

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,7 @@ end
 group :system_tests do
   gem 'beaker', '~> 4.x',             :require => false
   gem 'beaker-rspec',                 :require => false
-  gem 'beaker-puppet',                :require => false
+  gem 'beaker-puppet', '< 1.15.0',    :require => false
   gem 'beaker-docker',                :require => false
   gem 'serverspec',                   :require => false
   gem 'beaker-puppet_install_helper', :require => false

--- a/lib/puppet/provider/sensu_user/sensuctl.rb
+++ b/lib/puppet/provider/sensu_user/sensuctl.rb
@@ -97,6 +97,9 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
         if ! resource[:old_password]
           fail("old_password is manditory when changing a password")
         end
+        if ! password_insync?(resource[:name], resource[:old_password])
+          fail("old_password given for #{resource[:name]} is incorrect")
+        end
         sensuctl('user', 'change-password', resource[:name], '--current-password', resource[:old_password], '--new-password', @property_flush[:password])
         if resource[:configure] == :true
           sensuctl('configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password])

--- a/lib/puppet/provider/sensu_user/sensuctl.rb
+++ b/lib/puppet/provider/sensu_user/sensuctl.rb
@@ -52,32 +52,9 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
     if password.is_a?(Array)
       password = password[0]
     end
-    # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
-    #ret = execute(['sensuctl', 'user', 'test-creds', user, '--password', password], failonfail: false)
-    #exitstatus = ret.exitstatus
-    #exitstatus == 0
-    config = load_config(config_path)
-    api_url = config['api-url']
-    if api_url =~ /^https/
-      use_ssl = true
-    else
-      use_ssl = false
-    end
-    uri = URI(api_url)
-    http = Net::HTTP.new(uri.hostname, uri.port)
-    if Puppet[:debug]
-      http.set_debug_output($stdout)
-    end
-    http.use_ssl = use_ssl
-    if use_ssl
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    end
-    request = Net::HTTP::Get.new('/auth')
-    request.add_field("Accept", "application/json")
-    request.basic_auth(user, password)
-    response = http.request(request)
-    Puppet.debug("GET /auth returned #{response.code}")
-    response.kind_of?(Net::HTTPSuccess)
+    ret = execute(['sensuctl', 'user', 'test-creds', user, '--password', password], failonfail: false)
+    exitstatus = ret.exitstatus
+    exitstatus == 0
   end
 
   def initialize(value = {})

--- a/spec/acceptance/sensu_event_spec.rb
+++ b/spec/acceptance/sensu_event_spec.rb
@@ -36,9 +36,6 @@ describe 'sensu_event', if: RSpec.configuration.sensu_full do
       sensu_event { 'test for sensu_agent':
         ensure => 'resolve',
       }
-      sensu_event { 'keepalive for sensu_agent':
-        ensure => 'resolve',
-      }
       EOS
 
       apply_manifest_on(node, check_pp, :catch_failures => true)
@@ -62,9 +59,6 @@ describe 'sensu_event', if: RSpec.configuration.sensu_full do
       sensu_event { 'test for sensu_agent':
         ensure => 'absent',
       }
-      sensu_event { 'keepalive for sensu_agent':
-        ensure => 'absent',
-      }
       EOS
 
       # Stop sensu-agent on agent node to avoid re-creating event
@@ -76,10 +70,6 @@ describe 'sensu_event', if: RSpec.configuration.sensu_full do
     end
 
     describe command('sensuctl event info sensu_agent test'), :node => node do
-      its(:exit_status) { should_not eq 0 }
-    end
-
-    describe command('sensuctl event info sensu_agent keepalive'), :node => node do
       its(:exit_status) { should_not eq 0 }
     end
   end

--- a/spec/acceptance/sensu_event_spec.rb
+++ b/spec/acceptance/sensu_event_spec.rb
@@ -11,7 +11,7 @@ describe 'sensu_event', if: RSpec.configuration.sensu_full do
       }
       EOS
 
-      # There should be no changes
+      apply_manifest_on(node, pp, :catch_failures  => true)
       apply_manifest_on(node, pp, :catch_changes  => true)
     end
   end

--- a/spec/acceptance/sensu_event_spec.rb
+++ b/spec/acceptance/sensu_event_spec.rb
@@ -2,35 +2,81 @@ require 'spec_helper_acceptance'
 
 describe 'sensu_event', if: RSpec.configuration.sensu_full do
   node = hosts_as('sensu_backend')[0]
-  context 'default' do
+  agent = hosts_as('sensu_agent')[0]
+  context 'setup agent' do
     it 'should work without errors' do
       pp = <<-EOS
+      class { '::sensu': }
+      class { '::sensu::agent':
+        backends    => ['sensu_backend:8081'],
+        config_hash => {
+          'name' => 'sensu_agent',
+        }
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(agent, pp, :catch_failures => true)
+      apply_manifest_on(agent, pp, :catch_changes  => true)
+    end
+  end
+
+  context 'default' do
+    it 'should work without errors' do
+      check_pp = <<-EOS
       include ::sensu::backend
+      sensu_check { 'test':
+        command       => 'exit 1',
+        subscriptions => ['entity:sensu_agent'],
+        interval      => 3600,
+      }
+      EOS
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_event { 'test for sensu_agent':
+        ensure => 'resolve',
+      }
       sensu_event { 'keepalive for sensu_agent':
         ensure => 'resolve',
       }
       EOS
 
+      apply_manifest_on(node, check_pp, :catch_failures => true)
+      on node, 'sensuctl check execute test'
       apply_manifest_on(node, pp, :catch_failures  => true)
       apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    it 'should have resolved check' do
+      on node, 'sensuctl event info sensu_agent test --format json' do
+        data = JSON.parse(stdout)
+        expect(data['check']['status']).to eq(0)
+      end
     end
   end
 
   context 'ensure => absent' do
     it 'should remove without errors' do
-      # Stop sensu-agent on agent node to avoid re-creating event
-      apply_manifest_on(hosts_as('sensu_agent'),
-        "service { 'sensu-agent': ensure => 'stopped' }")
       pp = <<-EOS
       include ::sensu::backend
+      sensu_event { 'test for sensu_agent':
+        ensure => 'absent',
+      }
       sensu_event { 'keepalive for sensu_agent':
         ensure => 'absent',
       }
       EOS
 
+      # Stop sensu-agent on agent node to avoid re-creating event
+      apply_manifest_on(hosts_as('sensu_agent'),
+        "service { 'sensu-agent': ensure => 'stopped' }")
       # Run it twice and test for idempotency
       apply_manifest_on(node, pp, :catch_failures => true)
       apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+
+    describe command('sensuctl event info sensu_agent test'), :node => node do
+      its(:exit_status) { should_not eq 0 }
     end
 
     describe command('sensuctl event info sensu_agent keepalive'), :node => node do

--- a/spec/acceptance/sensu_user_spec.rb
+++ b/spec/acceptance/sensu_user_spec.rb
@@ -31,13 +31,8 @@ describe 'sensu_user', if: RSpec.configuration.sensu_full do
     end
 
     it 'should have valid password' do
-      # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
-      #exit_code = on(node, 'sensuctl user test-creds test --password password').exit_code
-      #expect(exit_code).to eq(0)
-      on node, 'curl -k -u test:password https://sensu_backend:8080/auth' do
-        data = JSON.parse(stdout)
-        expect(data.keys).to include('access_token')
-      end
+      exit_code = on(node, 'sensuctl user test-creds test --password password').exit_code
+      expect(exit_code).to eq(0)
     end
   end
 
@@ -71,13 +66,8 @@ describe 'sensu_user', if: RSpec.configuration.sensu_full do
       end
     end
     it 'should have valid password' do
-      # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
-      #exit_code = on(node, 'sensuctl user test-creds test --password password2').exit_code
-      #expect(exit_code).to eq(0)
-      on node, 'curl -k -u test:password2 https://sensu_backend:8080/auth' do
-        data = JSON.parse(stdout)
-        expect(data.keys).to include('access_token')
-      end
+      exit_code = on(node, 'sensuctl user test-creds test --password password2').exit_code
+      expect(exit_code).to eq(0)
     end
   end
 
@@ -98,13 +88,8 @@ describe 'sensu_user', if: RSpec.configuration.sensu_full do
     end
 
     it 'should have valid password' do
-      # Use this approach once merged: https://github.com/sensu/sensu-go/pull/2278
-      #exit_code = on(node, 'sensuctl user test-creds test --password password2').exit_code
-      #expect(exit_code).to eq(0)
-      on node, 'curl -k -u test:password3 https://sensu_backend:8080/auth' do
-        data = JSON.parse(stdout)
-        expect(data.keys).to include('access_token')
-      end
+      exit_code = on(node, 'sensuctl user test-creds test --password password3').exit_code
+      expect(exit_code).to eq(0)
     end
   end
 

--- a/spec/acceptance/sensu_user_spec.rb
+++ b/spec/acceptance/sensu_user_spec.rb
@@ -93,6 +93,21 @@ describe 'sensu_user', if: RSpec.configuration.sensu_full do
     end
   end
 
+  context 'invalid old_password' do
+    it 'should result in an error' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_user { 'test':
+        password     => 'password2',
+        old_password => 'password4',
+        groups       => ['read-only'],
+      }
+      EOS
+
+      apply_manifest_on(node, pp, :expect_failures => true)
+    end
+  end
+
   context 'ensure => absent' do
     it 'should result in error as unsupported' do
       pp = <<-EOS


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace temporary net/http API call for testing user passwords with new `sensuctl user test-creds` subcommand.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes couple check boxes for #901 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
sensu-go 5.1.1 added `sensuctl user test-creds` subcommand to test passwords.  This is much simpler than temporary net/http approach and much more likely to be supported on future versions of sensu-go.