### PR TITLE
Support listing sensuctl resources using chunk-size

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
     * [Resource purging](#resource-purging)
     * [Sensu backend cluster](#sensu-backend-cluster)
         * [Adding backend members to an existing cluster](#adding-backend-members-to-an-existing-cluster)
+    * [Large Environment Considerations](#large-environment-considerations)
 4. [Reference](#reference)
     * [Facts](#facts)
 5. [Limitations - OS compatibility, etc.](#limitations)
@@ -470,6 +471,16 @@ sensu::backend::config_hash:
 ```
 
 The first step will not fully add the node to the cluster until the second step is performed.
+
+### Large Environment Considerations
+
+If the backend system has a large number of resources it may be necessary to query resources using chunk size added in Sensu Go 5.8.
+
+```
+class { '::sensu::backend':
+  sensuctl_chunk_size => 100,
+}
+```
 
 ## Reference
 

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -7,6 +7,10 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
 
   commands :sensuctl => 'sensuctl'
 
+  class << self
+    attr_accessor :chunk_size
+  end
+
   def self.config_path
     # https://github.com/sensu/sensu-puppet/issues/1072
     # since $HOME is not set in systemd service File.expand_path('~') won't work
@@ -51,6 +55,10 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
     end
     args << '--format'
     args << 'json'
+    if ! chunk_size.nil?
+      args << '--chunk-size'
+      args << chunk_size.to_s
+    end
     data = []
     output = sensuctl(args)
     Puppet.debug("sensuctl #{args.join(' ')}: #{output}")

--- a/lib/puppet/type/sensuctl_config.rb
+++ b/lib/puppet/type/sensuctl_config.rb
@@ -1,0 +1,35 @@
+require_relative '../../puppet_x/sensu/type'
+require_relative '../../puppet_x/sensu/array_property'
+require_relative '../../puppet_x/sensu/hash_property'
+require_relative '../../puppet_x/sensu/integer_property'
+
+Puppet::Type.newtype(:sensuctl_config) do
+  desc <<-DESC
+@summary Abstract type to configure other types
+DESC
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the resource."
+  end
+
+  newparam(:chunk_size, :parent => PuppetX::Sensu::IntegerProperty) do
+    desc "sensuctl chunk-size"
+  end
+
+  # First collect all types with sensuctl provider that come from this module
+  # For each sensuctl type, set the class variable 'chunk_size' used by
+  # each provider to list resources
+  # Return empty array since we are not actually generating resources
+  def generate
+    sensuctl_types = []
+    Dir[File.join(File.dirname(__FILE__), '../provider/sensu_*/sensuctl.rb')].each do |file|
+      type = File.basename(File.dirname(file))
+      sensuctl_types << type.to_sym
+    end
+    sensuctl_types.each do |type|
+      provider_class = Puppet::Type.type(type).provider(:sensuctl)
+      provider_class.chunk_size = self[:chunk_size]
+    end
+    []
+  end
+end

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -93,6 +93,8 @@
 #   Hash of sensu_silenced resources
 # @param users
 #   Hash of sensu_user resources
+# @param sensuctl_chunk_size
+#   Chunk size to use when listing sensuctl resources
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -136,6 +138,7 @@ class sensu::backend (
   Hash $roles = {},
   Hash $silencings = {},
   Hash $users = {},
+  Optional[Integer] $sensuctl_chunk_size = undef,
 ) {
 
   if $license_source and $license_content {
@@ -193,6 +196,10 @@ class sensu::backend (
     ensure  => $_version,
     name    => $cli_package_name,
     require => $::sensu::package_require,
+  }
+
+  sensuctl_config { 'sensu':
+    chunk_size => $sensuctl_chunk_size,
   }
 
   sensu_api_validator { 'sensu':

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -54,6 +54,32 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
     end
   end
 
+  context 'with chunk size' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      class { '::sensu::backend':
+        sensuctl_chunk_size => 1,
+      }
+      sensu_check { 'test3':
+        command       => 'check-http3.rb',
+        subscriptions => ['demo'],
+        handlers      => ['email'],
+        interval      => 60,
+      }
+      sensu_check { 'test4':
+        command       => 'check-cpu4.rb',
+        subscriptions => ['demo'],
+        handlers      => ['email'],
+        interval      => 60,
+      }
+      EOS
+
+      # Run it twice and test for idempotency
+      apply_manifest_on(node, pp, :catch_failures => true)
+      apply_manifest_on(node, pp, :catch_changes  => true)
+    end
+  end
+
   context 'updates check' do
     it 'should work without errors' do
       pp = <<-EOS

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -64,6 +64,18 @@ add_custom_fact :puppet_localcacert, ->(os, facts) {
   end
 }
 
+# Gets an array of types that have sensuctl provider
+# This logic is similar to that used by sensuctl_config type
+# Used in sensuctl_config tests
+def sensuctl_types
+  types = []
+  Dir[File.join(File.dirname(__FILE__), '..', 'lib/puppet/provider') + '/*/sensuctl.rb'].each do |f|
+    type = File.basename(File.dirname(f))
+    types << type.to_sym
+  end
+  types
+end
+
 def platforms
   {
     'Debian' => {

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -33,6 +33,13 @@ describe Puppet::Provider::Sensuctl do
       data = subject.sensuctl_list('check')
       expect(data).to eq([])
     end
+
+    it 'should execute with chunk-size' do
+      subject.chunk_size = 100
+      expected_args = ['check','list','--all-namespaces','--format','json','--chunk-size','100']
+      expect(subject).to receive(:sensuctl).with(expected_args).and_return("{}\n")
+      subject.sensuctl_list('check')
+    end
   end
 
   context 'sensuctl_create' do

--- a/spec/unit/sensuctl_config_spec.rb
+++ b/spec/unit/sensuctl_config_spec.rb
@@ -1,0 +1,172 @@
+require 'spec_helper'
+require 'puppet/type/sensuctl_config'
+
+describe Puppet::Type.type(:sensuctl_config) do
+  let(:default_config) do
+    {name: 'sensu'}
+  end
+  let(:config) do
+    default_config
+  end
+  let(:sensuctl_config) do
+    described_class.new(config)
+  end
+
+  it 'should add to catalog without raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource sensuctl_config
+    }.to_not raise_error
+  end
+
+  it 'should require a name' do
+    expect {
+      described_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  defaults = {}
+
+  # String properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 'foo'
+      expect(sensuctl_config[property]).to eq('foo')
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # String regex validated properties
+  [
+  ].each do |property|
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo bar'
+      expect { sensuctl_config }.to raise_error(Puppet::Error, /#{property.to_s} invalid/)
+    end
+  end
+
+  # Array properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = ['foo', 'bar']
+      expect(sensuctl_config[property]).to eq(['foo', 'bar'])
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Integer properties
+  [
+    :chunk_size,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 30
+      expect(sensuctl_config[property]).to eq(30)
+    end
+    it "should accept valid #{property} as string" do
+      config[property] = '30'
+      expect(sensuctl_config[property]).to eq(30)
+    end
+    it "should not accept invalid value for #{property}" do
+      config[property] = 'foo'
+      expect { sensuctl_config }.to raise_error(Puppet::Error, /should be an Integer/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Boolean properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = true
+      expect(sensuctl_config[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = false
+      expect(sensuctl_config[property]).to eq(:false)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'true'
+      expect(sensuctl_config[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'false'
+      expect(sensuctl_config[property]).to eq(:false)
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { sensuctl_config }.to raise_error(Puppet::Error, /Invalid value "foo". Valid values are true, false/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Hash properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = { 'foo': 'bar' }
+      expect(sensuctl_config[property]).to eq({'foo': 'bar'})
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { sensuctl_config }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(sensuctl_config[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  describe 'generate' do
+    before do
+      sensuctl_config[:chunk_size] = 100
+      sensuctl_config.generate
+    end
+
+    sensuctl_types.each do |type|
+      it "should configure #{type} with chunk-size" do
+        resource = Puppet::Type.type(type)
+        provider_class = resource.provider(:sensuctl)
+        expect(provider_class.chunk_size).to eq(100)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for passing `--chunk-size` when listing sensuctl resources.

Adds `sensuctl_chunk_size` parameter to `sensu::backend` class.  Default is not to use `--chunk-size` to maintain compatibility with versions of Sensu Go before 5.8.

The `sensuctl_config` type is abstract type capable of configuring other types so that one value can be passed to multiple types and used in prefetch before a type's parameters are evaluated.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.8 added `--chunk-size` flag to list commands and this adds support for that new flag. This would be useful for sites with large number of resources in their backend where chunking requests would be needed to avoid timeouts.

WIP:

- [x] Remove commented out code if not needed
- [x] Document in README?
- [x] Add acceptance tests