### PR TITLE
Convert sensu_sorted_json legacy function to new Ruby function

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,7 +48,7 @@ end
 group :system_tests do
   gem 'beaker', '~> 4.x',             :require => false
   gem 'beaker-rspec',                 :require => false
-  gem 'beaker-puppet',                :require => false
+  gem 'beaker-puppet', '< 1.15.0',    :require => false
   gem 'beaker-docker',                :require => false
   gem 'beaker-vagrant',               :require => false
   gem 'serverspec',                   :require => false

--- a/lib/puppet/functions/sensu_sorted_json.rb
+++ b/lib/puppet/functions/sensu_sorted_json.rb
@@ -119,80 +119,60 @@ module JSON
   end # end class
 end # end module
 
-module Puppet::Parser::Functions
-  newfunction(:sensu_sorted_json, :type => :rvalue, :doc => <<-EOS
-This function takes unsorted hash and outputs JSON object making sure the keys are sorted.
-Optionally you can pass a boolean as the second parameter, which controls if
-the output is pretty formatted.
+# This function takes unsorted hash and outputs JSON object making sure the keys are sorted.
+# Optionally you can pass a boolean as the second parameter, which controls if
+# the output is pretty formatted.
+Puppet::Functions.create_function(:sensu_sorted_json) do
+  # @param hash Hash to be sorted
+  # @param pretty Boolean that determines if output should be pretty format
+  # @return [String] Returns a JSON string
+  # @example Calling function without pretty
+  #   unsorted_hash = {
+  #     'client_addr' => '127.0.0.1',
+  #     'bind_addr'   => '192.168.34.56',
+  #     'start_join'  => [
+  #       '192.168.34.60',
+  #       '192.168.34.61',
+  #       '192.168.34.62',
+  #     ],
+  #     'ports'       => {
+  #       'rpc'   => 8567,
+  #       'https' => 8500,
+  #       'http'  => -1,
+  #     },
+  #   }
+  #   sorted_json(unsorted_hash)
+  #
+  #   {"bind_addr":"192.168.34.56","client_addr":"127.0.0.1",
+  #   "ports":{"http":-1,"https":8500,"rpc":8567},
+  #   "start_join":["192.168.34.60","192.168.34.61","192.168.34.62"]}
+  # @example Calling function with pretty output
+  #   sorted_json(unsorted_hash, true)
+  #
+  #   {
+  #       "bind_addr": "192.168.34.56",
+  #       "client_addr": "127.0.0.1",
+  #       "ports": {
+  #           "http": -1,
+  #           "https": 8500,
+  #           "rpc": 8567
+  #       },
+  #       "start_join": [
+  #           "192.168.34.60",
+  #           "192.168.34.61",
+  #           "192.168.34.62"
+  #       ]
+  #   }
+  dispatch :sort_json do
+    param 'Hash', :hash
+    optional_param 'Boolean', :pretty
+  end
 
-*Examples:*
-
-    -------------------
-    -- UNSORTED HASH --
-    -------------------
-    unsorted_hash = {
-      'client_addr' => '127.0.0.1',
-      'bind_addr'   => '192.168.34.56',
-      'start_join'  => [
-        '192.168.34.60',
-        '192.168.34.61',
-        '192.168.34.62',
-      ],
-      'ports'       => {
-        'rpc'   => 8567,
-        'https' => 8500,
-        'http'  => -1,
-      },
-    }
-
-    -----------------
-    -- SORTED JSON --
-    -----------------
-
-    sorted_json(unsorted_hash)
-
-    {"bind_addr":"192.168.34.56","client_addr":"127.0.0.1",
-    "ports":{"http":-1,"https":8500,"rpc":8567},
-    "start_join":["192.168.34.60","192.168.34.61","192.168.34.62"]}
-
-    ------------------------
-    -- PRETTY SORTED JSON --
-    ------------------------
-    Params: data <hash>, pretty <true|false>.
-
-    sorted_json(unsorted_hash, true)
-
-    {
-        "bind_addr": "192.168.34.56",
-        "client_addr": "127.0.0.1",
-        "ports": {
-            "http": -1,
-            "https": 8500,
-            "rpc": 8567
-        },
-        "start_join": [
-            "192.168.34.60",
-            "192.168.34.61",
-            "192.168.34.62"
-        ]
-    }
-
-    EOS
-  ) do |args|
-
-    raise(Puppet::ParseError, "sensu_sorted_json(): Wrong number of arguments " +
-      "given (#{args.size} for 1 or 2)") unless args.size.between?(1,2)
-
-    unsorted_hash = args[0]      || {}
-    pretty        = args[1]      || false
-    indent_len    = 4
-
-    unsorted_hash.reject! {|key, value| value == :undef }
-
+  def sort_json(hash, pretty = false)
     if pretty
-      return JSON.sorted_pretty_generate(unsorted_hash, indent_len) << "\n"
+      return JSON.sorted_pretty_generate(hash, 4) << "\n"
     else
-      return JSON.sorted_generate(unsorted_hash)
+      return JSON.sorted_generate(hash)
     end
   end
 end

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -34,6 +34,14 @@ describe 'sensu class', :unless => UNSUPPORTED_PLATFORMS.include?(fact('osfamily
           rabbitmq_password        => 'secret',
           rabbitmq_host            => '127.0.0.1',
         }
+        sensu::handler { 'default':
+          command => "mail -s 'sensu alert' ops@example.com",
+        }
+        sensu::check { 'check_ntp':
+          command     => 'PATH=$PATH:/usr/lib64/nagios/plugins check_ntp_time -H pool.ntp.org -w 30 -c 60',
+          handlers    => 'default',
+          subscribers => 'sensu-test',
+        }
         EOS
 
         # Run it twice and test for idempotency

--- a/spec/functions/sensu_sorted_json_spec.rb
+++ b/spec/functions/sensu_sorted_json_spec.rb
@@ -3,8 +3,8 @@ describe 'sensu_sorted_json' do
   it { is_expected.not_to eq(nil) }
 
   describe 'should error when expected' do
-    it { is_expected.to run.with_params.and_raise_error(Puppet::ParseError, /0 for 1 or 2/) }
-    it { is_expected.to run.with_params(1,2,3).and_raise_error(Puppet::ParseError, /3 for 1 or 2/) }
+    it { is_expected.to run.with_params.and_raise_error(/expects between 1 and 2 arguments, got none/) }
+    it { is_expected.to run.with_params(1,2,3).and_raise_error(/expects between 1 and 2 arguments, got 3/) }
   end
 
   input_hash = {


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Convert `sensu_sorted_json` that was Legacy Puppet 3 format to new Ruby function format introduced in Puppet 4.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1055 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This should fix issue raised in #1055 where Puppet 6.2.0 does not allow legacy function to define Ruby functions.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran `vagrant up sensu-server --provision` on existing Vagrant VM and no changes took place.