### PR TITLE
(GH-1080) Fixes "missing custom" in sensu_enterprise_dashboard_config

### DIFF
--- a/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
+++ b/lib/puppet/provider/sensu_enterprise_dashboard_config/json.rb
@@ -226,7 +226,7 @@ Puppet::Type.type(:sensu_enterprise_dashboard_config).provide(:json) do
   end
 
   def custom
-    conf['dashboard'].reject { |k,v| is_property?(k) }
+    conf['dashboard']['custom']
   end
 
   def custom=(value)


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Every other parameter defined in sensu_enterprise_dashboard_config has a getter that returns the config object. I'm not sure why custom had something different, but this appears to cause issues with applying the sensu config. I do not claim to understand the purpose of having a reject in the getter, but applying this fix does not seem to cause problems, and a bad custom config is still caught. 

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1080 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested in our open source Puppet 6.2 master server environment across multiple RHEL7 client systems. 

## General

- [ ] Update `README.md` with any necessary configuration snippets

- [ ] New parameters are documented

- [ ] New parameters have tests

- [ ] Tests pass - `bundle exec rake validate lint spec`
