### PR TITLE
Fix sensu facts to work with sensu-go 5.2.0 output

### DIFF
--- a/lib/facter/sensu_facts.rb
+++ b/lib/facter/sensu_facts.rb
@@ -19,7 +19,8 @@ module SensuFacts
       build = $1
     end
     built = nil
-    if output =~ /built '(.*)'$/
+    # Match value that is optionally wrapped in single quotes
+    if output =~ /built (?:')?([^']+)(?:')?$/
       built = $1
     end
     return version, build, built

--- a/spec/unit/facter/sensu_facts_spec.rb
+++ b/spec/unit/facter/sensu_facts_spec.rb
@@ -10,6 +10,13 @@ describe "SensuFacts" do
       expect(Facter.fact(:sensu_agent).value).to eq({'version' => '5.1.0', 'build' => 'b2ea9fcdb21e236e6e9a7de12225a6d90c786c57', 'built' => '2018-12-18T21:31:11+0000'})
     end
 
+    it 'returns version information for 5.2.0' do
+      allow(SensuFacts).to receive(:which).with('sensu-agent').and_return('/bin/sensu-agent')
+      allow(Facter::Core::Execution).to receive(:exec).with('/bin/sensu-agent version 2>&1').and_return("sensu-agent version 5.2.0#21a24d9, build 21a24d9cf073863d6c2b02c0b7acaae673e4f597, built 2019-02-06T22:08:44Z")
+      SensuFacts.add_agent_facts
+      expect(Facter.fact(:sensu_agent).value).to eq({'version' => '5.2.0', 'build' => '21a24d9cf073863d6c2b02c0b7acaae673e4f597', 'built' => '2019-02-06T22:08:44Z'})
+    end
+
     it 'returns nil' do
       allow(SensuFacts).to receive(:which).with('sensu-agent').and_return(nil)
       SensuFacts.add_agent_facts


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix sensu facts to handle output for version subcommands in sensu-go 5.2.0.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The output format for latest sensu-go release, 5.2.0, changed a bit and caused sensu facts `built` value to not be returned.  The fix is not assume built value is wrapped in quotes as 5.2.0 removed quotes around the timestamp.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Added unit tests.