### PR TITLE
Fix cluster tests to work with Sensu Go 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,6 +149,9 @@ matrix:
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6
     bundler_args:
     script: bundle exec rake beaker
-
+branches:
+  only:
+    - master
+    - /^v\d/
 notifications:
   email: false

--- a/spec/acceptance/02_backend_cluster_spec.rb
+++ b/spec/acceptance/02_backend_cluster_spec.rb
@@ -57,14 +57,14 @@ describe 'sensu::backend cluster class', if: RSpec.configuration.sensu_cluster d
     end
     it 'should have cluster members' do
       on node1, 'sensuctl cluster member-list --format json' do
-        data = JSON.parse(stdout.split(/\n\n/)[1])
+        data = JSON.parse(stdout)
         expect(data['members'].size).to eq(2)
       end
     end
 
     it 'should be healthy' do
       on node1, 'sensuctl cluster health --format json' do
-        data = JSON.parse(stdout.split(/\n\n/)[1])
+        data = JSON.parse(stdout)
         healthy = data.select { |m| m['Healthy'] == true }
         expect(healthy.size).to eq(2)
       end
@@ -106,7 +106,7 @@ describe 'sensu::backend cluster class', if: RSpec.configuration.sensu_cluster d
 
     it 'should have new cluster member' do
       on node1, 'sensuctl cluster member-list --format json' do
-        data = JSON.parse(stdout.split(/\n\n/)[1])
+        data = JSON.parse(stdout)
         member = data['members'].select { |m| m['name'] == 'backend3' }[0]
         expect(member['peerURLs']).to eq(["http://#{fact_on(node3, 'ipaddress')}:2380"])
       end
@@ -114,7 +114,7 @@ describe 'sensu::backend cluster class', if: RSpec.configuration.sensu_cluster d
 
     it 'should be healthy' do
       on node1, 'sensuctl cluster health --format json' do
-        data = JSON.parse(stdout.split(/\n\n/)[1])
+        data = JSON.parse(stdout)
         healthy = data.select { |m| m['Healthy'] == true }
         expect(healthy.size).to eq(3)
       end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix cluster acceptance tests to work with sensu go 5.7

The Puppet provider has extra logic to handle both old and fixed JSON but the acceptance tests were targeted at latest release which now fixes JSON output.

Fix upstream: https://github.com/sensu/sensu-go/pull/2924