### PR TITLE
Fix package resources when manage_repo is false

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -76,7 +76,7 @@ class sensu::agent (
     ensure  => $_version,
     name    => $package_name,
     before  => File['sensu_etc_dir'],
-    require => Class['::sensu::repo'],
+    require => $::sensu::package_require,
   }
 
   file { 'sensu_agent_config':

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -105,7 +105,7 @@ class sensu::backend (
   package { 'sensu-go-cli':
     ensure  => $_version,
     name    => $cli_package_name,
-    require => Class['::sensu::repo'],
+    require => $::sensu::package_require,
   }
 
   sensu_api_validator { 'sensu':
@@ -159,7 +159,7 @@ class sensu::backend (
     ensure  => $_version,
     name    => $package_name,
     before  => File['sensu_etc_dir'],
-    require => Class['::sensu::repo'],
+    require => $::sensu::package_require,
   }
 
   file { 'sensu_backend_state_dir':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -51,6 +51,9 @@ class sensu (
 
   if $manage_repo {
     include ::sensu::repo
+    $package_require = Class['::sensu::repo']
+  } else {
+    $package_require = undef
   }
 
   file { 'sensu_etc_dir':

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -76,6 +76,13 @@ describe 'sensu::agent', :type => :class do
         it { should contain_file('sensu_agent_config').with_show_diff('false') }
       end
 
+      context 'with manage_repo => false' do
+        let(:pre_condition) do
+          "class { 'sensu': manage_repo => false }"
+        end
+        it { should contain_package('sensu-go-agent').without_require }
+      end
+
       # Test various backend values
       [
         ['ws://localhost:8081'],

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -179,6 +179,14 @@ describe 'sensu::backend', :type => :class do
         let(:params) {{ :show_diff => false }}
         it { should contain_file('sensu_backend_config').with_show_diff('false') }
       end
+
+      context 'with manage_repo => false' do
+        let(:pre_condition) do
+          "class { 'sensu': manage_repo => false }"
+        end
+        it { should contain_package('sensu-go-cli').without_require }
+        it { should contain_package('sensu-go-backend').without_require }
+      end
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix for when `manage_repo` is `false`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes  #1069
Replaces #1068 


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is same idea as #1068 from @maxadamo but with smaller change set and keeps logic in `sensu::repo` a bit simpler.
