### PR TITLE
Add max_output_size and discard_output to sensu_check

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -191,6 +191,15 @@ DESC
     newvalues(/.*/, :absent)
   end
 
+  newproperty(:max_output_size, :parent => PuppetX::Sensu::IntegerProperty) do
+    desc 'Maximum size, in bytes, of stored check outputs.'
+  end
+
+  newproperty(:discard_output, :boolean => true) do
+    desc 'Discard check output after extracting metrics.'
+    newvalues(:true, :false)
+  end
+
   newproperty(:namespace) do
     desc "The Sensu RBAC namespace that this check belongs to."
     defaultto 'default'

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -101,6 +101,7 @@ describe Puppet::Type.type(:sensu_check) do
     :low_flap_threshold,
     :high_flap_threshold,
     :proxy_requests_splay_coverage,
+    :max_output_size,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = 30
@@ -132,6 +133,7 @@ describe Puppet::Type.type(:sensu_check) do
     :round_robin,
     :proxy_requests_splay,
     :silenced,
+    :discard_output,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = true


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `max_output_size` and `discard_output` to `sensu_check` type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
sensu-go 5.2.0 added new attributes to checks and this adds support for those new attributes.