### PR TITLE
fixes: couldn't find login name expanding tilde

### DIFF
--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -8,6 +8,8 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
   commands :sensuctl => 'sensuctl'
 
   def config_path
+    # https://github.com/sensu/sensu-puppet/issues/1072
+    # since $HOME is not set in systemd service File.expand_path('~') won't work
     user_name = Etc.getpwuid(Process.uid).name
     home = Etc.getpwnam(user_name).dir
     File.join(home, '.config/sensu/sensuctl/cluster')

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -1,3 +1,4 @@
+require 'etc'
 require 'json'
 require 'tempfile'
 
@@ -7,7 +8,8 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
   commands :sensuctl => 'sensuctl'
 
   def config_path
-    home = File.expand_path('~')
+    user_name = Etc.getpwuid(Process.uid).name
+    home = Etc.getpwnam(user_name).dir
     File.join(home, '.config/sensu/sensuctl/cluster')
   end
 

--- a/spec/unit/provider/sensu_configure/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_configure/sensuctl_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
       @resource.provider.flush
     end
     it 'should remove SSL trusted ca' do
-      allow(File).to receive(:expand_path).with('~').and_return('/root')
+      allow(@resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
       expect(@resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       expect(File).to receive(:delete).with('/root/.config/sensu/sensuctl/cluster')
       @resource.provider.trusted_ca_file = 'absent'
@@ -41,7 +41,7 @@ describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should not support deleting a configure' do
-      allow(File).to receive(:expand_path).with('~').and_return('/root')
+      allow(@resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
       expect(File).to receive(:delete).with('/root/.config/sensu/sensuctl/cluster')
       @resource.provider.destroy
     end


### PR DESCRIPTION
# Pull Request Checklist

puppet fails to run unattended

## Description

tildes expansion does not seem to work if the process runs unattended. Hence, we can guess the UID of the user running puppet, and then we guess the home directory for that user: 

the new code:
```ruby
require 'etc'
user_name = Etc.getpwuid(Process.uid).name
home = Etc.getpwnam(user_name).dir
```
the old code: 
```ruby
home = File.expand_path('~')
```
## Related Issue

Fixes #1072 

## Motivation and Context

puppet fails to run unattended

## How Has This Been Tested? 

I have added the code on my puppetserver and I tested it on one agent.  
