### PR TITLE
Support installing sensu plugins and extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@
     * [Advanced agent](#advanced-agent)
     * [Advanced SSL](#advanced-ssl)
     * [Enterprise support](#enterprise-support)
+    * [Installing Plugins](#installing-plugins)
+    * [Installing Extensions](#installing-extensions)
     * [Exported resources](#exported-resources)
     * [Resource purging](#resource-purging)
     * [Sensu backend cluster](#sensu-backend-cluster)
@@ -114,7 +116,7 @@ associated to `linux` and `apache-servers` subscriptions.
   class { 'sensu::agent':
     backends    => ['sensu-backend.example.com:8081'],
     config_hash => {
-      'subscriptions => ['linux', 'apache-servers'],
+      'subscriptions' => ['linux', 'apache-servers'],
     },
   }
 ```
@@ -161,7 +163,7 @@ class { 'sensu':
 class { 'sensu::agent':
   backends    => ['sensu-backend.example.com:8081'],
   config_hash => {
-    'subscriptions => ['linux', 'apache-servers'],
+    'subscriptions' => ['linux', 'apache-servers'],
   },
 }
 ```
@@ -185,6 +187,108 @@ class { 'sensu::backend':
 ```
 
 The type `sensu_ldap_auth` requires a valid enterprise license.
+
+### Installing Plugins
+
+Plugin management is handled by the `sensu::plugins` class.
+
+Example installing plugins on agent:
+
+```puppet
+  class { 'sensu::agent':
+    backends    => ['sensu-backend.example.com:8081'],
+    config_hash => {
+      'subscriptions' => ['linux', 'apache-servers'],
+    },
+  }
+  class { 'sensu::plugins':
+    plugins => ['disk-checks'],
+  }
+```
+
+The `plugins` parameter can also be a Hash that sets the version:
+
+```puppet
+  class { 'sensu::agent':
+    backends    => ['sensu-backend.example.com:8081'],
+    config_hash => {
+      'subscriptions' => ['linux', 'apache-servers'],
+    },
+  }
+  class { 'sensu::plugins':
+    plugins => {
+      'disk-checks' => { 'version' => 'latest' },
+    },
+  }
+```
+
+Set `dependencies` to an empty Array to disable the `sensu::plugins` dependency management.
+
+```puppet
+  class { 'sensu::plugins':
+    dependencies => [],
+  }
+```
+
+You can uninstall plugins by passing `ensure` as `absent`.
+
+```puppet
+  class { 'sensu::agent':
+    backends    => ['sensu-backend.example.com:8081'],
+    config_hash => {
+      'subscriptions' => ['linux', 'apache-servers'],
+    },
+  }
+  class { 'sensu::plugins':
+    plugins => {
+      'disk-checks' => { 'ensure' => 'absent' },
+    },
+  }
+```
+
+### Installing Extensions
+
+Extension management is handled by the `sensu::plugins` class.
+
+Example installing extension on backend:
+
+```puppet
+  class { 'sensu::backend':
+    password     => 'supersecret',
+    old_password => 'P@ssw0rd!',
+  }
+  class { 'sensu::plugins':
+    extensions => ['graphite'],
+  }
+```
+
+The `extensions` parameter can also be a Hash that sets the version:
+
+```puppet
+  class { 'sensu::backend':
+    password     => 'supersecret',
+    old_password => 'P@ssw0rd!',
+  }
+  class { 'sensu::plugins':
+    extensions => {
+      'graphite' => { 'version' => 'latest' },
+    },
+  }
+```
+
+You can uninstall extensions by passing `ensure` as `absent`.
+
+```puppet
+  class { 'sensu::backend':
+    password     => 'supersecret',
+    old_password => 'P@ssw0rd!',
+  }
+  class { 'sensu::plugins':
+    extensions => {
+      'graphite' => { 'ensure' => 'absent' },
+    },
+  }
+```
 
 ### Exported resources
 

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,6 @@
+---
+sensu::plugins::dependencies:
+  - make
+  - gcc
+  - g++
+  - libssl-dev

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,0 +1,6 @@
+---
+sensu::plugins::dependencies:
+  - make
+  - gcc
+  - gcc-c++
+  - openssl-devel

--- a/lib/puppet/provider/sensu_plugin/sensu_install.rb
+++ b/lib/puppet/provider/sensu_plugin/sensu_install.rb
@@ -1,0 +1,162 @@
+Puppet::Type.type(:sensu_plugin).provide(:sensu_install) do
+  desc "Provider sensu_check using sensuctl"
+
+  mk_resource_methods
+
+  commands :gem => '/opt/sensu-plugins-ruby/embedded/bin/gem'
+  commands :sensu_install => 'sensu-install'
+
+  def self.instances
+    plugins = []
+
+    output = gem('list', '--local', '^sensu-(plugins|extensions)')
+    Puppet.debug("gem output: #{output}")
+    output.each_line do |o|
+      next unless o.start_with?('sensu-')
+      # This regex matches the gem list format.
+      # First capture group is non-white space
+      # Second capture group is anything preceeded by space(s) wrapped in parentheses
+      # Expected format:
+      # gem-name (version, version)
+      if o =~ /^(\S+)\s+\((.+)\)/
+        gem_name = $1
+        versions = $2.sub('default: ', '').split(/,\s*/)
+        if gem_name.start_with?('sensu-extensions')
+          extension = :true
+        else
+          extension = :false
+        end
+        plugin = {
+          :name      => gem_name.sub('sensu-plugins-', '').sub('sensu-extensions-', ''),
+          :ensure    => :present,
+          :version   => versions.map{|v| v.split[0]}[0],
+          :extension => extension,
+        }
+        Puppet.debug("plugin: #{plugin}")
+        plugins << new(plugin)
+      end
+    end
+    plugins
+  end
+
+  def self.prefetch(resources)
+    plugins = instances
+    resources.keys.each do |name|
+      if provider = plugins.find { |c| c.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def self.latest_versions
+    return @latest_versions if @latest_versions
+    @latest_versions = {}
+    output = gem('search', '--remote', '--all', "^sensu-(plugins|extensions)-")
+    output.each_line do |o|
+      # This regex matches the gem list format.
+      # First capture group is non-white space
+      # Second capture group is anything preceeded by space(s) wrapped in parentheses
+      # Expected format:
+      # gem-name (version, version)
+      if o =~ /^(\S+)\s+\((.+)\)/
+        gem_name = $1
+        versions = $2.sub('default: ', '').split(/,\s*/)
+        Puppet.debug("#{gem_name} versions: #{versions}")
+        name = gem_name.sub('sensu-plugins-', '').sub('sensu-extensions-', '')
+        ver = versions.map { |v| v.split[0]}[0]
+        @latest_versions[name] = ver
+      end
+    end
+    @latest_versions
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  def version=(value)
+    @property_flush[:version] = value
+  end
+
+  def install(version)
+    args = []
+    if resource[:extension] == :true
+      args << '--extension'
+      prefix = 'sensu-extensions-'
+    else
+      args << '--plugin'
+      prefix = 'sensu-plugins-'
+    end
+    if version == :latest
+      latest_versions = self.class.latest_versions
+      version = latest_versions[resource[:name]]
+    end
+    if version 
+      name = "#{prefix}#{resource[:name]}:#{version}"
+    else
+      name = resource[:name]
+    end
+    args << name
+    if resource[:clean] == :true
+      args << '--clean'
+    end
+    if resource[:source]
+      args << '--source'
+      args << resource[:source]
+    end
+    if resource[:proxy]
+      args << '--proxy'
+      args << resource[:proxy]
+    end
+    sensu_install(args)
+  end
+
+  def create
+    begin
+      install(resource[:version])
+    rescue Exception => e
+      raise Puppet::Error, "sensu-install of #{resource[:name]} failed\nError message: #{e.message}"
+    end
+    @property_hash[:ensure] = :present
+  end
+
+  def flush
+    if !@property_flush.empty?
+      begin
+        install(@property_flush[:version])
+      rescue Exception => e
+        raise Puppet::Error, "sensu-install of #{resource[:name]} failed\nError message: #{e.message}"
+      end
+    end
+    @property_hash = resource.to_hash
+  end
+
+  def destroy
+    args = ['uninstall']
+    if resource[:extension] == :true
+      name = "sensu-extensions-#{resource[:name]}"
+    else
+      name = "sensu-plugins-#{resource[:name]}"
+    end
+    args << name
+    args << '--executables'
+    if resource[:version]
+      args << '--version'
+      args << resource[:version]
+    else
+      args << '--all'
+    end
+    begin
+      gem(args)
+    rescue Exception => e
+      raise Puppet::Error, "sensu-install delete of #{resource[:name]} failed\nError message: #{e.message}"
+    end
+    @property_hash.clear
+  end
+end
+

--- a/lib/puppet/type/sensu_plugin.rb
+++ b/lib/puppet/type/sensu_plugin.rb
@@ -1,0 +1,88 @@
+require_relative '../../puppet_x/sensu/type'
+require_relative '../../puppet_x/sensu/array_property'
+require_relative '../../puppet_x/sensu/hash_property'
+require_relative '../../puppet_x/sensu/integer_property'
+
+Puppet::Type.newtype(:sensu_plugin) do
+  desc <<-DESC
+@summary Manages Sensu plugins
+@example Install a sensu plugin
+  sensu_plugin { 'disk-checks':
+    ensure  => 'present',
+  }
+
+@example Install specific version of a sensu plugin
+  sensu_plugin { 'disk-checks':
+    ensure  => 'present',
+    version => '4.0.0',
+  }
+
+@example Install latest version of a sensu plugin
+  sensu_plugin { 'disk-checks':
+    ensure  => 'present',
+    version => 'latest',
+  }
+
+**Autorequires**:
+* `Package[sensu-plugins-ruby]`
+DESC
+
+  extend PuppetX::Sensu::Type
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "Plugin or extension name"
+    munge do |v|
+      n = v.sub('sensu-plugins-', '').sub('sensu-extensions-', '')
+      n
+    end
+  end
+
+  newproperty(:version) do
+    desc "Specific version to install, or latest"
+    newvalues(:latest, /[0-9\.]+/)
+    def insync?(is)
+      @should.each do |should|
+        if should == :latest || should == 'latest'
+          latest_versions = provider.class.latest_versions
+          @latest = latest_versions[@resource.name]
+          return is == @latest
+        else
+          super
+        end
+      end
+    end
+    def should_to_s(newvalue)
+      if @latest
+        super(@latest)
+      else
+        super(newvalue)
+      end
+    end
+  end
+
+  newparam(:extension, :boolean => true) do
+    desc "Sets to install an extension instead of a plugin"
+    newvalues(:true, :false)
+    defaultto(:false)
+  end
+
+  newparam(:source) do
+    desc "Install Sensu plugins and extensions from a custom SOURCE"
+  end
+
+  newparam(:clean, :boolean => true) do
+    desc "Clean up (remove) other installed versions of the plugin(s) and/or extension(s)"
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
+
+  newparam(:proxy) do
+    desc "Install Sensu plugins and extensions via a PROXY URL"
+  end
+
+  autorequire(:package) do
+    ['sensu-plugins-ruby']
+  end
+end

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -1,0 +1,92 @@
+# @summary Manage Sensu plugins
+#
+# Class to manage the Sensu plugins.
+#
+# @example
+#   class { 'sensu::plugins':
+#     plugins    => ['disk-checks'],
+#     extensions => ['graphite'],
+#   }
+#
+# @example
+#   class { 'sensu::plugins':
+#     plugins    => {
+#       'disk-checks' => { 'version' => 'latest' },
+#     },
+#     extensions => {
+#       'graphite' => { 'version' => 'latest' },
+#     },
+#   }
+#
+# @param package_ensure
+#   Ensure property for sensu plugins package.
+# @param package_name
+#   Name of the Sensu plugins ruby package.
+# @param dependencies
+#   Package dependencies needed to install plugins and extensions.
+#   Default is OS dependent.
+# @param plugins
+#   Plugins to install
+# @param extensions
+#   Extensions to install
+#
+class sensu::plugins (
+  String $package_ensure = 'installed',
+  String $package_name = 'sensu-plugins-ruby',
+  Array $dependencies = [],
+  Variant[Array, Hash] $plugins = [],
+  Variant[Array, Hash] $extensions = [],
+) {
+
+  include ::sensu
+
+  if $::sensu::manage_repo {
+    include ::sensu::repo::community
+    $package_require = [Class['::sensu::repo::community']] + $::sensu::os_package_require
+  } else {
+    $package_require = undef
+  }
+
+  package { 'sensu-plugins-ruby':
+    ensure  => $package_ensure,
+    name    => $package_name,
+    require => $package_require,
+  }
+
+  ensure_packages($dependencies)
+  $dependencies.each |$package| {
+    Package[$package] -> Sensu_plugin <| |> # lint:ignore:spaceship_operator_without_tag
+  }
+
+  if $plugins =~ Array {
+    $plugins.each |$plugin| {
+      sensu_plugin { $plugin:
+        ensure => 'present',
+      }
+    }
+  } else {
+    $plugins.each |$plugin, $plugin_data| {
+      $data = { 'ensure' => 'present' } + $plugin_data
+      sensu_plugin { $plugin:
+        * => $data,
+      }
+    }
+  }
+
+  if $extensions =~ Array {
+    $extensions.each |$extension| {
+      sensu_plugin { $extension:
+        ensure    => 'present',
+        extension => true,
+      }
+    }
+  } else {
+    $extensions.each |$extension, $extension_data| {
+      $data = { 'ensure' => 'present', 'extension' => true } + $extension_data
+      sensu_plugin { $extension:
+        * => $data,
+      }
+    }
+  }
+
+}

--- a/manifests/repo/community.pp
+++ b/manifests/repo/community.pp
@@ -1,0 +1,45 @@
+# @summary Private class to manage sensu community repository resources
+# @api private
+#
+class sensu::repo::community {
+
+  if $facts['os']['family'] == 'RedHat' {
+    if $facts['os']['name'] == 'Amazon' {
+      if $facts['os']['release']['major'] =~ /^201\d$/ {
+        $repo_release = '6'
+      } else {
+        $repo_release = '7'
+      }
+    } else {
+      $repo_release = $facts['os']['release']['major']
+    }
+    yumrepo { 'sensu_community':
+      ensure          => 'present',
+      baseurl         => "https://packagecloud.io/sensu/community/el/${repo_release}/\$basearch",
+      descr           => 'sensu_community',
+      enabled         => 1,
+      gpgcheck        => 0,
+      gpgkey          => 'https://packagecloud.io/sensu/community/gpgkey',
+      metadata_expire => 300,
+      repo_gpgcheck   => 1,
+      sslcacert       => '/etc/pki/tls/certs/ca-bundle.crt',
+      sslverify       => 1,
+    }
+  }
+  if $facts['os']['family'] == 'Debian' {
+    apt::source { 'sensu_community':
+      ensure   => 'present',
+      location => "https://packagecloud.io/sensu/community/${downcase($facts['os']['name'])}/",
+      repos    => 'main',
+      release  => $facts['os']['distro']['codename'],
+      include  => {
+        'src' => true,
+      },
+      key      => {
+        'id'     => '7F54E8A5C0CB51DBE612D2F50156BD72FEC8CD59',
+        'source' => 'https://packagecloud.io/sensu/community/gpgkey',
+      },
+    }
+  }
+}
+

--- a/spec/acceptance/03_no_ssl_spec.rb
+++ b/spec/acceptance/03_no_ssl_spec.rb
@@ -9,7 +9,10 @@ describe 'sensu without SSL', unless: RSpec.configuration.sensu_cluster do
       class { '::sensu':
         use_ssl => false,
       }
-      class { '::sensu::backend': }
+      class { '::sensu::backend':
+        password     => 'P@ssw0rd!',
+        old_password => 'supersecret',
+      }
       sensu_entity { 'sensu_agent':
         ensure => 'absent',
       }

--- a/spec/acceptance/04_plugins_spec.rb
+++ b/spec/acceptance/04_plugins_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper_acceptance'
 describe 'sensu::plugins class', unless: RSpec.configuration.sensu_cluster do
   agent = hosts_as('sensu_agent')[0]
   backend = hosts_as('sensu_backend')[0]
+  before do
+    if fact_on(agent, 'operatingsystem') == 'Debian'
+      skip("TODO: package is missing on Debian - See https://github.com/sensu/sensu-plugins-omnibus/issues/3")
+    end
+  end
   context 'on agent' do
     it 'should work without errors and be idempotent' do
       pp = <<-EOS

--- a/spec/acceptance/04_plugins_spec.rb
+++ b/spec/acceptance/04_plugins_spec.rb
@@ -1,0 +1,78 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu::plugins class', unless: RSpec.configuration.sensu_cluster do
+  agent = hosts_as('sensu_agent')[0]
+  backend = hosts_as('sensu_backend')[0]
+  context 'on agent' do
+    it 'should work without errors and be idempotent' do
+      pp = <<-EOS
+      class { '::sensu': }
+      class { '::sensu::agent':
+        backends    => ['sensu_backend:8081'],
+        config_hash => {
+          'name' => 'sensu_agent',
+        }
+      }
+      class { '::sensu::plugins':
+        plugins => ['disk-checks'],
+        extensions => ['ruby-hash']
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(agent, pp, :catch_failures => true)
+      apply_manifest_on(agent, pp, :catch_changes  => true)
+    end
+
+    describe package('sensu-plugins-ruby'), :node => agent do
+      it { should be_installed }
+    end
+
+    it 'should have plugin installed' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^sensu-plugins-disk-checks/)
+      end
+    end
+
+    it 'should have extension installed' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^sensu-extensions-ruby-hash/)
+      end
+    end
+  end
+  context 'on backend' do
+    it 'should work without errors and be idempotent' do
+      pp = <<-EOS
+      class { '::sensu': }
+      class { '::sensu::backend':
+        password     => 'P@ssw0rd!',
+        old_password => 'supersecret',
+      }
+      class { '::sensu::plugins':
+        plugins => ['disk-checks'],
+        extensions => ['ruby-hash']
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(backend, pp, :catch_failures => true)
+      apply_manifest_on(backend, pp, :catch_changes  => true)
+    end
+
+    describe package('sensu-plugins-ruby'), :node => backend do
+      it { should be_installed }
+    end
+
+    it 'should have plugin installed' do
+      on backend, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^sensu-plugins-disk-checks/)
+      end
+    end
+
+    it 'should have extension installed' do
+      on backend, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^sensu-extensions-ruby-hash/)
+      end
+    end
+  end
+end

--- a/spec/acceptance/sensu_plugin_spec.rb
+++ b/spec/acceptance/sensu_plugin_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu_plugin', if: RSpec.configuration.sensu_full do
+  agent = hosts_as('sensu_agent')[0]
+  context 'install plugin' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::agent
+      include ::sensu::plugins
+      sensu_plugin { 'cpu-checks':
+        ensure  => 'present',
+        version => '2.0.0',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(agent, pp, :catch_failures => true)
+      apply_manifest_on(agent, pp, :catch_changes  => true)
+    end
+
+    it 'should have plugin installed' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^sensu-plugins-cpu-checks \(2.0.0\)/)
+      end
+    end
+  end
+
+  context 'install plugin latest version' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::agent
+      include ::sensu::plugins
+      sensu_plugin { 'cpu-checks':
+        ensure  => 'present',
+        version => 'latest',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(agent, pp, :catch_failures => true)
+      apply_manifest_on(agent, pp, :catch_changes  => true)
+    end
+
+    it 'should have plugin installed' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).not_to match(/^sensu-plugins-cpu-checks \(2.0.0\)/)
+        expect(stdout).to match(/^sensu-plugins-cpu-checks/)
+      end
+    end
+  end
+
+  context 'uninstall plugin' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::agent
+      include ::sensu::plugins
+      sensu_plugin { 'cpu-checks':
+        ensure  => 'absent',
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(agent, pp, :catch_failures => true)
+      apply_manifest_on(agent, pp, :catch_changes  => true)
+    end
+
+    it 'should have plugin uninstalled' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).not_to match(/^sensu-plugins-cpu-checks/)
+      end
+    end
+  end
+end

--- a/spec/acceptance/sensu_plugin_spec.rb
+++ b/spec/acceptance/sensu_plugin_spec.rb
@@ -2,6 +2,11 @@ require 'spec_helper_acceptance'
 
 describe 'sensu_plugin', if: RSpec.configuration.sensu_full do
   agent = hosts_as('sensu_agent')[0]
+  before do
+    if fact_on(agent, 'operatingsystem') == 'Debian'
+      skip("TODO: package is missing on Debian - See https://github.com/sensu/sensu-plugins-omnibus/issues/3")
+    end
+  end
   context 'install plugin' do
     it 'should work without errors' do
       pp = <<-EOS

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -15,7 +15,7 @@ describe 'sensu::agent', :type => :class do
             'ensure'  => 'installed',
             'name'    => 'sensu-go-agent',
             'before'  => 'File[sensu_etc_dir]',
-            'require' => 'Class[Sensu::Repo]',
+            'require' => platforms[facts[:osfamily]][:package_require],
           })
         }
 

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -18,7 +18,7 @@ describe 'sensu::backend', :type => :class do
           should contain_package('sensu-go-cli').with({
             'ensure'  => 'installed',
             'name'    => 'sensu-go-cli',
-            'require' => 'Class[Sensu::Repo]',
+            'require' => platforms[facts[:osfamily]][:package_require],
           })
         }
 
@@ -86,7 +86,7 @@ describe 'sensu::backend', :type => :class do
           should contain_package('sensu-go-backend').with({
             'ensure'  => 'installed',
             'name'    => 'sensu-go-backend',
-            'require' => 'Class[Sensu::Repo]',
+            'require' => platforms[facts[:osfamily]][:package_require],
           })
         }
 

--- a/spec/classes/plugins_spec.rb
+++ b/spec/classes/plugins_spec.rb
@@ -1,0 +1,85 @@
+require 'spec_helper'
+
+describe 'sensu::plugins', :type => :class do
+  on_supported_os({facterversion: '3.8.0'}).each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      context 'with default values for all parameters' do
+        it { should compile }
+
+        it { should create_class('sensu::plugins')}
+        it { should contain_class('sensu')}
+        it { should contain_class('sensu::repo::community')}
+
+        it {
+          should contain_package('sensu-plugins-ruby').with({
+            'ensure'  => 'installed',
+            'require' => platforms[facts[:osfamily]][:plugins_package_require],
+          })
+        }
+      end
+
+      platforms[facts[:osfamily]][:plugins_dependencies].each do |package|
+        it { should contain_package(package) }
+      end
+
+      context 'with plugins array' do
+        let(:params) {{ :plugins => ['disk-checks'] }}
+        it { should contain_sensu_plugin('disk-checks').with_ensure('present') }
+      end
+
+      context 'with plugins hash' do
+        let(:params) {{ :plugins => {'disk-checks' => {'version' => '4.0.0'}} }}
+        it {
+          should contain_sensu_plugin('disk-checks').with({
+            'ensure'  => 'present',
+            'version' => '4.0.0',
+          })
+        }
+      end
+
+      context 'with extensions array' do
+        let(:params) {{ :extensions => ['test'] }}
+        it { should contain_sensu_plugin('test').with_ensure('present') }
+        it { should contain_sensu_plugin('test').with_extension('true') }
+      end
+
+      context 'with extensions hash' do
+        let(:params) {{ :extensions => {'test' => {'version' => '1.0.0'}} }}
+        it {
+          should contain_sensu_plugin('test').with({
+            'ensure'    => 'present',
+            'extension' => 'true',
+            'version'   => '1.0.0',
+          })
+        }
+      end
+
+      context 'remove plugins' do
+        let(:params) {{ :plugins => {'disk-checks' => {'ensure' => 'absent'}} }}
+        it { should contain_sensu_plugin('disk-checks').with_ensure('absent') }
+      end
+
+      context 'remove extensions' do
+        let(:params) {{ :extensions => {'test' => {'ensure' => 'absent'}} }}
+        it { should contain_sensu_plugin('test').with_ensure('absent') }
+      end
+
+      context 'dependencies => []' do
+        let(:params) {{ :dependencies => [] }}
+        platforms[facts[:osfamily]][:plugins_dependencies].each do |package|
+          it { should_not contain_package(package) }
+        end
+      end
+
+      context 'with manage_repo => false' do
+        let(:pre_condition) do
+          "class { 'sensu': manage_repo => false }"
+        end
+        it { should_not contain_class('sensu::repo::community') }
+        it { should contain_package('sensu-plugins-ruby').without_require }
+      end
+    end
+  end
+end
+

--- a/spec/classes/repo_community_spec.rb
+++ b/spec/classes/repo_community_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'sensu::repo::community', :type => :class do
+  on_supported_os({facterversion: '3.8.0'}).each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      case os
+      when /(redhat-6|centos-6|amazon-2017|amazon-2018)-x86_64/
+        baseurl = "https://packagecloud.io/sensu/community/el/6/$basearch"
+      when /(redhat-7|centos-7|amazon-2)-x86_64/
+        baseurl = "https://packagecloud.io/sensu/community/el/7/$basearch"
+      else
+        baseurl = nil
+      end
+      if facts[:osfamily] == 'RedHat'
+        it {
+          should contain_yumrepo('sensu_community').with({
+            'descr'           => 'sensu_community',
+            'baseurl'         => baseurl,
+            'repo_gpgcheck'   => 1,
+            'gpgcheck'        => 0,
+            'enabled'         => 1,
+            'gpgkey'          => 'https://packagecloud.io/sensu/community/gpgkey',
+            'sslverify'       => 1,
+            'sslcacert'       => '/etc/pki/tls/certs/ca-bundle.crt',
+            'metadata_expire' => 300,
+          })
+        }
+      elsif facts[:osfamily] == 'Debian'
+        it {
+          should contain_apt__source('sensu_community').with({
+            'ensure' => 'present',
+            'location' => "https://packagecloud.io/sensu/community/#{facts[:os]['name'].downcase}/",
+            'repos'    => 'main',
+            'release'  => facts[:os]['distro']['codename'],
+            'include'  => { 'src' => 'true' },
+            'key'      => {
+              'id'     => '7F54E8A5C0CB51DBE612D2F50156BD72FEC8CD59',
+              'source' => 'https://packagecloud.io/sensu/community/gpgkey',
+            },
+          })
+        }
+      end
+    end
+  end
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,3 +55,18 @@ RSpec.configure do |config|
     %r{/.rvm/},
   ]
 end
+
+def platforms
+  {
+    'Debian' => {
+      :package_require => ['Class[Sensu::Repo]', 'Class[Apt::Update]'],
+      :plugins_package_require => ['Class[Sensu::Repo::Community]', 'Class[Apt::Update]'],
+      :plugins_dependencies => ['make','gcc','g++','libssl-dev'],
+    },
+    'RedHat' => {
+      :package_require => ['Class[Sensu::Repo]'],
+      :plugins_package_require => ['Class[Sensu::Repo::Community]'],
+      :plugins_dependencies => ['make','gcc','gcc-c++','openssl-devel'],
+    },
+  }
+end

--- a/spec/unit/provider/sensu_plugin/sensu_install_spec.rb
+++ b/spec/unit/provider/sensu_plugin/sensu_install_spec.rb
@@ -1,0 +1,181 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_plugin).provider(:sensu_install) do
+  before(:each) do
+    @provider = described_class
+    @type = Puppet::Type.type(:sensu_plugin)
+    @resource = @type.new({
+      :name => 'test',
+      :ensure => 'present',
+      :provider => @provider.name,
+    })
+    #allow(Puppet::Util).to receive(:which).with('sensu-install').and_return('/bin/sensu-install')
+  end
+
+  let(:list_local_output) { "
+
+*** LOCAL GEMS ***
+
+sensu-plugins-disk-plugins (4.0.0)
+"}
+
+  let(:list_remote_output) { "
+
+*** REMOTE GEMS ***
+
+sensu-extensions-check-dependencies (1.1.0, 1.0.1, 1.0.0)
+sensu-plugins-nvidia (1.0.0, 0.0.2, 0.0.1)
+" }
+
+  describe 'self.instances' do
+    it 'should create instances' do
+      allow(@provider).to receive(:gem).with('list','--local','^sensu-(plugins|extensions)').and_return(list_local_output)
+      expect(@provider.instances.length).to eq(1)
+    end
+
+    it 'should return the resource for a plugin' do
+      allow(@provider).to receive(:gem).with('list','--local','^sensu-(plugins|extensions)').and_return(list_local_output)
+      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      expect(property_hash[:name]).to eq('disk-plugins')
+    end
+  end
+
+  describe 'self.latest_versions' do
+    it 'should return latest versions' do
+      allow(@provider).to receive(:gem).with('search', '--remote', '--all', "^sensu-(plugins|extensions)-").and_return(list_remote_output)
+      latest_versions = @provider.latest_versions
+      expect(latest_versions).to eq({'check-dependencies' => '1.1.0', 'nvidia' => '1.0.0'})
+    end
+  end
+
+  describe 'create' do
+    it 'should install a plugin' do
+      expected_args = [
+        '--plugin', 'test',
+        '--clean', 
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should install an extension' do
+      @resource[:extension] = :true
+      expected_args = [
+        '--extension', 'test',
+        '--clean', 
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should install specific version' do
+      @resource[:version] = '1.0.0'
+      expected_args = [
+        '--plugin', 'sensu-plugins-test:1.0.0',
+        '--clean', 
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'installs latest version' do
+      @resource[:name] = 'nvidia'
+      @resource[:version] = :latest
+      allow(@provider).to receive(:gem).with('search', '--remote', '--all', "^sensu-(plugins|extensions)-").and_return(list_remote_output)
+      expected_args = [
+        '--plugin', 'sensu-plugins-nvidia:1.0.0',
+        '--clean', 
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should install a plugin without clean' do
+      @resource[:clean] = :false
+      expected_args = [
+        '--plugin', 'test',
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should install a plugin with source' do
+      @resource[:source] = 'http://foo'
+      expected_args = [
+        '--plugin', 'test',
+        '--clean',
+        '--source', 'http://foo',
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should install a plugin with proxy' do
+      @resource[:proxy] = 'http://foo'
+      expected_args = [
+        '--plugin', 'test',
+        '--clean',
+        '--proxy', 'http://foo',
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.create
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+  end
+
+  describe 'flush' do
+    it 'should install specific version' do
+      expected_args = [
+        '--plugin', 'sensu-plugins-test:1.0.0',
+        '--clean', 
+      ]
+      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
+      @resource.provider.version = '1.0.0'
+      @resource.provider.flush
+    end
+  end
+
+  describe 'destroy' do
+    it 'should uninstall a plugin' do
+      expected_args = [
+        'uninstall', 'sensu-plugins-test',
+        '--executables', '--all'
+      ]
+      expect(@resource.provider).to receive(:gem).with(expected_args)
+      @resource.provider.destroy
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash).to eq({})
+    end
+    it 'should uninstall an extension' do
+      @resource[:extension] = :true
+      expected_args = [
+        'uninstall', 'sensu-extensions-test',
+        '--executables', '--all'
+      ]
+      expect(@resource.provider).to receive(:gem).with(expected_args)
+      @resource.provider.destroy
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash).to eq({})
+    end
+    it 'should uninstall a plugin by version' do
+      @resource[:version] = '1.0.0'
+      expected_args = [
+        'uninstall', 'sensu-plugins-test',
+        '--executables',
+        '--version', '1.0.0',
+      ]
+      expect(@resource.provider).to receive(:gem).with(expected_args)
+      @resource.provider.destroy
+      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash).to eq({})
+    end
+  end
+end
+

--- a/spec/unit/sensu_plugin_spec.rb
+++ b/spec/unit/sensu_plugin_spec.rb
@@ -1,0 +1,209 @@
+require 'spec_helper'
+require 'puppet/type/sensu_plugin'
+
+describe Puppet::Type.type(:sensu_plugin) do
+  let(:default_config) do
+    {
+      name: 'test',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:plugin) do
+    described_class.new(config)
+  end
+
+  it 'should add to catalog with raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource plugin
+    }.to_not raise_error
+  end
+
+  it 'should require a name' do
+    expect {
+      described_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should munge name when includes sensu-plugins-' do
+    config[:name] = 'sensu-plugins-disk-plugins'
+    expect(plugin[:name]).to eq('disk-plugins')
+  end
+
+  it 'should munge name when includes sensu-extensions-' do
+    config[:name] = 'sensu-extensions-foo'
+    expect(plugin[:name]).to eq('foo')
+  end
+
+  defaults = {
+    'extension': :false,
+    'clean': :true,
+  }
+
+  # String properties
+  [
+    :source,
+    :proxy,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 'foo'
+      expect(plugin[property]).to eq('foo')
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(plugin[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(plugin[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # String regex validated properties
+  [
+  ].each do |property|
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo bar'
+      expect { plugin }.to raise_error(Puppet::Error, /#{property.to_s} invalid/)
+    end
+  end
+
+  # Array properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = ['foo', 'bar']
+      expect(plugin[property]).to eq(['foo', 'bar'])
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(plugin[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(plugin[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Integer properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 30
+      expect(plugin[property]).to eq(30)
+    end
+    it "should accept valid #{property} as string" do
+      config[property] = '30'
+      expect(plugin[property]).to eq(30)
+    end
+    it "should not accept invalid value for #{property}" do
+      config[property] = 'foo'
+      expect { plugin }.to raise_error(Puppet::Error, /should be an Integer/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(plugin[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(plugin[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Boolean properties
+  [
+    :extension,
+    :clean,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = true
+      expect(plugin[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = false
+      expect(plugin[property]).to eq(:false)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'true'
+      expect(plugin[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'false'
+      expect(plugin[property]).to eq(:false)
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { plugin }.to raise_error(Puppet::Error, /Invalid value "foo". Valid values are true, false/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(plugin[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(plugin[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Hash properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = { 'foo': 'bar' }
+      expect(plugin[property]).to eq({'foo': 'bar'})
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { plugin }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(plugin[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(plugin[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  describe 'version' do
+    it 'should allow latest' do
+      config[:version] = 'latest'
+      expect(plugin[:version]).to eq(:latest)
+    end
+    it 'should allow a version' do
+      config[:version] = '1.0.0'
+      expect(plugin[:version]).to eq('1.0.0')
+    end
+    it 'should raise error if not latest or version' do
+      config[:version] = 'foo'
+      expect { plugin }.to raise_error(Puppet::Error, /Invalid value/)
+    end
+  end
+
+  it 'should autorequire sensu-plugins-ruby' do
+    package = Puppet::Type.type(:package).new(:name => 'sensu-plugins-ruby')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource plugin
+    catalog.add_resource package
+    rel = plugin.autorequire[0]
+    expect(rel.source.ref).to eq(package.ref)
+    expect(rel.target.ref).to eq(plugin.ref)
+  end
+
+  [
+  ].each do |property|
+    it "should require property when ensure => present" do
+      config.delete(property)
+      config[:ensure] = :present
+      expect { plugin }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add both type and provider and class to manage sensu plugin and extension installation.

Had to have apt based systems have packages depend on `Class[apt::update]` as adding a second repo caused `apt-get update` to take place later and prevented install of core sensu-go packages.  The dependency change ensures `apt-get update` is run before trying to install any packages.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
sensu-go docs for plugins: https://docs.sensu.io/sensu-go/5.2/installation/plugins/

This change makes it easy to utilize plugins.

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
