### PR TITLE
Add Debian 8 and 9 support back

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -148,13 +148,6 @@ matrix:
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
-  # Allow failure for OSes not yet supported by sensu-go stable
-  # See https://github.com/sensu/sensu-go/issues/2498
-  allow_failures:
-  - env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
-  - env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
-  - env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
-  - env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
 
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -367,16 +367,13 @@ Linux.
 
 * EL 6
 * EL 7
+* Debian 8
+* Debian 9
 * Ubuntu 14.04 LTS
 * Ubuntu 16.04 LTS
 * Ubuntu 18.04 LTS
 * Amazon 2018.03
 * Amazon 2
-
-The following platforms will be supported again once packages are released.
-
-* Debian 8
-* Debian 9
 
 ## Development
 

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,13 @@
       ]
     },
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "14.04",


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support back for Debian 8 and Debian 9.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu-go 5.2.0 has packages for Debian 8 and Debian 9 so adding support back.
