### PR TITLE
Support trusting CA cert with sensuctl

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -10,8 +10,5 @@ fixtures:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1
       puppet_version: ">= 6.0.0"
-    trusted_ca:
-      repo: git://github.com/voxpupuli/puppet-trusted_ca.git
-      ref: v2.0.0
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,8 +10,5 @@ fixtures:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1
       puppet_version: ">= 6.0.0"
-    trusted_ca:
-      repo: git://github.com/voxpupuli/puppet-trusted_ca.git
-      ref: v2.0.0
   symlinks:
     sensu: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -165,30 +165,6 @@ class { 'sensu::agent':
 }
 ```
 
-If the certificate is already trusted by your operating system's trust store then you can disable adding the CA to system's trust.
-
-```puppet
-class { 'sensu':
-  ssl_add_ca_trust => false,
-}
-class { 'sensu::backend':
-  url_host        => 'sensu-backend.example.com',
-  ssl_cert_source => 'puppet:///modules/site_sensu/cert.pem',
-  ssl_key_source  => 'puppet:///modules/site_sensu/key.pem',
-}
-```
-```puppet
-class { 'sensu':
-  ssl_add_ca_trust => false,
-}
-class { 'sensu::agent':
-  backends    => ['sensu-backend.example.com:8081'],
-  config_hash => {
-    'subscriptions => ['linux', 'apache-servers'],
-  },
-}
-```
-
 To disable SSL support:
 
 ```puppet

--- a/lib/puppet/type/sensu_configure.rb
+++ b/lib/puppet/type/sensu_configure.rb
@@ -11,6 +11,7 @@ Puppet::Type.newtype(:sensu_configure) do
 * `Package[sensu-cli]`
 * `Service[sensu-backend]`
 * `Sensu_api_validator[sensu]`
+* `file` - Puppet will autorequire `file` resources defined in `trusted_ca_file` property.
 DESC
 
   extend PuppetX::Sensu::Type
@@ -37,6 +38,17 @@ DESC
   newparam(:bootstrap_password) do
     desc "Password to use when bootstrapping sensuctl"
     defaultto('P@ssw0rd!')
+  end
+
+  newproperty(:trusted_ca_file) do
+    desc "Path to trusted CA"
+    defaultto('/etc/sensu/ssl/ca.crt')
+  end
+
+  autorequire(:file) do
+    if self[:trusted_ca_file] && self[:trusted_ca_file] != 'absent'
+      [ self[:trusted_ca_file] ]
+    end
   end
 
   validate do

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -90,12 +90,13 @@ class sensu::backend (
     $service_subscribe = undef
   }
 
+  $url = "${url_protocol}://${url_host}:${url_port}"
   $default_config = {
     'state-dir' => $state_dir,
+    'api-url'   => $url,
   }
   $config = $default_config + $ssl_config + $config_hash
 
-  $url = "${url_protocol}://${url_host}:${url_port}"
 
   if $include_default_resources {
     include ::sensu::backend::resources

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -32,9 +32,6 @@
 #   The SSL certificate source
 # @param ssl_key_source
 #   The SSL private key source
-# @param ssl_add_ca_trust
-#   Boolean that determines if SSL CA should be added
-#   to the system's trust store
 # @param password
 #   Sensu backend admin password used to confiure sensuctl.
 # @param old_password
@@ -61,7 +58,6 @@ class sensu::backend (
   Stdlib::Port $url_port = 8080,
   String $ssl_cert_source = $facts['puppet_hostcert'],
   String $ssl_key_source = $facts['puppet_hostprivkey'],
-  Boolean $ssl_add_ca_trust = true,
   String $password = 'P@ssw0rd!',
   Optional[String] $old_password = undef,
   String $agent_password = 'P@ssw0rd!',
@@ -155,19 +151,6 @@ class sensu::backend (
       mode      => '0600',
       show_diff => false,
       notify    => Service['sensu-backend'],
-    }
-    # Needed for sensuctl
-    if $ssl_add_ca_trust {
-      ensure_packages(['openssl'])
-      include ::trusted_ca
-      trusted_ca::ca { 'sensu-ca':
-        source  => "${::sensu::ssl_dir}/ca.crt",
-        require => [
-          Package['openssl'],
-          File['sensu_ssl_ca'],
-        ],
-        before  => Sensu_configure['puppet'],
-      }
     }
   }
 

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -79,15 +79,17 @@ class sensu::backend (
 
   if $use_ssl {
     $url_protocol = 'https'
+    $trusted_ca_file = "${ssl_dir}/ca.crt"
     $ssl_config = {
       'cert-file'       => "${ssl_dir}/cert.pem",
       'key-file'        => "${ssl_dir}/key.pem",
-      'trusted-ca-file' => "${ssl_dir}/ca.crt",
+      'trusted-ca-file' => $trusted_ca_file,
     }
     $service_subscribe = Class['::sensu::ssl']
     Class['::sensu::ssl'] -> Sensu_configure['puppet']
   } else {
     $url_protocol = 'http'
+    $trusted_ca_file = 'absent'
     $ssl_config = {}
     $service_subscribe = undef
   }
@@ -121,6 +123,7 @@ class sensu::backend (
     username           => 'admin',
     password           => $password,
     bootstrap_password => 'P@ssw0rd!',
+    trusted_ca_file    => $trusted_ca_file,
   }
   sensu_user { 'admin':
     ensure        => 'present',

--- a/metadata.json
+++ b/metadata.json
@@ -46,7 +46,6 @@
     { "name": "puppet", "version_requirement": ">= 5.0.0 < 7.0.0" }
   ],
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.1 < 6.0.0" },
-    { "name": "puppet/trusted_ca", "version_requirement": ">= 2.0.0 < 3.0.0" }
+    { "name": "puppetlabs/stdlib", "version_requirement": ">= 4.25.1 < 6.0.0" }
   ]
 }

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -38,6 +38,7 @@ describe 'sensu::backend', :type => :class do
             'username'            => 'admin',
             'password'            => 'P@ssw0rd!',
             'bootstrap_password'  => 'P@ssw0rd!',
+            'trusted_ca_file'     => '/etc/sensu/ssl/ca.crt',
           })
         }
 
@@ -168,6 +169,7 @@ describe 'sensu::backend', :type => :class do
             'username'            => 'admin',
             'password'            => 'P@ssw0rd!',
             'bootstrap_password'  => 'P@ssw0rd!',
+            'trusted_ca_file'     => 'absent',
           })
         }
 

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -102,6 +102,7 @@ describe 'sensu::backend', :type => :class do
         backend_content = <<-END.gsub(/^\s+\|/, '')
           |---
           |state-dir: "/var/lib/sensu/sensu-backend"
+          |api-url: https://test.example.com:8080
           |cert-file: "/etc/sensu/ssl/cert.pem"
           |key-file: "/etc/sensu/ssl/key.pem"
           |trusted-ca-file: "/etc/sensu/ssl/ca.crt"
@@ -158,6 +159,7 @@ describe 'sensu::backend', :type => :class do
         backend_content = <<-END.gsub(/^\s+\|/, '')
           |---
           |state-dir: "/var/lib/sensu/sensu-backend"
+          |api-url: http://test.example.com:8080
         END
 
         it {

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -13,7 +13,6 @@ describe 'sensu::backend', :type => :class do
         it { should_not contain_class('sensu::agent') }
         it { should contain_class('sensu::ssl').that_comes_before('Sensu_configure[puppet]') }
         it { should contain_class('sensu::backend::resources') }
-        it { should contain_class('trusted_ca') }
 
         it {
           should contain_package('sensu-go-cli').with({
@@ -80,19 +79,6 @@ describe 'sensu::backend', :type => :class do
           })
         }
 
-        it { should contain_package('openssl') }
-
-        it {
-          should contain_trusted_ca__ca('sensu-ca').with({
-            'source'  => '/etc/sensu/ssl/ca.crt',
-            'require' => [
-              'Package[openssl]',
-              'File[sensu_ssl_ca]',
-            ],
-            'before'  => 'Sensu_configure[puppet]',
-          })
-        }
-
         it {
           should contain_package('sensu-go-backend').with({
             'ensure'  => 'installed',
@@ -142,13 +128,6 @@ describe 'sensu::backend', :type => :class do
         }
       end
 
-      context 'ssl_add_ca_trust => false' do
-        let(:params) { { :ssl_add_ca_trust => false } }
-        it { should_not contain_class('trusted_ca') }
-        it { should_not contain_package('openssl') }
-        it { should_not contain_trusted_ca__ca('sensu-ca') }
-      end
-
       context 'with use_ssl => false' do
         let(:pre_condition) do
           "class { 'sensu': use_ssl => false }"
@@ -175,9 +154,6 @@ describe 'sensu::backend', :type => :class do
 
         it { should_not contain_file('sensu_ssl_cert') }
         it { should_not contain_file('sensu_ssl_key') }
-        it { should_not contain_class('trusted_ca') }
-        it { should_not contain_package('openssl') }
-        it { should_not contain_trusted_ca__ca('sensu-ca') }
 
         backend_content = <<-END.gsub(/^\s+\|/, '')
           |---

--- a/spec/unit/provider/sensu_configure/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_configure/sensuctl_spec.rb
@@ -14,6 +14,11 @@ describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
 
   describe 'create' do
     it 'should run sensuctl configure' do
+      expect(@resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
+      @resource.provider.create
+    end
+    it 'should run sensuctl configure without SSL' do
+      @resource[:trusted_ca_file] = 'absent'
       expect(@resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
       @resource.provider.create
     end
@@ -21,8 +26,15 @@ describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
 
   describe 'flush' do
     it 'should update a configure' do
-      expect(@resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
+      expect(@resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       @resource.provider.url = 'https://localhost:8080'
+      @resource.provider.flush
+    end
+    it 'should remove SSL trusted ca' do
+      allow(File).to receive(:expand_path).with('~').and_return('/root')
+      expect(@resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
+      expect(File).to receive(:delete).with('/root/.config/sensu/sensuctl/cluster')
+      @resource.provider.trusted_ca_file = 'absent'
       @resource.provider.flush
     end
   end

--- a/spec/unit/sensu_configure_spec.rb
+++ b/spec/unit/sensu_configure_spec.rb
@@ -32,6 +32,7 @@ describe Puppet::Type.type(:sensu_configure) do
 
   defaults = {
     bootstrap_password: 'P@ssw0rd!',
+    trusted_ca_file: '/etc/sensu/ssl/ca.crt',
   }
 
   # String properties
@@ -40,6 +41,7 @@ describe Puppet::Type.type(:sensu_configure) do
     :username,
     :password,
     :url,
+    :trusted_ca_file,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = 'foo'
@@ -127,6 +129,17 @@ describe Puppet::Type.type(:sensu_configure) do
       configure[property] = 'foo'
       expect { configure }.to raise_error(Puppet::Error, /should be a Hash/)
     end
+  end
+
+  it 'should autorequire trusted_ca_file' do
+    file = Puppet::Type.type(:file).new(:name => '/etc/sensu/ssl/ca.crt')
+    config[:trusted_ca_file] = '/etc/sensu/ssl/ca.crt'
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource configure
+    catalog.add_resource file
+    rel = configure.autorequire[0]
+    expect(rel.source.ref).to eq(file.ref)
+    expect(rel.target.ref).to eq(configure.ref)
   end
 
   include_examples 'autorequires', false, false do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `trusted_ca_file` property to `sensu_configure` to support sensuctl using sensu CA cert without adding the CA cert to system trusted CAs.  Remove dependency on trusted_ca module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
sensu-go 5.2.0 added support for `--trusted-ca-file` with sensuctl and this PR takes advantage of that new feature.