### PR TITLE
Support opting out of tessen phone home

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -51,6 +51,10 @@
 # @param license_content
 #   The content of sensu-go enterprise license
 #   Do not define with license_source
+# @param manage_tessen
+#   Boolean that determines if Tessen is managed
+# @param tessen_ensure
+#   Determine if Tessen is opt-in (present) or opt-out (absent)
 # @param ad_auths
 #   Hash of sensu_ad_auth resources
 # @param assets
@@ -111,6 +115,8 @@ class sensu::backend (
   Boolean $show_diff = true,
   Optional[String] $license_source = undef,
   Optional[String] $license_content = undef,
+  Boolean $manage_tessen = true,
+  Enum['present','absent'] $tessen_ensure = 'present',
   Hash $ad_auths = {},
   Hash $assets = {},
   Hash $checks = {},
@@ -138,6 +144,9 @@ class sensu::backend (
 
   include ::sensu
   include ::sensu::backend::resources
+  if $manage_tessen {
+    include ::sensu::backend::tessen
+  }
 
   $etc_dir = $::sensu::etc_dir
   $ssl_dir = $::sensu::ssl_dir

--- a/manifests/backend/tessen.pp
+++ b/manifests/backend/tessen.pp
@@ -1,0 +1,24 @@
+# @summary Manage tessen phone home
+# @api private
+#
+class sensu::backend::tessen {
+  include ::sensu::backend
+
+  if $::sensu::backend::tessen_ensure == 'present' {
+    $command = 'sensuctl tessen opt-in'
+    $match = 'true' # lint:ignore:quoted_booleans
+  } else {
+    $command = 'sensuctl tessen opt-out --skip-confirm'
+    $match = 'false' # lint:ignore:quoted_booleans
+  }
+
+  exec { $command:
+    path    => '/usr/bin:/bin:/usr/sbin:/sbin',
+    onlyif  => "sensuctl tessen info --format json | grep 'opt_out' | grep -q ${match}",
+    require => [
+      Sensu_configure['puppet'],
+      Sensu_user['admin'],
+    ],
+  }
+
+}

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -54,12 +54,13 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
     end
   end
 
-  context 'reset admin password' do
+  context 'reset admin password and opt-out tessen' do
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu::backend':
-        password     => 'P@ssw0rd!',
-        old_password => 'supersecret',
+        password      => 'P@ssw0rd!',
+        old_password  => 'supersecret',
+        tessen_ensure => 'absent',
       }
       EOS
 
@@ -71,6 +72,13 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
     describe service('sensu-backend'), :node => node do
       it { should be_enabled }
       it { should be_running }
+    end
+
+    it 'should opt-out of tessen' do
+      on node, 'sensuctl tessen info --format json' do
+        data = JSON.parse(stdout)
+        expect(data['opt_out']).to eq(true)
+      end
     end
   end
 end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -13,6 +13,7 @@ describe 'sensu::backend', :type => :class do
         it { should_not contain_class('sensu::agent') }
         it { should contain_class('sensu::ssl').that_comes_before('Sensu_configure[puppet]') }
         it { should contain_class('sensu::backend::default_resources') }
+        it { should contain_class('sensu::backend::tessen') }
 
         it {
           should contain_package('sensu-go-cli').with({
@@ -271,6 +272,11 @@ describe 'sensu::backend', :type => :class do
         it 'should fail' do
            is_expected.to compile.and_raise_error(/Do not define both license_source and license_content/)
         end
+      end
+
+      context 'manage_tessen => false' do
+        let(:params) {{ :manage_tessen => false }}
+        it { is_expected.not_to contain_class('sensu::backend::tessen') }
       end
     end
   end

--- a/spec/classes/backend_tessen_spec.rb
+++ b/spec/classes/backend_tessen_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+
+describe 'sensu::backend::tessen', :type => :class do
+  on_supported_os({
+    facterversion: '3.8.0',
+    supported_os: [{ 'operatingsystem' => 'RedHat', 'operatingsystemrelease' => ['7'] }]
+  }).each do |os, facts|
+    context "on #{os}" do
+      let(:facts) { facts }
+      context 'default (present)' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend': }
+          EOS
+        end
+        it do
+          should contain_exec('sensuctl tessen opt-in').with({
+            :path => '/usr/bin:/bin:/usr/sbin:/sbin',
+            :onlyif   => "sensuctl tessen info --format json | grep 'opt_out' | grep -q true",
+            :require  => [
+              'Sensu_configure[puppet]',
+              'Sensu_user[admin]',
+            ]
+          })
+        end
+      end
+      context 'opt-out (absent)' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            tessen_ensure => 'absent',
+          }
+          EOS
+        end
+        it do
+          should contain_exec('sensuctl tessen opt-out --skip-confirm').with({
+            :path => '/usr/bin:/bin:/usr/sbin:/sbin',
+            :onlyif   => "sensuctl tessen info --format json | grep 'opt_out' | grep -q false",
+            :require  => [
+              'Sensu_configure[puppet]',
+              'Sensu_user[admin]',
+            ]
+          })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support the ability to opt out of tessen phone home.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.5 added Tessen phone-home and is opt-in by default.  This change maintains default behavior of opt-in but makes it easy to opt-out.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit and acceptance.
