### PR TITLE
Ensure presence of sensuclassic doesn't break this module

### DIFF
--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -33,6 +33,8 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
+    # Install sensuclassic to ensure no conflicts
+    on hosts, puppet('module', 'install', 'sensu-sensuclassic'), { :acceptable_exit_codes => [0,1] }
     # Install soft module dependencies
     on hosts, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 7.0.0"'), { :acceptable_exit_codes => [0,1] }
     if collection == 'puppet6'


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Installing sensuclassic module during acceptance tests to ensure this module won't break when sensuclassic is installed.

I will do same to sensuclassic once sensu-go changes are in forge.
