### PR TITLE
Better support for resources in different namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
     * [Sensu backend cluster](#sensu-backend-cluster)
         * [Adding backend members to an existing cluster](#adding-backend-members-to-an-existing-cluster)
     * [Large Environment Considerations](#large-environment-considerations)
+    * [Composite Names for Namespaces](#composite-names-for-namespaces)
 4. [Reference](#reference)
     * [Facts](#facts)
 5. [Limitations - OS compatibility, etc.](#limitations)
@@ -481,6 +482,35 @@ class { '::sensu::backend':
   sensuctl_chunk_size => 100,
 }
 ```
+
+### Composite Names for Namespaces
+
+All resources that support having a `namespace` also support a composite name to define the namespace.
+
+For example, the `sensu_check` with name `check-cpu in team1` would be named `check-cpu` and put into the `team1` namespace.
+
+Using composite names is necessary if you wish to have multiple resources with the same name but in different namespaces.
+
+For example to define the same check in two namespaces using the same check name:
+
+```puppet
+sensu_check { 'check-cpu in default':
+  ensure        => 'present',
+  command       => 'check-cpu.sh -w 75 -c 90',
+  interval      => 60,
+  subscriptions => ['linux'],
+}
+sensu_check { 'check-cpu in team1':
+  ensure        => 'present',
+  command       => 'check-cpu.sh -w 75 -c 90',
+  interval      => 60,
+  subscriptions => ['linux'],
+}
+```
+
+The example above would add the `check-cpu` check to both the `default` and `team1` namespaces.
+
+**NOTE:** If you use composite names for namespaces, the `namespace` property takes precedence.
 
 ## Reference
 

--- a/lib/puppet/provider/sensu_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_asset/sensuctl.rb
@@ -13,8 +13,9 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
     data.each do |d|
       asset = {}
       asset[:ensure] = :present
-      asset[:name] = d['metadata']['name']
+      asset[:resource_name] = d['metadata']['name']
       asset[:namespace] = d['metadata']['namespace']
+      asset[:name] = "#{asset[:resource_name]} in #{asset[:namespace]}"
       asset[:labels] = d['metadata']['labels']
       asset[:annotations] = d['metadata']['annotations']
       d.each_pair do |key, value|
@@ -34,7 +35,7 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
   def self.prefetch(resources)
     assets = instances
     resources.keys.each do |name|
-      if provider = assets.find { |c| c.name == name }
+      if provider = assets.find { |c| c.resource_name == resources[name][:resource_name] && c.namespace == resources[name][:namespace] }
         resources[name].provider = provider
       end
     end
@@ -58,7 +59,7 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
   def create
     spec = {}
     metadata = {}
-    metadata[:name] = resource[:name]
+    metadata[:name] = resource[:resource_name]
     type_properties.each do |property|
       value = resource[property]
       next if value.nil?
@@ -88,7 +89,7 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
     if !@property_flush.empty?
       spec = {}
       metadata = {}
-      metadata[:name] = resource[:name]
+      metadata[:name] = resource[:resource_name]
       type_properties.each do |property|
         if @property_flush[property]
           value = @property_flush[property]
@@ -122,7 +123,7 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
 
   def destroy
     begin
-      sensuctl_delete('asset', resource[:name])
+      sensuctl_delete('asset', resource[:resource_name], resource[:namespace])
     rescue Exception => e
       raise Puppet::Error, "sensuctl delete asset #{resource[:name]} failed\nError message: #{e.message}"
     end

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -88,11 +88,15 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
     self.class.sensuctl_create(*args)
   end
 
-  def self.sensuctl_delete(command, name)
+  def self.sensuctl_delete(command, name, namespace = nil)
     args = [command]
     args << 'delete'
     args << name
     args << '--skip-confirm'
+    if namespace
+      args << '--namespace'
+      args << namespace
+    end
     sensuctl(args)
   end
   def sensuctl_delete(*args)

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -26,6 +26,13 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
         handlers      => ['email'],
         interval      => 60,
       }
+      sensu_namespace { 'test': ensure => 'present' }
+      sensu_check { 'test2 in test':
+        command       => 'check-cpu.rb',
+        subscriptions => ['demo'],
+        handlers      => ['email'],
+        interval      => 60,
+      }
       EOS
 
       if RSpec.configuration.sensu_use_agent
@@ -51,6 +58,14 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
         expect(data['proxy_requests']['entity_attributes']).to eq(["entity.Class == 'proxy'"])
         expect(data['output_metric_format']).to eq('nagios_perfdata')
         expect(data['metadata']['labels']['foo']).to eq('baz')
+      end
+    end
+
+    it 'should have a valid check in namespace' do
+      on node, 'sensuctl check info test2 --namespace test --format json' do
+        data = JSON.parse(stdout)
+        expect(data['metadata']['name']).to eq('test2')
+        expect(data['metadata']['namespace']).to eq('test')
       end
     end
 

--- a/spec/unit/provider/sensu_asset/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_asset/sensuctl_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
     it 'should return the resource for a asset' do
       allow(@provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('check-cpu.sh')
+      expect(property_hash[:name]).to eq('check-cpu.sh in default')
     end
   end
 
@@ -78,7 +78,7 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a asset' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('asset', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('asset', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_check/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_check/sensuctl_spec.rb
@@ -22,7 +22,7 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
     it 'should return the resource for a check' do
       allow(@provider).to receive(:sensuctl_list).with('check').and_return(JSON.parse(my_fixture_read('check_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('check-cpu')
+      expect(property_hash[:name]).to eq('check-cpu in default')
     end
   end
 
@@ -113,7 +113,7 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a check' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('check', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('check', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_entity/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_entity/sensuctl_spec.rb
@@ -15,7 +15,7 @@ describe Puppet::Type.type(:sensu_entity).provider(:sensuctl) do
     it 'should return the @resource for a entity' do
       allow(@provider).to receive(:sensuctl_list).with('entity').and_return(JSON.parse(my_fixture_read('entity_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('sensu-backend.example.com')
+      expect(property_hash[:name]).to eq('sensu-backend.example.com in default')
     end
   end
 
@@ -55,7 +55,7 @@ describe Puppet::Type.type(:sensu_entity).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a entity' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('entity', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('entity', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_filter/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_filter/sensuctl_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Type.type(:sensu_filter).provider(:sensuctl) do
     it 'should return the resource for a filter' do
       allow(@provider).to receive(:sensuctl_list).with('filter').and_return(JSON.parse(my_fixture_read('filter_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('production_filter')
+      expect(property_hash[:name]).to eq('production_filter in default')
     end
   end
 
@@ -59,7 +59,7 @@ describe Puppet::Type.type(:sensu_filter).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a filter' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('filter', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('filter', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_handler/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_handler/sensuctl_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
     it 'should return the resource for a handler' do
       allow(@provider).to receive(:sensuctl_list).with('handler').and_return(JSON.parse(my_fixture_read('handler_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('tcp_handler')
+      expect(property_hash[:name]).to eq('tcp_handler in default')
     end
   end
 
@@ -98,7 +98,7 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a handler' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('handler', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('handler', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_hook/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_hook/sensuctl_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Type.type(:sensu_hook).provider(:sensuctl) do
     it 'should return the resource for a hook' do
       allow(@provider).to receive(:sensuctl_list).with('hook').and_return(JSON.parse(my_fixture_read('hook_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('process_tree')
+      expect(property_hash[:name]).to eq('process_tree in default')
     end
   end
 
@@ -60,7 +60,7 @@ describe Puppet::Type.type(:sensu_hook).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a hook' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('hook', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('hook', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_mutator/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_mutator/sensuctl_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Type.type(:sensu_mutator).provider(:sensuctl) do
     it 'should return the resource for a mutator' do
       allow(@provider).to receive(:sensuctl_list).with('mutator').and_return(JSON.parse(my_fixture_read('mutator_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('example-mutator')
+      expect(property_hash[:name]).to eq('example-mutator in default')
     end
   end
 
@@ -71,7 +71,7 @@ describe Puppet::Type.type(:sensu_mutator).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a mutator' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('mutator', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('mutator', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_role/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_role/sensuctl_spec.rb
@@ -19,7 +19,7 @@ describe Puppet::Type.type(:sensu_role).provider(:sensuctl) do
     it 'should return the resource for a role' do
       allow(@provider).to receive(:sensuctl_list).with('role').and_return(JSON.parse(my_fixture_read('role_list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('prod-admin')
+      expect(property_hash[:name]).to eq('prod-admin in default')
       expect(property_hash[:rules]).to include({'verbs' => ['get','list','create','update','delete'], 'resources' => ['*'], 'resource_names' => []})
     end
   end
@@ -57,7 +57,7 @@ describe Puppet::Type.type(:sensu_role).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a role' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('role', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('role', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
@@ -20,7 +20,7 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
     it 'should return the resource for a role_binding' do
       allow(@provider).to receive(:sensuctl_list).with('role-binding').and_return(JSON.parse(my_fixture_read('list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('test')
+      expect(property_hash[:name]).to eq('test in default')
       expect(property_hash[:role_ref]).to eq('test')
     end
   end
@@ -60,7 +60,7 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
 
   describe 'destroy' do
     it 'should delete a role_binding' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('role-binding', 'test')
+      expect(@resource.provider).to receive(:sensuctl_delete).with('role-binding', 'test', 'default')
       @resource.provider.destroy
       property_hash = @resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})

--- a/spec/unit/sensu_asset_spec.rb
+++ b/spec/unit/sensu_asset_spec.rb
@@ -29,6 +29,33 @@ describe Puppet::Type.type(:sensu_asset) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(asset[:name]).to eq('test in dev')
+    expect(asset[:resource_name]).to eq('test')
+    expect(asset[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(asset[:name]).to eq('test')
+    expect(asset[:resource_name]).to eq('test')
+    expect(asset[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(asset[:resource_name]).to eq('test')
+    expect(asset[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { asset }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   it 'should not accept ensure => absent' do
     config[:ensure] = 'absent'
     expect { asset[:ensure] = 'absent' }.to raise_error(Puppet::Error, /ensure does not support absent/)
@@ -184,7 +211,7 @@ describe Puppet::Type.type(:sensu_asset) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { asset }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { asset.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 end

--- a/spec/unit/sensu_entity_spec.rb
+++ b/spec/unit/sensu_entity_spec.rb
@@ -28,6 +28,33 @@ describe Puppet::Type.type(:sensu_entity) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(entity[:name]).to eq('test in dev')
+    expect(entity[:resource_name]).to eq('test')
+    expect(entity[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(entity[:name]).to eq('test')
+    expect(entity[:resource_name]).to eq('test')
+    expect(entity[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(entity[:resource_name]).to eq('test')
+    expect(entity[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { entity }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   defaults = {
     'namespace': 'default',
     'deregister': :false,
@@ -201,7 +228,7 @@ describe Puppet::Type.type(:sensu_entity) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { entity }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { entity.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 end

--- a/spec/unit/sensu_filter_spec.rb
+++ b/spec/unit/sensu_filter_spec.rb
@@ -29,6 +29,33 @@ describe Puppet::Type.type(:sensu_filter) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(filter[:name]).to eq('test in dev')
+    expect(filter[:resource_name]).to eq('test')
+    expect(filter[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(filter[:name]).to eq('test')
+    expect(filter[:resource_name]).to eq('test')
+    expect(filter[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(filter[:resource_name]).to eq('test')
+    expect(filter[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { filter }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   it 'should accept action allow' do
     filter[:action] = 'allow'
     expect(filter[:action]).to eq(:allow)
@@ -204,7 +231,7 @@ describe Puppet::Type.type(:sensu_filter) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { filter }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { filter.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 end

--- a/spec/unit/sensu_handler_spec.rb
+++ b/spec/unit/sensu_handler_spec.rb
@@ -31,6 +31,33 @@ describe Puppet::Type.type(:sensu_handler) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(handler[:name]).to eq('test in dev')
+    expect(handler[:resource_name]).to eq('test')
+    expect(handler[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(handler[:name]).to eq('test')
+    expect(handler[:resource_name]).to eq('test')
+    expect(handler[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(handler[:resource_name]).to eq('test')
+    expect(handler[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { handler }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   it 'should accept type' do
     handler[:type] = 'tcp'
     expect(handler[:type]).to eq(:tcp)
@@ -252,38 +279,38 @@ describe Puppet::Type.type(:sensu_handler) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { handler }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { handler.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 
   it 'should require command for type pipe' do
     config.delete(:command)
-    expect { handler }.to raise_error(Puppet::Error, /command must be defined for type pipe/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /command must be defined for type pipe/)
   end
 
   it 'should require socket_host and socket_port' do
     config.delete(:socket_port)
-    expect { handler }.to raise_error(Puppet::Error, /socket_port is required if socket_host is set/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_port is required if socket_host is set/)
   end
   it 'should require socket_host and socket_port' do
     config.delete(:socket_host)
-    expect { handler }.to raise_error(Puppet::Error, /socket_host is required if socket_port is set/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_host is required if socket_port is set/)
   end
   it 'should require socket properties for tcp type' do
     config.delete(:socket_host)
     config.delete(:socket_port)
     config[:type] = :tcp
-    expect { handler }.to raise_error(Puppet::Error, /socket_host and socket_port are required for type tcp or type udp/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_host and socket_port are required for type tcp or type udp/)
   end
   it 'should require socket properties for udp type' do
     config.delete(:socket_host)
     config.delete(:socket_port)
     config[:type] = :udp
-    expect { handler }.to raise_error(Puppet::Error, /socket_host and socket_port are required for type tcp or type udp/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_host and socket_port are required for type tcp or type udp/)
   end
   it 'should require handlers for type set' do
     config[:type] = 'set'
     config.delete(:handlers)
-    expect { handler }.to raise_error(Puppet::Error, /handlers must be defined for type set/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /handlers must be defined for type set/)
   end
 end

--- a/spec/unit/sensu_hook_spec.rb
+++ b/spec/unit/sensu_hook_spec.rb
@@ -28,6 +28,33 @@ describe Puppet::Type.type(:sensu_hook) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(hook[:name]).to eq('test in dev')
+    expect(hook[:resource_name]).to eq('test')
+    expect(hook[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(hook[:name]).to eq('test')
+    expect(hook[:resource_name]).to eq('test')
+    expect(hook[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(hook[:resource_name]).to eq('test')
+    expect(hook[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { hook }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   defaults = {
     'namespace': 'default',
     'timeout': 60,
@@ -178,7 +205,7 @@ describe Puppet::Type.type(:sensu_hook) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { hook }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { hook.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 end

--- a/spec/unit/sensu_mutator_spec.rb
+++ b/spec/unit/sensu_mutator_spec.rb
@@ -28,6 +28,33 @@ describe Puppet::Type.type(:sensu_mutator) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(mutator[:name]).to eq('test in dev')
+    expect(mutator[:resource_name]).to eq('test')
+    expect(mutator[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(mutator[:name]).to eq('test')
+    expect(mutator[:resource_name]).to eq('test')
+    expect(mutator[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(mutator[:resource_name]).to eq('test')
+    expect(mutator[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { mutator }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   defaults = {
     'namespace': 'default',
   }
@@ -188,7 +215,7 @@ describe Puppet::Type.type(:sensu_mutator) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { mutator }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { mutator.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 end

--- a/spec/unit/sensu_role_binding_spec.rb
+++ b/spec/unit/sensu_role_binding_spec.rb
@@ -29,6 +29,33 @@ describe Puppet::Type.type(:sensu_role_binding) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(binding[:name]).to eq('test in dev')
+    expect(binding[:resource_name]).to eq('test')
+    expect(binding[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(binding[:name]).to eq('test')
+    expect(binding[:resource_name]).to eq('test')
+    expect(binding[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(binding[:resource_name]).to eq('test')
+    expect(binding[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { binding }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   defaults = {
     namespace: 'default',
   }
@@ -192,7 +219,7 @@ describe Puppet::Type.type(:sensu_role_binding) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { binding }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { binding.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 end

--- a/spec/unit/sensu_role_spec.rb
+++ b/spec/unit/sensu_role_spec.rb
@@ -28,6 +28,33 @@ describe Puppet::Type.type(:sensu_role) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  it 'should handle composite title' do
+    config.delete(:namespace)
+    config[:name] = 'test in dev'
+    expect(role[:name]).to eq('test in dev')
+    expect(role[:resource_name]).to eq('test')
+    expect(role[:namespace]).to eq('dev')
+  end
+
+  it 'should handle non-composite title' do
+    config[:name] = 'test'
+    expect(role[:name]).to eq('test')
+    expect(role[:resource_name]).to eq('test')
+    expect(role[:namespace]).to eq('default')
+  end
+
+  it 'should handle composite title and namespace' do
+    config[:namespace] = 'test'
+    config[:name] = 'test in qa'
+    expect(role[:resource_name]).to eq('test')
+    expect(role[:namespace]).to eq('test')
+  end
+
+  it 'should handle invalid composites' do
+    config[:name] = 'test test in qa'
+    expect { role }.to raise_error(Puppet::Error, /name invalid/)
+  end
+
   defaults = {
     :namespace => 'default',
   }
@@ -161,7 +188,7 @@ describe Puppet::Type.type(:sensu_role) do
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
-      expect { role }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+      expect { role.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resources that can belong to a namespace now support composite names in form of "<name> in <namespace>". This change is backwards compatible. I did have to change how some properties are validated as doing `validate do` for an entire type was not working with composite names. The official Puppet docs for custom types only document the use of `pre_run_check` which essentially does the same thing, performs validation after the catalog is compiled but before the catalog is applied. This is how properties are validated against other properties.

This also resolves a bug where it would have been impossible to delete a resource if it was not in the `default` namespace.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Partial fix for #1125 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In Sensu Go resources that belong to namespaces can have the same name so long as they are in different namespaces. This change ensures the Puppet types support this same behavior by matching resources by name + namespace and not just name.