### PR TITLE
Add env_vars parameter

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -267,6 +267,8 @@
 #
 # @param path Used to set PATH in /etc/default/sensu
 #
+# @param env_vars Additional environment variables for /etc/default/sensu
+#
 # @param redact Use to redact passwords from checks on the client side
 #
 # @param deregister_on_stop Whether the sensu client should deregister from the API on service stop
@@ -470,6 +472,7 @@ class sensu (
   Optional[Any]      $enterprise_dashboard_oidc = undef,
   Optional[Hash]     $enterprise_dashboard_custom = undef,
   Variant[Stdlib::Absolutepath,Pattern[/^\$PATH$/]] $path = '$PATH',
+  Optional[Hash[String[1], Variant[String, Boolean, Integer]]] $env_vars = {},
   Optional[Array]    $redact = undef,
   Boolean            $deregister_on_stop = false,
   Optional[String]   $deregister_handler = undef,

--- a/manifests/package.pp
+++ b/manifests/package.pp
@@ -28,6 +28,8 @@
 #
 # @param path Used to set PATH in /etc/default/sensu
 #
+# @param env_vars Additional environment variables for /etc/default/sensu
+#
 # @param rubyopt Ruby opts to be passed to the sensu services
 #
 # @param use_embedded_ruby If the embedded ruby should be used, e.g. to install the
@@ -48,6 +50,7 @@ class sensu::package (
   Optional[String] $log_dir             = $::sensu::log_dir,
   Optional[String] $log_level           = $::sensu::log_level,
   Optional[String] $path                = $::sensu::path,
+  Optional[Hash[String[1], Variant[String, Boolean, Integer]]] $env_vars = $::sensu::env_vars,
   Optional[String] $rubyopt             = $::sensu::rubyopt,
   Optional[Boolean] $use_embedded_ruby  = $::sensu::use_embedded_ruby,
 ) {

--- a/spec/classes/sensu_package_spec.rb
+++ b/spec/classes/sensu_package_spec.rb
@@ -583,4 +583,20 @@ describe 'sensu' do
       it { should contain_file('/etc/sensu/conf.d/spawn.json').with_content(/limit.*20/) }
     end
   end
+
+  describe 'env_vars' do
+    context 'string value' do
+      let(:params) { { :env_vars => { 'FOO' => 'bar' } } }
+      it { should compile }
+      it { should contain_file('/etc/default/sensu').with_content(%r{^FOO="bar"$}) }
+    end
+    context 'boolean value' do
+      let(:params) { { :env_vars => { 'FOO' => true } } }
+      it { should contain_file('/etc/default/sensu').with_content(%r{^FOO=true$}) }
+    end
+    context 'integer value' do
+      let(:params) { { :env_vars => { 'FOO' => 1 } } }
+      it { should contain_file('/etc/default/sensu').with_content(%r{^FOO=1$}) }
+    end
+  end
 end

--- a/templates/sensu.erb
+++ b/templates/sensu.erb
@@ -22,3 +22,10 @@ HEAP_SIZE="<%= @heap_size %>"
 <% if @config_file -%>
 CONFIG_FILE="<%= @config_file %>"
 <% end -%>
+<% @env_vars.each_pair do |key,value| -%>
+<% if value.is_a?(String) -%>
+<%= key %>="<%= value %>"
+<% else -%>
+<%= key %>=<%= value %>
+<% end -%>
+<% end -%>


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `env_vars` parameter that provides environment variables to `/etc/default/sensu`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1074

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Support arbitrary environment variables in `/etc/default/sensu`.
