### PR TITLE
Remove hardcoded /etc/sensu

### DIFF
--- a/manifests/check.pp
+++ b/manifests/check.pp
@@ -132,6 +132,8 @@ define sensu::check (
   Variant[Undef,Enum['absent'],Hash]    $hooks = undef,
 ) {
 
+  include ::sensu
+
   if $ensure == 'present' and !$command {
     fail("sensu::check{${name}}: a command must be given when ensure is present")
   }
@@ -158,23 +160,6 @@ define sensu::check (
     $interval_real = 'absent'
   } else {
     $interval_real = $interval
-  }
-
-  case $::osfamily {
-    'windows': {
-      $etc_dir   = 'C:/opt/sensu'
-      $conf_dir  = "${etc_dir}/conf.d"
-      $user      = $::sensu::user
-      $group     = $::sensu::group
-      $file_mode = undef
-    }
-    default: {
-      $etc_dir   = '/etc/sensu'
-      $conf_dir  = "${etc_dir}/conf.d"
-      $user      = $::sensu::user
-      $group     = $::sensu::group
-      $file_mode = '0440'
-    }
   }
 
   case $handlers {
@@ -277,12 +262,12 @@ define sensu::check (
   # on top of any arbitrary plugin and extension configuration in $content.
   $content_real = $content + $checks_scope
 
-  sensu::write_json { "${conf_dir}/checks/${check_name}.json":
+  sensu::write_json { "${::sensu::conf_dir}/checks/${check_name}.json":
     ensure      => $ensure,
     content     => $content_real,
     owner       => $::sensu::user,
     group       => $::sensu::group,
-    mode        => $file_mode,
+    mode        => $::sensu::config_file_mode,
     notify_list => $::sensu::check_notify,
   }
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -15,7 +15,9 @@ define sensu::config (
   Optional[Hash] $event  = undef,
 ) {
 
-  file { "/etc/sensu/conf.d/checks/config_${name}.json":
+  include ::sensu
+
+  file { "${::sensu::conf_dir}/checks/config_${name}.json":
     ensure => $ensure,
     owner  => 'sensu',
     group  => 'sensu',

--- a/manifests/contact.pp
+++ b/manifests/contact.pp
@@ -22,17 +22,19 @@ define sensu::contact(
   Hash $config = {},
 ) {
 
+  include ::sensu
+
   $file_ensure = $ensure ? {
     'absent' => 'absent',
     default  => 'file'
   }
 
   # handler configuration may contain "secrets"
-  file { "/etc/sensu/conf.d/contacts/${name}.json":
+  file { "${::sensu::conf_dir}/contacts/${name}.json":
     ensure => $file_ensure,
-    owner  => 'sensu',
-    group  => 'sensu',
-    mode   => '0440',
+    owner  => $::sensu::user,
+    group  => $::sensu::group,
+    mode   => $::sensu::config_file_mode,
     before => Sensu_contact[$name],
   }
 
@@ -40,6 +42,6 @@ define sensu::contact(
     ensure    => $ensure,
     config    => $config,
     base_path => $base_path,
-    require   => File['/etc/sensu/conf.d/contacts'],
+    require   => File["${::sensu::conf_dir}/contacts/${name}.json"],
   }
 }

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -19,6 +19,8 @@ define sensu::extension (
   Hash $config                              = {},
 ) {
 
+  include ::sensu
+
   if $::sensu::client and $::sensu::manage_services {
     $notify_services = Service['sensu-client']
   } else {
@@ -40,7 +42,7 @@ define sensu::extension (
     source => $source,
   }
 
-  file { "/etc/sensu/conf.d/extensions/${name}.json":
+  file { "${::sensu::conf_dir}/extensions/${name}.json":
     ensure => $ensure,
     owner  => 'sensu',
     group  => 'sensu',
@@ -52,6 +54,6 @@ define sensu::extension (
     ensure  => $ensure,
     config  => $config,
     notify  => $notify_services,
-    require => File['/etc/sensu/conf.d/extensions'],
+    require => File["${::sensu::conf_dir}/extensions"],
   }
 }

--- a/manifests/filter.pp
+++ b/manifests/filter.pp
@@ -19,7 +19,9 @@ define sensu::filter (
   Optional[Hash] $when             = undef,
 ) {
 
-  file { "/etc/sensu/conf.d/filters/${name}.json":
+  include ::sensu
+
+  file { "${::sensu::conf_dir}/filters/${name}.json":
     ensure => $ensure,
     owner  => $::sensu::user,
     group  => $::sensu::group,
@@ -31,7 +33,7 @@ define sensu::filter (
     negate     => $negate,
     attributes => $attributes,
     when       => $when,
-    require    => File['/etc/sensu/conf.d/filters'],
+    require    => File["${::sensu::conf_dir}/filters"],
   }
 
 }

--- a/manifests/mutator.pp
+++ b/manifests/mutator.pp
@@ -23,6 +23,8 @@ define sensu::mutator(
 
   assert_type(Pattern[/^[\w\.-]+$/], $name)
 
+  include ::sensu
+
   if $::sensu::server {
     $notify_services = Class['sensu::server::service']
   } else {
@@ -48,7 +50,7 @@ define sensu::mutator(
     $file_ensure = undef
   }
 
-  file { "/etc/sensu/conf.d/mutators/${name}.json":
+  file { "${::sensu::conf_dir}/mutators/${name}.json":
     ensure => $file_ensure,
     owner  => 'sensu',
     group  => 'sensu',
@@ -60,6 +62,6 @@ define sensu::mutator(
     ensure  => $ensure,
     command => $command,
     timeout => $timeout,
-    require => File['/etc/sensu/conf.d/mutators'],
+    require => File["${::sensu::conf_dir}/mutators"],
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Several places in code did not respect changes to `sensu::etc_dir`, this change removes hardcoded `/etc/sensu` and `/etc/sensu/conf.d` from several locations.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Replaces #1058 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support changing `sensu::etc_dir` and other resources doing the right thing.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Existing unit tests verify these changes don't change behavior but don't actually verify that changes to `sensu::etc_dir` do what the changes intended, those will be added.
