### PR TITLE
Support role_ref property being Hash

### DIFF
--- a/lib/puppet/provider/sensu_cluster_role_binding/sensuctl.rb
+++ b/lib/puppet/provider/sensu_cluster_role_binding/sensuctl.rb
@@ -14,7 +14,7 @@ Puppet::Type.type(:sensu_cluster_role_binding).provide(:sensuctl, :parent => Pup
       binding = {}
       binding[:ensure] = :present
       binding[:name] = d['metadata']['name']
-      binding[:role_ref] = d['role_ref']['name']
+      binding[:role_ref] = d['role_ref']
       binding[:subjects] = d['subjects']
       bindings << new(binding)
     end
@@ -49,7 +49,6 @@ Puppet::Type.type(:sensu_cluster_role_binding).provide(:sensuctl, :parent => Pup
     spec = {}
     metadata = {}
     metadata[:name] = resource[:name]
-    spec[:role_ref] = { type: 'ClusterRole' }
     type_properties.each do |property|
       value = resource[property]
       next if value.nil?
@@ -57,11 +56,7 @@ Puppet::Type.type(:sensu_cluster_role_binding).provide(:sensuctl, :parent => Pup
       if [:true, :false].include?(value)
         value = convert_boolean_property_value(value)
       end
-      if property == :role_ref
-        spec[:role_ref][:name] = value
-      else
-        spec[property] = value
-      end
+      spec[property] = value
     end
     begin
       sensuctl_create('ClusterRoleBinding', metadata, spec)
@@ -76,7 +71,6 @@ Puppet::Type.type(:sensu_cluster_role_binding).provide(:sensuctl, :parent => Pup
       spec = {}
       metadata = {}
       metadata[:name] = resource[:name]
-      spec[:role_ref] = { type: 'ClusterRole' }
       type_properties.each do |property|
         if @property_flush[property]
           value = @property_flush[property]
@@ -89,11 +83,7 @@ Puppet::Type.type(:sensu_cluster_role_binding).provide(:sensuctl, :parent => Pup
         elsif value == :absent
           value = nil
         end
-        if property == :role_ref
-          spec[:role_ref][:name] = value
-        else
-          spec[property] = value
-        end
+        spec[property] = value
       end
       begin
         sensuctl_create('ClusterRoleBinding', metadata, spec)

--- a/lib/puppet/provider/sensu_role_binding/sensuctl.rb
+++ b/lib/puppet/provider/sensu_role_binding/sensuctl.rb
@@ -16,7 +16,7 @@ Puppet::Type.type(:sensu_role_binding).provide(:sensuctl, :parent => Puppet::Pro
       binding[:resource_name] = d['metadata']['name']
       binding[:namespace] = d['metadata']['namespace']
       binding[:name] = "#{binding[:resource_name]} in #{binding[:namespace]}"
-      binding[:role_ref] = d['role_ref']['name']
+      binding[:role_ref] = d['role_ref']
       binding[:subjects] = d['subjects']
       bindings << new(binding)
     end
@@ -51,7 +51,6 @@ Puppet::Type.type(:sensu_role_binding).provide(:sensuctl, :parent => Puppet::Pro
     spec = {}
     metadata = {}
     metadata[:name] = resource[:resource_name]
-    spec[:role_ref] = { type: 'Role' }
     type_properties.each do |property|
       value = resource[property]
       next if value.nil?
@@ -59,9 +58,7 @@ Puppet::Type.type(:sensu_role_binding).provide(:sensuctl, :parent => Puppet::Pro
       if [:true, :false].include?(value)
         value = convert_boolean_property_value(value)
       end
-      if property == :role_ref
-        spec[:role_ref][:name] = value
-      elsif property == :namespace
+      if property == :namespace
         metadata[:namespace] = value
       else
         spec[property] = value
@@ -80,7 +77,6 @@ Puppet::Type.type(:sensu_role_binding).provide(:sensuctl, :parent => Puppet::Pro
       spec = {}
       metadata = {}
       metadata[:name] = resource[:resource_name]
-      spec[:role_ref] = { type: 'Role' }
       type_properties.each do |property|
         if @property_flush[property]
           value = @property_flush[property]
@@ -93,9 +89,7 @@ Puppet::Type.type(:sensu_role_binding).provide(:sensuctl, :parent => Puppet::Pro
         elsif value == :absent
           value = nil
         end
-        if property == :role_ref
-          spec[:role_ref][:name] = value
-        elsif property == :namespace
+        if property == :namespace
           metadata[:namespace] = value
         else
           spec[property] = value

--- a/lib/puppet/type/sensu_cluster_role_binding.rb
+++ b/lib/puppet/type/sensu_cluster_role_binding.rb
@@ -16,6 +16,15 @@ Puppet::Type.newtype(:sensu_cluster_role_binding) do
     ], 
   }
 
+@example Add a cluster role binding for a Role
+  sensu_cluster_role_binding { 'test':
+    ensure   => 'present',
+    role_ref => {'type' => 'Role', 'name' => 'test-role'},
+    subjects => [
+      { 'type' => 'User', 'name' => 'test-user' }
+    ],
+  }
+
 **Autorequires**:
 * `Package[sensu-go-cli]`
 * `Service[sensu-backend]`
@@ -35,7 +44,27 @@ DESC
   end
 
   newproperty(:role_ref) do
-    desc "References a cluster role."
+    desc "References a role."
+    validate do |value|
+      if ! ['String','Hash'].include?(value.class.to_s)
+        raise ArgumentError, "role_ref must be a String or Hash"
+      end
+      if value.is_a?(Hash)
+        if value.keys.sort != ["name","type"]
+          raise ArgumentError, "role_ref must only contain keys of 'name' and 'type'"
+        end
+        if ! ["Role","ClusterRole"].include?(value["type"])
+          raise ArgumentError, "role_ref 'type' must be either 'Role' or 'ClusterRole'"
+        end
+      end
+    end
+    munge do |value|
+      if value.is_a?(String)
+        { "type" => "ClusterRole", "name" => value }
+      else
+        value
+      end
+    end
   end
 
   newproperty(:subjects, :array_matching => :all, :parent => PuppetX::Sensu::ArrayOfHashesProperty) do
@@ -65,7 +94,31 @@ DESC
   end
 
   autorequire(:sensu_cluster_role) do
-    [ self[:role_ref] ]
+    roles = []
+    if self[:role_ref] && self[:role_ref]["type"] == 'ClusterRole'
+      catalog.resources.each do |resource|
+        if resource.class.to_s == "Puppet::Type::Sensu_cluster_role"
+          if resource.name == self[:role_ref]["name"]
+            roles << resource.name
+          end
+        end
+      end
+    end
+    roles
+  end
+
+  autorequire(:sensu_role) do
+    roles = []
+    if self[:role_ref] && self[:role_ref]["type"] == 'Role'
+      catalog.resources.each do |resource|
+        if resource.class.to_s == "Puppet::Type::Sensu_role"
+          if resource[:resource_name] == self[:role_ref]["name"]
+            roles << resource[:resource_name]
+          end
+        end
+      end
+    end
+    roles
   end
 
   autorequire(:sensu_user) do

--- a/lib/puppet/type/sensu_cluster_role_binding.rb
+++ b/lib/puppet/type/sensu_cluster_role_binding.rb
@@ -10,7 +10,7 @@ Puppet::Type.newtype(:sensu_cluster_role_binding) do
 @example Add a cluster role binding
   sensu_cluster_role_binding { 'test':
     ensure   => 'present',
-    role_ref => 'test-role',
+    role_ref => {'type' => 'ClusterRole', 'name' => 'test-role'},
     subjects => [
       { 'type' => 'User', 'name' => 'test-user' }
     ], 
@@ -43,26 +43,15 @@ DESC
     desc "The name of the role binding."
   end
 
-  newproperty(:role_ref) do
-    desc "References a role."
+  newproperty(:role_ref, :parent => PuppetX::Sensu::HashProperty) do
+    desc "References a role in the current namespace or a cluster role."
     validate do |value|
-      if ! ['String','Hash'].include?(value.class.to_s)
-        raise ArgumentError, "role_ref must be a String or Hash"
+      super(value)
+      if value.keys.sort != ["name","type"]
+        raise ArgumentError, "role_ref must only contain keys of 'name' and 'type'"
       end
-      if value.is_a?(Hash)
-        if value.keys.sort != ["name","type"]
-          raise ArgumentError, "role_ref must only contain keys of 'name' and 'type'"
-        end
-        if ! ["Role","ClusterRole"].include?(value["type"])
-          raise ArgumentError, "role_ref 'type' must be either 'Role' or 'ClusterRole'"
-        end
-      end
-    end
-    munge do |value|
-      if value.is_a?(String)
-        { "type" => "ClusterRole", "name" => value }
-      else
-        value
+      if ! ["Role","ClusterRole"].include?(value["type"])
+        raise ArgumentError, "role_ref 'type' must be either 'Role' or 'ClusterRole'"
       end
     end
   end

--- a/manifests/backend/default_resources.pp
+++ b/manifests/backend/default_resources.pp
@@ -121,7 +121,7 @@ class sensu::backend::default_resources {
 
   sensu_cluster_role_binding { 'cluster-admin':
     ensure   => 'present',
-    role_ref => 'cluster-admin',
+    role_ref => {'type' => 'ClusterRole', 'name' => 'cluster-admin'},
     subjects => [
       {
         'type' => 'Group',
@@ -131,7 +131,7 @@ class sensu::backend::default_resources {
   }
   sensu_cluster_role_binding { 'system:agent':
     ensure   => 'present',
-    role_ref => 'system:agent',
+    role_ref => {'type' => 'ClusterRole', 'name' => 'system:agent'},
     subjects => [
       {
         'type' => 'Group',
@@ -141,7 +141,7 @@ class sensu::backend::default_resources {
   }
   sensu_cluster_role_binding { 'system:user':
     ensure   => 'present',
-    role_ref => 'system:user',
+    role_ref => {'type' => 'ClusterRole', 'name' => 'system:user'},
     subjects => [
       {
         'type' => 'Group',

--- a/spec/acceptance/sensu_cluster_role_binding_spec.rb
+++ b/spec/acceptance/sensu_cluster_role_binding_spec.rb
@@ -13,7 +13,7 @@ describe 'sensu_cluster_role_binding', if: RSpec.configuration.sensu_full do
         rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
       }
       sensu_cluster_role_binding { 'test':
-        role_ref => 'test',
+        role_ref => {'type' => 'ClusterRole', 'name' => 'test'},
         subjects => [{'type' => 'User', 'name' => 'admin'}],
       }
       sensu_cluster_role_binding { 'test2':
@@ -63,7 +63,7 @@ describe 'sensu_cluster_role_binding', if: RSpec.configuration.sensu_full do
         rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
       }
       sensu_cluster_role_binding { 'test':
-        role_ref => 'test',
+        role_ref => {'type' => 'ClusterRole', 'name' => 'test'},
         subjects => [{'type' => 'User', 'name' => 'admin'},{'type' => 'User', 'name' => 'agent'}],
       }
       sensu_cluster_role_binding { 'test2':

--- a/spec/acceptance/sensu_role_binding_spec.rb
+++ b/spec/acceptance/sensu_role_binding_spec.rb
@@ -13,7 +13,7 @@ describe 'sensu_role_binding', if: RSpec.configuration.sensu_full do
         rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
       }
       sensu_role_binding { 'test':
-        role_ref => 'test',
+        role_ref => {'type' => 'Role', 'name' => 'test'},
         subjects => [{'type' => 'User', 'name' => 'admin'}],
       }
       sensu_role_binding { 'test2':
@@ -66,7 +66,7 @@ describe 'sensu_role_binding', if: RSpec.configuration.sensu_full do
         rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
       }
       sensu_role_binding { 'test':
-        role_ref => 'test2',
+        role_ref => {'type' => 'Role', 'name' => 'test2'},
         subjects => [{'type' => 'User', 'name' => 'admin'},{'type' => 'User', 'name' => 'agent'}],
       }
       sensu_role_binding { 'test2':

--- a/spec/acceptance/sensu_role_binding_spec.rb
+++ b/spec/acceptance/sensu_role_binding_spec.rb
@@ -9,8 +9,15 @@ describe 'sensu_role_binding', if: RSpec.configuration.sensu_full do
       sensu_role { 'test':
         rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
       }
+      sensu_cluster_role { 'test':
+        rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
+      }
       sensu_role_binding { 'test':
         role_ref => 'test',
+        subjects => [{'type' => 'User', 'name' => 'admin'}],
+      }
+      sensu_role_binding { 'test2':
+        role_ref => {'type' => 'ClusterRole', 'name' => 'test'},
         subjects => [{'type' => 'User', 'name' => 'admin'}],
       }
       EOS
@@ -31,7 +38,15 @@ describe 'sensu_role_binding', if: RSpec.configuration.sensu_full do
     it 'should have a valid role_binding' do
       on node, 'sensuctl role-binding info test --format json' do
         data = JSON.parse(stdout)
-        expect(data['role_ref']['name']).to eq('test')
+        expect(data['role_ref']).to eq({'type' => 'Role', 'name' => 'test'})
+        expect(data['subjects']).to eq([{'type' => 'User', 'name' => 'admin'}])
+      end
+    end
+
+    it 'should have a valid role_binding for ClusterRole' do
+      on node, 'sensuctl role-binding info test2 --format json' do
+        data = JSON.parse(stdout)
+        expect(data['role_ref']).to eq({'type' => 'ClusterRole', 'name' => 'test'})
         expect(data['subjects']).to eq([{'type' => 'User', 'name' => 'admin'}])
       end
     end
@@ -44,9 +59,19 @@ describe 'sensu_role_binding', if: RSpec.configuration.sensu_full do
       sensu_role { 'test':
         rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
       }
+      sensu_role { 'test2':
+        rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
+      }
+      sensu_cluster_role { 'test2':
+        rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}],
+      }
       sensu_role_binding { 'test':
-        role_ref => 'test',
+        role_ref => 'test2',
         subjects => [{'type' => 'User', 'name' => 'admin'},{'type' => 'User', 'name' => 'agent'}],
+      }
+      sensu_role_binding { 'test2':
+        role_ref => {'type' => 'ClusterRole', 'name' => 'test2'},
+        subjects => [{'type' => 'User', 'name' => 'admin'}],
       }
       EOS
 
@@ -66,8 +91,16 @@ describe 'sensu_role_binding', if: RSpec.configuration.sensu_full do
     it 'should have a valid role_binding with updated propery' do
       on node, 'sensuctl role-binding info test --format json' do
         data = JSON.parse(stdout)
-        expect(data['role_ref']['name']).to eq('test')
+        expect(data['role_ref']).to eq({'type' => 'Role', 'name' => 'test2'})
         expect(data['subjects']).to eq([{'type' => 'User', 'name' => 'admin'},{'type' => 'User', 'name' => 'agent'}])
+      end
+    end
+
+    it 'should have a valid role_binding for ClusterRole with updated property' do
+      on node, 'sensuctl role-binding info test2 --format json' do
+        data = JSON.parse(stdout)
+        expect(data['role_ref']).to eq({'type' => 'ClusterRole', 'name' => 'test2'})
+        expect(data['subjects']).to eq([{'type' => 'User', 'name' => 'admin'}])
       end
     end
   end

--- a/spec/classes/backend_default_resources_spec.rb
+++ b/spec/classes/backend_default_resources_spec.rb
@@ -149,7 +149,7 @@ describe 'sensu::backend::default_resources', :type => :class do
         it {
           should contain_sensu_cluster_role_binding('cluster-admin').with({
             'ensure'   => 'present',
-            'role_ref' => 'cluster-admin',
+            'role_ref' => {'type' => 'ClusterRole', 'name' => 'cluster-admin'},
             'subjects' => [
               {
                 'type' => 'Group',
@@ -161,7 +161,7 @@ describe 'sensu::backend::default_resources', :type => :class do
         it {
           should contain_sensu_cluster_role_binding('system:agent').with({
             'ensure'   => 'present',
-            'role_ref' => 'system:agent',
+            'role_ref' => {'type' => 'ClusterRole', 'name' => 'system:agent'},
             'subjects' => [
               {
                 'type' => 'Group',
@@ -173,7 +173,7 @@ describe 'sensu::backend::default_resources', :type => :class do
         it {
           should contain_sensu_cluster_role_binding('system:user').with({
             'ensure'   => 'present',
-            'role_ref' => 'system:user',
+            'role_ref' => {'type' => 'ClusterRole', 'name' => 'system:user'},
             'subjects' => [
               {
                 'type' => 'Group',

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -76,7 +76,7 @@ describe 'sensu::backend::resources', :type => :class do
           class { '::sensu::backend':
             cluster_role_bindings => {
               'test' => {
-                'role_ref' => 'test',
+                'role_ref' => {'type' => 'ClusterRole', 'name' => 'test'},
                 'subjects' => [{'type' => 'User', 'name' => 'test'}],
               }
             }
@@ -230,7 +230,7 @@ describe 'sensu::backend::resources', :type => :class do
           class { '::sensu::backend':
             role_bindings => {
               'test' => {
-                'role_ref' => 'test',
+                'role_ref' => {'type' => 'Role', 'name' => 'test'},
                 'subjects' => [{'type' => 'User', 'name' => 'test'}],
               }
             }

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -87,7 +87,7 @@ sensu::manage_repo: #{RSpec.configuration.sensu_manage_repo}
 sensu::plugins::manage_repo: true
 EOS
     create_remote_file(setup_nodes, '/etc/puppetlabs/puppet/hiera.yaml', hiera_yaml)
-    on setup_nodes, 'mkdir -m 0755 /etc/puppetlabs/puppet/data'
+    on setup_nodes, 'mkdir -p -m 0755 /etc/puppetlabs/puppet/data'
     create_remote_file(setup_nodes, '/etc/puppetlabs/puppet/data/common.yaml', common_yaml)
 
     if RSpec.configuration.sensu_use_agent

--- a/spec/unit/provider/sensu_cluster_role_binding/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_cluster_role_binding/sensuctl_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
       allow(@provider).to receive(:sensuctl_list).with('cluster-role-binding', false).and_return(JSON.parse(my_fixture_read('list.json')))
       property_hash = @provider.instances.select {|i| i.name == 'cluster-admin'}[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('cluster-admin')
-      expect(property_hash[:role_ref]).to eq('cluster-admin')
+      expect(property_hash[:role_ref]).to eq({'type' => 'ClusterRole', 'name' => 'cluster-admin'})
     end
   end
 
@@ -31,7 +31,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
         :name => 'test',
       }
       expected_spec = {
-        :role_ref => {'type': 'ClusterRole', 'name': 'test-role'},
+        :role_ref => {'type' => 'ClusterRole', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test-user'}],
       }
       expect(@resource.provider).to receive(:sensuctl_create).with('ClusterRoleBinding', expected_metadata, expected_spec)
@@ -47,7 +47,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
         :name => 'test',
       }
       expected_spec = {
-        :role_ref => {'type': 'ClusterRole', 'name': 'test-role'},
+        :role_ref => {'type' => 'ClusterRole', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test'}],
       }
       expect(@resource.provider).to receive(:sensuctl_create).with('ClusterRoleBinding', expected_metadata, expected_spec)

--- a/spec/unit/provider/sensu_cluster_role_binding/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_cluster_role_binding/sensuctl_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
     @type = Puppet::Type.type(:sensu_cluster_role_binding)
     @resource = @type.new({
       :name => 'test',
-      :role_ref => 'test-role',
+      :role_ref => {'type' => 'ClusterRole', 'name' => 'test-role'},
       :subjects => [{'type' => 'User', 'name' => 'test-user'}],
     })
   end

--- a/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
@@ -21,7 +21,7 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
       allow(@provider).to receive(:sensuctl_list).with('role-binding').and_return(JSON.parse(my_fixture_read('list.json')))
       property_hash = @provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('test in default')
-      expect(property_hash[:role_ref]).to eq('test')
+      expect(property_hash[:role_ref]).to eq({'type' => 'Role', 'name' => 'test'})
     end
   end
 
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
         :namespace => 'default',
       }
       expected_spec = {
-        :role_ref => {'type': 'Role', 'name': 'test-role'},
+        :role_ref => {'type' => 'Role', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test-user'}],
       }
       expect(@resource.provider).to receive(:sensuctl_create).with('RoleBinding', expected_metadata, expected_spec)
@@ -49,7 +49,7 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
         :namespace => 'default',
       }
       expected_spec = {
-        :role_ref => {'type': 'Role', 'name': 'test-role'},
+        :role_ref => {'type' => 'Role', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test'}],
       }
       expect(@resource.provider).to receive(:sensuctl_create).with('RoleBinding', expected_metadata, expected_spec)

--- a/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
@@ -6,7 +6,7 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
     @type = Puppet::Type.type(:sensu_role_binding)
     @resource = @type.new({
       :name => 'test',
-      :role_ref => 'test-role',
+      :role_ref => {'type' => 'Role', 'name' => 'test-role'},
       :subjects => [{'type' => 'User', 'name' => 'test-user'}],
     })
   end

--- a/spec/unit/sensu_cluster_role_binding_spec.rb
+++ b/spec/unit/sensu_cluster_role_binding_spec.rb
@@ -34,7 +34,6 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
 
   # String properties
   [
-    :role_ref,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = 'foo'
@@ -120,6 +119,22 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
     end
   end
 
+  describe 'role_ref' do
+    it 'converts string to hash' do
+      expect(binding[:role_ref]).to eq({'type' => 'ClusterRole', 'name' => 'test'})
+    end
+
+    it 'accepts hash' do
+      config[:role_ref] = {'type' => 'Role', 'name' => 'test'}
+      expect(binding[:role_ref]).to eq({'type' => 'Role', 'name' => 'test'})
+    end
+
+    it 'should verify type' do
+      config[:role_ref] = {'type' => 'foo', 'name' => 'test'}
+      expect { binding }.to raise_error(Puppet::Error, /'type' must be either/)
+    end
+  end
+
   describe 'subjects' do
     it 'accepts valid value' do
       expect(binding[:subjects]).to eq([{'type' => 'User', 'name' => 'test'}])
@@ -149,6 +164,17 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
   it 'should autorequire sensu_cluster_role' do
     config[:role_ref] = 'test'
     role = Puppet::Type.type(:sensu_cluster_role).new(:name => 'test', :rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}])
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource binding
+    catalog.add_resource role
+    rel = binding.autorequire[0]
+    expect(rel.source.ref).to eq(role.ref)
+    expect(rel.target.ref).to eq(binding.ref)
+  end
+
+  it 'should autorequire sensu_role' do
+    config[:role_ref] = {'type' => 'Role', 'name' => 'test'}
+    role = Puppet::Type.type(:sensu_role).new(:name => 'test', :rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}])
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource binding
     catalog.add_resource role

--- a/spec/unit/sensu_cluster_role_binding_spec.rb
+++ b/spec/unit/sensu_cluster_role_binding_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
   let(:default_config) do
     {
       name: 'test',
-      role_ref: 'test',
+      role_ref: {'type' => 'ClusterRole', 'name' => 'test'},
       subjects: [{'type' => 'User', 'name' => 'test'}],
     }
   end
@@ -120,13 +120,14 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
   end
 
   describe 'role_ref' do
-    it 'converts string to hash' do
-      expect(binding[:role_ref]).to eq({'type' => 'ClusterRole', 'name' => 'test'})
-    end
-
     it 'accepts hash' do
       config[:role_ref] = {'type' => 'Role', 'name' => 'test'}
       expect(binding[:role_ref]).to eq({'type' => 'Role', 'name' => 'test'})
+    end
+
+    it 'requires hash' do
+      config[:role_ref] = 'test'
+      expect { binding }.to raise_error(Puppet::Error, /Hash/)
     end
 
     it 'should verify type' do
@@ -162,7 +163,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
   end
 
   it 'should autorequire sensu_cluster_role' do
-    config[:role_ref] = 'test'
+    config[:role_ref] = {'type' => 'ClusterRole', 'name' => 'test'}
     role = Puppet::Type.type(:sensu_cluster_role).new(:name => 'test', :rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}])
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource binding

--- a/spec/unit/sensu_role_binding_spec.rb
+++ b/spec/unit/sensu_role_binding_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:sensu_role_binding) do
   let(:default_config) do
     {
       name: 'test',
-      role_ref: 'test',
+      role_ref: {'type' => 'Role', 'name' => 'test'},
       subjects: [{'type' => 'User', 'name' => 'test'}],
     }
   end
@@ -149,13 +149,14 @@ describe Puppet::Type.type(:sensu_role_binding) do
   end
 
   describe 'role_ref' do
-    it 'converts string to hash' do
-      expect(binding[:role_ref]).to eq({'type' => 'Role', 'name' => 'test'})
-    end
-
     it 'accepts hash' do
       config[:role_ref] = {'type' => 'ClusterRole', 'name' => 'test'}
       expect(binding[:role_ref]).to eq({'type' => 'ClusterRole', 'name' => 'test'})
+    end
+
+    it 'requires hash' do
+      config[:role_ref] = 'test'
+      expect { binding }.to raise_error(Puppet::Error, /Hash/)
     end
 
     it 'should verify type' do
@@ -191,7 +192,7 @@ describe Puppet::Type.type(:sensu_role_binding) do
   end
 
   it 'should autorequire sensu_role' do
-    config[:role_ref] = 'test'
+    config[:role_ref] = {'type' => 'Role', 'name' => 'test'}
     role = Puppet::Type.type(:sensu_role).new(:name => 'test', :rules => [{'verbs' => ['get','list'], 'resources' => ['checks']}])
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource binding


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow `role_ref` to be String or Hash for `sensu_role_binding` and `sensu_cluster_role_binding`.

This is backwards compatible as `role_ref` can still be a string and munged to maintain old behavior.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1131

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The `role_ref` hash can have either `Role` or `ClusterRole` for both role bindings and cluster role bindings.