### PR TITLE
Do not raise errors if custom puppet facts are undefined

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -101,8 +101,8 @@ class sensu::backend (
   Hash $config_hash = {},
   String $url_host = $trusted['certname'],
   Stdlib::Port $url_port = 8080,
-  String $ssl_cert_source = $facts['puppet_hostcert'],
-  String $ssl_key_source = $facts['puppet_hostprivkey'],
+  Optional[String] $ssl_cert_source = $facts['puppet_hostcert'],
+  Optional[String] $ssl_key_source = $facts['puppet_hostprivkey'],
   String $password = 'P@ssw0rd!',
   Optional[String] $old_password = undef,
   String $agent_password = 'P@ssw0rd!',
@@ -143,6 +143,13 @@ class sensu::backend (
   $ssl_dir = $::sensu::ssl_dir
   $use_ssl = $::sensu::use_ssl
   $_version = pick($version, $::sensu::version)
+
+  if $use_ssl and ! $ssl_cert_source {
+    fail('sensu::backend: ssl_cert_source must be defined when sensu::use_ssl is true')
+  }
+  if $use_ssl and ! $ssl_key_source {
+    fail('sensu::backend: ssl_key_source must be defined when sensu::use_ssl is true')
+  }
 
   if $use_ssl {
     $url_protocol = 'https'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,8 +46,12 @@ class sensu (
   Boolean $ssl_dir_purge = true,
   Boolean $manage_repo = true,
   Boolean $use_ssl = true,
-  String $ssl_ca_source = $facts['puppet_localcacert'],
+  Optional[String] $ssl_ca_source = $facts['puppet_localcacert'],
 ) {
+
+  if $use_ssl and ! $ssl_ca_source {
+    fail('sensu: ssl_ca_source must be defined when use_ssl is true')
+  }
 
   file { 'sensu_etc_dir':
     ensure  => 'directory',

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -132,6 +132,16 @@ describe 'sensu::backend', :type => :class do
         }
       end
 
+      context 'when puppet_hostcert undefined' do
+        let(:facts) { facts.merge(puppet_hostcert: nil) }
+        it { should compile.and_raise_error(/ssl_cert_source must be defined/) }
+      end
+
+      context 'when puppet_hostprivkey undefined' do
+        let(:facts) { facts.merge(puppet_hostprivkey: nil) }
+        it { should compile.and_raise_error(/ssl_key_source must be defined/) }
+      end
+
       context 'with use_ssl => false' do
         let(:pre_condition) do
           "class { 'sensu': use_ssl => false }"
@@ -176,6 +186,16 @@ describe 'sensu::backend', :type => :class do
         }
 
         it { should contain_service('sensu-backend').without_notify }
+
+        context 'when puppet_hostcert undefined' do
+          let(:facts) { facts.merge(puppet_hostcert: nil) }
+          it { should compile }
+        end
+
+        context 'when puppet_hostprivkey undefined' do
+          let(:facts) { facts.merge(puppet_hostprivkey: nil) }
+          it { should compile }
+        end
       end
 
       context 'with show_diff => false' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,6 +25,16 @@ describe 'sensu', :type => :class do
       context 'with use_ssl => false' do
         let(:params) { { :use_ssl => false } }
         it { should_not contain_class('sensu::ssl') }
+
+        context 'when puppet_localcacert undefined' do
+          let(:facts) { facts.merge!(puppet_localcacert: nil) }
+          it { should compile }
+        end
+      end
+
+      context 'when puppet_localcacert undefined' do
+        let(:facts) { facts.merge!(puppet_localcacert: nil) }
+        it { should compile.and_raise_error(/ssl_ca_source must be defined/) }
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Make `sensu::ssl_ca_source`, `sensu::backend::ssl_cert_source` and `sensu::backend::ssl_key_source` optional.  If those parameters are undefined and `sensu::use_ssl` is `true` then an error is raised.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1098

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better support for masterless Puppet where SSL certificates may not exist by default and the custom Puppet facts will be undefined or point to non-existent paths.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and beaker, unit tests updated to test several conditions.