### PR TITLE
fixes: couldn't find login name  expanding tilde (cont.)

### DIFF
--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -1,3 +1,4 @@
+require 'etc'
 require 'json'
 require 'tempfile'
 
@@ -6,9 +7,14 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
 
   commands :sensuctl => 'sensuctl'
 
-  def config_path
-    home = File.expand_path('~')
+  def self.config_path
+    # https://github.com/sensu/sensu-puppet/issues/1072
+    # since $HOME is not set in systemd service File.expand_path('~') won't work
+    home = Etc.getpwuid(Process.uid).dir
     File.join(home, '.config/sensu/sensuctl/cluster')
+  end
+  def config_path
+    self.class.config_path
   end
 
   def load_config(path)

--- a/spec/unit/provider/sensu_configure/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_configure/sensuctl_spec.rb
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
       @resource.provider.flush
     end
     it 'should remove SSL trusted ca' do
-      allow(File).to receive(:expand_path).with('~').and_return('/root')
+      allow(@resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
       expect(@resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       expect(File).to receive(:delete).with('/root/.config/sensu/sensuctl/cluster')
       @resource.provider.trusted_ca_file = 'absent'
@@ -41,7 +41,7 @@ describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should not support deleting a configure' do
-      allow(File).to receive(:expand_path).with('~').and_return('/root')
+      allow(@resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
       expect(File).to receive(:delete).with('/root/.config/sensu/sensuctl/cluster')
       @resource.provider.destroy
     end

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -1,8 +1,19 @@
 require 'spec_helper'
 require 'puppet/provider/sensuctl'
+require 'ostruct'
 
 describe Puppet::Provider::Sensuctl do
   subject { Puppet::Provider::Sensuctl }
+
+  context 'config_path' do
+    it 'should return path' do
+      allow(Process).to receive(:uid).and_return(0)
+      user = OpenStruct.new
+      user.dir = '/root'
+      allow(Etc).to receive(:getpwuid).with(0).and_return(user)
+      expect(subject.config_path).to eq('/root/.config/sensu/sensuctl/cluster')
+    end
+  end
 
   context 'sensuctl_list' do
     it 'should list a resource' do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix how sensuctl config path is determined to work when run in context that doesn't support expanding `~`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1072
Replaces #1076 