### PR TITLE
Puppet v6 now uses Ruby v2.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 5"
   - rvm: 2.4.4
     env: PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     env: PUPPET_GEM_VERSION="~> 6"
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.4.4
     sudo: required
@@ -34,7 +34,7 @@ matrix:
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
@@ -46,7 +46,7 @@ matrix:
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes
@@ -58,7 +58,7 @@ matrix:
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
@@ -70,7 +70,7 @@ matrix:
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
@@ -82,7 +82,7 @@ matrix:
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6
@@ -94,7 +94,7 @@ matrix:
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
@@ -106,7 +106,7 @@ matrix:
     env: BEAKER_set="ubuntu-1404" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1404" BEAKER_PUPPET_COLLECTION=puppet6
@@ -118,7 +118,7 @@ matrix:
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6
@@ -130,7 +130,7 @@ matrix:
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6
@@ -142,7 +142,7 @@ matrix:
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet5
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.5.1
+  - rvm: 2.5.3
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6


### PR DESCRIPTION
This ensures that we are testing the latest Puppet 6 release with the
correct version of Ruby.

https://puppet.com/docs/puppet/6.2/about_agent.html