### PR TITLE
Hiera resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
     * [Installing Plugins](#installing-plugins)
     * [Installing Extensions](#installing-extensions)
     * [Exported resources](#exported-resources)
+    * [Hiera resources](#hiera-resources)
     * [Resource purging](#resource-purging)
     * [Sensu backend cluster](#sensu-backend-cluster)
         * [Adding backend members to an existing cluster](#adding-backend-members-to-an-existing-cluster)
@@ -306,6 +307,60 @@ The backend system would collect all `sensu_check` resources.
 
 ```puppet
   Sensu_check <<||>>
+```
+
+### Hiera resources
+
+All the types provided by this module can have their resources defined via Hiera. A type such as `sensu_check` would be defined via `sensu::backend::checks`.
+
+The following example adds an asset, filter, handler and checks via Hiera:
+
+```yaml
+sensu::backend::assets:
+  sensu-email-handler:
+    ensure: present
+    url: 'https://github.com/sensu/sensu-email-handler/releases/download/0.1.0/sensu-email-handler_0.1.0_linux_amd64.tar.gz'
+    sha512: '755c7a673d94997ab9613ec5969666e808f8b4a8eec1ba998ee7071606c96946ca2947de5189b24ac34a962713d156619453ff7ea43c95dae62bf0fcbe766f2e'
+    filters:
+      - "entity.system.os == 'linux'"
+      - "entity.system.arch == 'amd64'"
+sensu::backend::filters:
+  hourly:
+    ensure: present
+    action: allow
+    expressions:
+      - 'event.check.occurrences == 1 || event.check.occurrences % (3600 / event.check.interval) == 0'
+sensu::backend::handlers:
+  email:
+    ensure: present
+    type: pipe
+    command: "sensu-email-handler -f root@localhost -t user@example.com -s localhost -i"
+    timeout: 10
+    runtime_assets:
+      - sensu-email-handler
+    filters:
+      - is_incident
+      - not_silenced
+      - hourly
+sensu::backend::checks:
+  check-cpu:
+    ensure: present
+    command: check-cpu.sh -w 75 -c 90
+    interval: 60
+    subscriptions:
+      - linux
+    handlers:
+      - email
+    publish: true
+  check-disks:
+    ensure: present
+    command: "/opt/sensu-plugins-ruby/embedded/bin/check-disk-usage.rb -t '(xfs|ext4)'"
+    subscriptions:
+      - linux
+    handlers:
+      - email
+    interval: 1800
+    publish: true
 ```
 
 ### Resource purging

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -51,6 +51,44 @@
 # @param license_content
 #   The content of sensu-go enterprise license
 #   Do not define with license_source
+# @param ad_auths
+#   Hash of sensu_ad_auth resources
+# @param assets
+#   Hash of sensu_asset resources
+# @param checks
+#   Hash of sensu_check resources
+# @param cluster_members
+#   Hash of sensu_cluster_member resources
+# @param cluster_role_bindings
+#   Hash of sensu_cluster_role_binding resources
+# @param cluster_roles
+#   Hash of sensu_cluster_role resources
+# @param configs
+#   Hash of sensu_config resources
+# @param entities
+#   Hash of sensu_entitie resources
+# @param events
+#   Hash of sensu_event resources
+# @param filters
+#   Hash of sensu_filter resources
+# @param handlers
+#   Hash of sensu_handler resources
+# @param hooks
+#   Hash of sensu_hook resources
+# @param ldap_auths
+#   Hash of sensu_ldap_auth resources
+# @param mutators
+#   Hash of sensu_mutator resources
+# @param namespaces
+#   Hash of sensu_namespace resources
+# @param role_bindings
+#   Hash of sensu_role_binding resources
+# @param roles
+#   Hash of sensu_role resources
+# @param silencings
+#   Hash of sensu_silenced resources
+# @param users
+#   Hash of sensu_user resources
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -73,6 +111,25 @@ class sensu::backend (
   Boolean $show_diff = true,
   Optional[String] $license_source = undef,
   Optional[String] $license_content = undef,
+  Hash $ad_auths = {},
+  Hash $assets = {},
+  Hash $checks = {},
+  Hash $cluster_members = {},
+  Hash $cluster_role_bindings = {},
+  Hash $cluster_roles = {},
+  Hash $configs = {},
+  Hash $entities = {},
+  Hash $events = {},
+  Hash $filters = {},
+  Hash $handlers = {},
+  Hash $hooks = {},
+  Hash $ldap_auths = {},
+  Hash $mutators = {},
+  Hash $namespaces = {},
+  Hash $role_bindings = {},
+  Hash $roles = {},
+  Hash $silencings = {},
+  Hash $users = {},
 ) {
 
   if $license_source and $license_content {
@@ -80,6 +137,7 @@ class sensu::backend (
   }
 
   include ::sensu
+  include ::sensu::backend::resources
 
   $etc_dir = $::sensu::etc_dir
   $ssl_dir = $::sensu::ssl_dir

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -112,7 +112,7 @@ class sensu::backend (
 
 
   if $include_default_resources {
-    include ::sensu::backend::resources
+    include ::sensu::backend::default_resources
   }
 
   package { 'sensu-go-cli':

--- a/manifests/backend/default_resources.pp
+++ b/manifests/backend/default_resources.pp
@@ -1,7 +1,7 @@
 # @summary Default sensu resources
 # @api private
 #
-class sensu::backend::resources {
+class sensu::backend::default_resources {
   include ::sensu::backend
 
   sensu_namespace { 'default':

--- a/manifests/backend/resources.pp
+++ b/manifests/backend/resources.pp
@@ -1,0 +1,101 @@
+# @summary Define sensu resources
+# @api private
+#
+class sensu::backend::resources {
+  include ::sensu::backend
+  $::sensu::backend::ad_auths.each |$name, $ad_auth| {
+    sensu_ad_auth { $name:
+      * => $ad_auth,
+    }
+  }
+  $::sensu::backend::assets.each |$name, $asset| {
+    sensu_asset { $name:
+      * => $asset,
+    }
+  }
+  $::sensu::backend::checks.each |$name, $check| {
+    sensu_check { $name:
+      * => $check,
+    }
+  }
+    $::sensu::backend::cluster_members.each |$name, $cluster_member| {
+    sensu_cluster_member { $name:
+      * => $cluster_member,
+    }
+  }
+  $::sensu::backend::cluster_role_bindings.each |$name, $cluster_role_binding| {
+    sensu_cluster_role_binding { $name:
+      * => $cluster_role_binding,
+    }
+  }
+  $::sensu::backend::cluster_roles.each |$name, $cluster_role| {
+    sensu_cluster_role { $name:
+      * => $cluster_role,
+    }
+  }
+  $::sensu::backend::configs.each |$name, $config| {
+    sensu_config { $name:
+      * => $config,
+    }
+  }
+  $::sensu::backend::entities.each |$name, $entity| {
+    sensu_entity { $name:
+      * => $entity,
+    }
+  }
+  $::sensu::backend::events.each |$name, $event| {
+    sensu_event { $name:
+      * => $event,
+    }
+  }
+  $::sensu::backend::filters.each |$name, $filter| {
+    sensu_filter { $name:
+      * => $filter,
+    }
+  }
+  $::sensu::backend::handlers.each |$name, $handler| {
+    sensu_handler { $name:
+      * => $handler,
+    }
+  }
+  $::sensu::backend::hooks.each |$name, $hook| {
+    sensu_hook { $name:
+      * => $hook,
+    }
+  }
+  $::sensu::backend::ldap_auths.each |$name, $ldap_auth| {
+    sensu_ldap_auth { $name:
+      * => $ldap_auth,
+    }
+  }
+  $::sensu::backend::mutators.each |$name, $mutator| {
+    sensu_mutator { $name:
+      * => $mutator,
+    }
+  }
+  $::sensu::backend::namespaces.each |$name, $namespace| {
+    sensu_namespace { $name:
+      * => $namespace,
+    }
+  }
+  $::sensu::backend::role_bindings.each |$name, $role_binding| {
+    sensu_role_binding { $name:
+      * => $role_binding,
+    }
+  }
+  $::sensu::backend::roles.each |$name, $role| {
+    sensu_role { $name:
+      * => $role,
+    }
+  }
+  $::sensu::backend::silencings.each |$name, $silencing| {
+    sensu_silenced { $name:
+      * => $silencing,
+    }
+  }
+  $::sensu::backend::users.each |$name, $user| {
+    sensu_user { $name:
+      * => $user,
+    }
+  }
+}

--- a/spec/classes/backend_default_resources_spec.rb
+++ b/spec/classes/backend_default_resources_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe 'sensu::backend::resources', :type => :class do
+describe 'sensu::backend::default_resources', :type => :class do
   on_supported_os({facterversion: '3.8.0'}).each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }

--- a/spec/classes/backend_default_resources_spec.rb
+++ b/spec/classes/backend_default_resources_spec.rb
@@ -1,7 +1,10 @@
 require 'spec_helper'
 
 describe 'sensu::backend::default_resources', :type => :class do
-  on_supported_os({facterversion: '3.8.0'}).each do |os, facts|
+  on_supported_os({
+    facterversion: '3.8.0',
+    supported_os: [{ 'operatingsystem' => 'RedHat', 'operatingsystemrelease' => ['7'] }]
+  }).each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
       context 'with default values for all parameters' do

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -1,0 +1,282 @@
+require 'spec_helper'
+
+describe 'sensu::backend::resources', :type => :class do
+  on_supported_os({
+    facterversion: '3.8.0',
+    supported_os: [{ 'operatingsystem' => 'RedHat', 'operatingsystemrelease' => ['7'] }]
+  }).each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      context 'ad_auths defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            ad_auths => {
+              'ad' => {
+                'servers'             => [{'host' => 'test', 'port' => 389}],
+                'server_binding'      => {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}},
+                'server_group_search' => {'test' => {'base_dn' => 'ou=Groups'}},
+                'server_user_search'  => {'test' => {'base_dn' => 'ou=People'}},
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_ad_auth('ad') }
+      end
+      context 'assets defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            assets => {
+              'test' => {
+                'url'    => 'http://localhost',
+                'sha512' => '0e3e75234abc68f4378a86b3f4b32a198ba301845b0cd6e50106e874345700cc6663a86c1ea125dc5e92be17c98f9a0f85ca9d5f595db2012f7cc3571945c123',
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_asset('test') }
+      end
+      context 'checks defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            checks => {
+              'test' => {
+                'command' => 'foobar',
+                'subscriptions' => ['demo'],
+                'handlers' => ['slack'],
+                'interval' => 60,
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_check('test') }
+      end
+      context 'cluster_members defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            cluster_members => {
+              'test' => {
+                'peer_urls' => ['http://localhost:2380'],
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_cluster_member('test') }
+      end
+      context 'cluster_role_bindings defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            cluster_role_bindings => {
+              'test' => {
+                'role_ref' => 'test',
+                'subjects' => [{'type' => 'User', 'name' => 'test'}],
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_cluster_role_binding('test') }
+      end
+      context 'cluster_roles defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            cluster_roles => {
+              'test'  => {
+                'rules' => [{'verbs' => ['get','list'], 'resources' => ['checks']}]
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_cluster_role('test') }
+      end
+      context 'configs defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            configs => {
+              'format' => {
+                'value' => 'json',
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_config('format') }
+      end
+      context 'entities defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            entities => {
+              'test' => {
+                'entity_class' => 'proxy',
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_entity('test') }
+      end
+      context 'events defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            events => {
+              'checkalive for test' => { 'ensure' => 'resolve' }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_event('checkalive for test') }
+      end
+      context 'filters defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            filters => {
+              'test' => {
+                'action'      => 'allow',
+                'expressions' => ['event.Check.Occurrences == 1']
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_filter('test') }
+      end
+      context 'handlers defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            handlers => {
+              'test' => {
+                'type'        => 'pipe',
+                'command'     => 'test',
+                'socket_host' => '127.0.0.1',
+                'socket_port' => 9000,
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_handler('test') }
+      end
+      context 'hooks defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            hooks => {
+              'test' => { 'command' => 'test' },
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_hook('test') }
+      end
+      context 'ldap_auths defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            ldap_auths => {
+              'ldap' => {
+                'servers'             => [{'host' => 'test', 'port' => 389}],
+                'server_binding'      => {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}},
+                'server_group_search' => {'test' => {'base_dn' => 'ou=Groups'}},
+                'server_user_search'  => {'test' => {'base_dn' => 'ou=People'}},
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_ldap_auth('ldap') }
+      end
+      context 'mutators defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            mutators => {
+              'test' => { 'command' => 'test' },
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_mutator('test') }
+      end
+      context 'namespaces defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            namespaces => {
+              'test' => { 'ensure' => 'present' },
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_namespace('test') }
+      end
+      context 'role_bindings defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            role_bindings => {
+              'test' => {
+                'role_ref' => 'test',
+                'subjects' => [{'type' => 'User', 'name' => 'test'}],
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_role_binding('test') }
+      end
+      context 'roles defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            roles => {
+              'test'  => {
+                'rules' => [{'verbs' => ['get','list'], 'resources' => ['checks']}]
+              }
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_role('test') }
+      end
+      context 'silencings defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            silencings => {
+              'test' => { 'subscription' => 'test' },
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_silenced('test') }
+      end
+      context 'users defined' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            users => {
+              'test' => { 'password' => 'foobar' },
+            }
+          }
+          EOS
+        end
+        it { should contain_sensu_user('test') }
+      end
+    end
+  end
+end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -12,7 +12,7 @@ describe 'sensu::backend', :type => :class do
         it { should contain_class('sensu') }
         it { should_not contain_class('sensu::agent') }
         it { should contain_class('sensu::ssl').that_comes_before('Sensu_configure[puppet]') }
-        it { should contain_class('sensu::backend::resources') }
+        it { should contain_class('sensu::backend::default_resources') }
 
         it {
           should contain_package('sensu-go-cli').with({
@@ -189,6 +189,11 @@ describe 'sensu::backend', :type => :class do
         end
         it { should contain_package('sensu-go-cli').without_require }
         it { should contain_package('sensu-go-backend').without_require }
+      end
+
+      context 'with include_default_resources => false' do
+        let(:params) {{ :include_default_resources => false }}
+        it { should_not contain_class('sensu::backend::default_resources') }
       end
 
       context 'with license_source defined' do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This adds ability to define all types via Hiera.  Renamed `sensu::backend::resources` to `sensu::backend::default_resources` to better match purpose of the class and allow these user defined resources to be defined via `sensu::backend::resources`.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This should make it easier for this module to be used with less possible changes needed to something like a profile class.  