### PR TITLE
Sensu2 agent ssl

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -45,15 +45,19 @@ class sensu::agent (
   include ::sensu
 
   $etc_dir = $::sensu::etc_dir
+  $ssl_dir = $::sensu::ssl_dir
   $use_ssl = $::sensu::use_ssl
   $_version = pick($version, $::sensu::version)
 
   if $use_ssl {
     $backend_protocol = 'wss'
+    $ssl_config = {
+      'trusted-ca-file' => "${ssl_dir}/ca.crt",
+    }
     $service_subscribe = Class['::sensu::ssl']
-  }
-  else {
+  } else {
     $backend_protocol = 'ws'
+    $ssl_config = {}
     $service_subscribe = undef
   }
   $backend_urls = $backends.map |$backend| {
@@ -66,7 +70,7 @@ class sensu::agent (
   $default_config = {
     'backend-url' => $backend_urls,
   }
-  $config = $default_config + $config_hash
+  $config = $default_config + $ssl_config + $config_hash
 
   package { 'sensu-go-agent':
     ensure  => $_version,

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -32,6 +32,9 @@
 #   The SSL certificate source
 # @param ssl_key_source
 #   The SSL private key source
+# @param ssl_add_ca_trust
+#   Boolean that determines if SSL CA should be added
+#   to the system's trust store
 # @param password
 #   Sensu backend admin password used to confiure sensuctl.
 # @param old_password
@@ -58,6 +61,7 @@ class sensu::backend (
   Stdlib::Port $url_port = 8080,
   String $ssl_cert_source = $facts['puppet_hostcert'],
   String $ssl_key_source = $facts['puppet_hostprivkey'],
+  Boolean $ssl_add_ca_trust = true,
   String $password = 'P@ssw0rd!',
   Optional[String] $old_password = undef,
   String $agent_password = 'P@ssw0rd!',
@@ -148,6 +152,19 @@ class sensu::backend (
       mode      => '0600',
       show_diff => false,
       notify    => Service['sensu-backend'],
+    }
+    # Needed for sensuctl
+    if $ssl_add_ca_trust {
+      ensure_packages(['openssl'])
+      include ::trusted_ca
+      trusted_ca::ca { 'sensu-ca':
+        source  => "${::sensu::ssl_dir}/ca.crt",
+        require => [
+          Package['openssl'],
+          File['sensu_ssl_ca'],
+        ],
+        before  => Sensu_configure['puppet'],
+      }
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -36,10 +36,6 @@
 # @param ssl_ca_source
 #   Source of SSL CA used by sensu services
 #
-# @param ssl_add_ca_trust
-#   Boolean that determines if SSL CA should be added
-#   to the system's trust store
-#
 class sensu (
   String $version = 'installed',
   Stdlib::Absolutepath $etc_dir = '/etc/sensu',
@@ -51,7 +47,6 @@ class sensu (
   Boolean $manage_repo = true,
   Boolean $use_ssl = true,
   String $ssl_ca_source = $facts['puppet_localcacert'],
-  Boolean $ssl_add_ca_trust = true,
 ) {
 
   if $manage_repo {

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -24,16 +24,4 @@ class sensu::ssl {
     show_diff => false,
     source    => $::sensu::ssl_ca_source,
   }
-
-  if $::sensu::ssl_add_ca_trust {
-    ensure_packages(['openssl'])
-    include ::trusted_ca
-    trusted_ca::ca { 'sensu-ca':
-      source  => "${::sensu::ssl_dir}/ca.crt",
-      require => [
-        Package['openssl'],
-        File['sensu_ssl_ca'],
-      ],
-    }
-  }
 }

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -23,6 +23,7 @@ describe 'sensu::agent', :type => :class do
           |---
           |backend-url:
           |- wss://localhost:8081
+          |trusted-ca-file: "/etc/sensu/ssl/ca.crt"
         END
 
         it {
@@ -102,6 +103,7 @@ describe 'sensu::agent', :type => :class do
             |---
             |backend-url:
             |- #{backend}
+            |trusted-ca-file: "/etc/sensu/ssl/ca.crt"
           END
 
           it {

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -13,6 +13,7 @@ describe 'sensu::backend', :type => :class do
         it { should_not contain_class('sensu::agent') }
         it { should contain_class('sensu::ssl').that_comes_before('Sensu_configure[puppet]') }
         it { should contain_class('sensu::backend::resources') }
+        it { should contain_class('trusted_ca') }
 
         it {
           should contain_package('sensu-go-cli').with({
@@ -78,6 +79,19 @@ describe 'sensu::backend', :type => :class do
           })
         }
 
+        it { should contain_package('openssl') }
+
+        it {
+          should contain_trusted_ca__ca('sensu-ca').with({
+            'source'  => '/etc/sensu/ssl/ca.crt',
+            'require' => [
+              'Package[openssl]',
+              'File[sensu_ssl_ca]',
+            ],
+            'before'  => 'Sensu_configure[puppet]',
+          })
+        }
+
         it {
           should contain_package('sensu-go-backend').with({
             'ensure'  => 'installed',
@@ -127,6 +141,13 @@ describe 'sensu::backend', :type => :class do
         }
       end
 
+      context 'ssl_add_ca_trust => false' do
+        let(:params) { { :ssl_add_ca_trust => false } }
+        it { should_not contain_class('trusted_ca') }
+        it { should_not contain_package('openssl') }
+        it { should_not contain_trusted_ca__ca('sensu-ca') }
+      end
+
       context 'with use_ssl => false' do
         let(:pre_condition) do
           "class { 'sensu': use_ssl => false }"
@@ -152,6 +173,9 @@ describe 'sensu::backend', :type => :class do
 
         it { should_not contain_file('sensu_ssl_cert') }
         it { should_not contain_file('sensu_ssl_key') }
+        it { should_not contain_class('trusted_ca') }
+        it { should_not contain_package('openssl') }
+        it { should_not contain_trusted_ca__ca('sensu-ca') }
 
         backend_content = <<-END.gsub(/^\s+\|/, '')
           |---

--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -9,7 +9,6 @@ describe 'sensu::ssl', :type => :class do
 
         it { should create_class('sensu::ssl') }
         it { should contain_class('sensu') }
-        it { should contain_class('trusted_ca') }
 
         it {
           should contain_file('sensu_ssl_dir').with({
@@ -35,28 +34,6 @@ describe 'sensu::ssl', :type => :class do
             'source'    => '/dne/ca.pem',
           })
         }
-
-        it { should contain_package('openssl') }
-
-        it {
-          should contain_trusted_ca__ca('sensu-ca').with({
-            'source'  => '/etc/sensu/ssl/ca.crt',
-            'require' => [
-              'Package[openssl]',
-              'File[sensu_ssl_ca]',
-            ],
-          })
-        }
-      end
-
-      context 'ssl_add_ca_trust => false' do
-        let(:pre_condition) do
-          "class { 'sensu': ssl_add_ca_trust => false }"
-        end
-
-        it { should_not contain_class('trusted_ca') }
-        it { should_not contain_package('openssl') }
-        it { should_not contain_trusted_ca__ca('sensu-ca') }
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update agent SSL to define trusted-ca-file when SSL is enabled
The system trusted CAs are only updated for backends in order to support SSL with sensuctl.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Agent supported `trusted-ca-file` like backend so use that when SSL is enabled instead of adding the CA to system trust store.  Now the only thing needing system trust store updates is sensuctl.  Once https://github.com/sensu/sensu-go/pull/2627 is released we can remove the dependency on trusted_ca module.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
beaker and unit
