### PR TITLE
Support PostgreSQL datastore

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -7,6 +7,15 @@ fixtures:
     yumrepo_core:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       puppet_version: ">= 6.0.0"
+    # Need by postgresql
+    augeas_core:
+      repo: git://github.com/puppetlabs/puppetlabs-augeas_core
+      puppet_version: ">= 6.0.0"
+    # Need by postgresql
+    concat:
+      repo: git://github.com/puppetlabs/puppetlabs-concat.git
+    postgresql:
+      repo: git://github.com/puppetlabs/puppetlabs-postgresql.git
     archive:
       repo: git://github.com/voxpupuli/puppet-archive.git
   symlinks:

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,6 +10,18 @@ fixtures:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1
       puppet_version: ">= 6.0.0"
+    # Need by postgresql
+    augeas_core:
+      repo: git://github.com/puppetlabs/puppetlabs-augeas_core
+      ref: 1.0.4
+      puppet_version: ">= 6.0.0"
+    # Need by postgresql
+    concat:
+      repo: git://github.com/puppetlabs/puppetlabs-concat.git
+      ref: v6.0.0
+    postgresql:
+      repo: git://github.com/puppetlabs/puppetlabs-postgresql.git
+      ref: v6.0.0
     archive:
       repo: git://github.com/voxpupuli/puppet-archive.git
       ref: 'v3.0.0'

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
     * [Advanced agent](#advanced-agent)
     * [Advanced SSL](#advanced-ssl)
     * [Enterprise support](#enterprise-support)
+    * [PostgreSQL datastore support](#postgresql-datastore-support)
     * [Installing Plugins](#installing-plugins)
     * [Installing Extensions](#installing-extensions)
     * [Exported resources](#exported-resources)
@@ -69,6 +70,8 @@ This module has a soft dependency on the [puppetlabs/apt](https://forge.puppet.c
 If using Puppet >= 6.0.0 there is a soft dependency on the [puppetlabs/yumrepo_core](https://forge.puppet.com/puppetlabs/yumrepo_core) module (`>= 1.0.1 < 2.0.0`) for systems using `yum`.
 
 If managing Windows there is a soft dependency on the [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.0 < 4.0.0`).
+
+For PostgreSQL datastore support there is a soft dependency on [puppetlabs/postgresql](https://forge.puppet.com/puppetlabs/postgresql) module (`>= 6.0.0 < 7.0.0`).
 
 ### Beginning with sensu
 
@@ -219,7 +222,40 @@ class { 'sensu::backend':
 }
 ```
 
-The type `sensu_ldap_auth` requires a valid enterprise license.
+The types `sensu_ad_auth` and `sensu_ldap_auth` require a valid enterprise license.
+
+### PostgreSQL datastore support
+
+**NOTE**: This features require a valid Sensu Go enterprise license.
+
+The following example will add a PostgreSQL server and database to the sensu-backend host and configure Sensu Go to use PostgreSQL as the event datastore.
+
+```puppet
+class { 'postgresql::globals':
+  manage_package_repo => true,
+  version             => '9.6',
+}
+class { 'postgresql::server': }
+class { '::sensu::backend':
+  license_source      => 'puppet:///modules/profile/sensu/license.json',
+  datastore           => 'postgresql',
+  postgresql_password => 'secret',
+}
+```
+
+Refer to the [puppetlabs/postgresql](https://forge.puppet.com/puppetlabs/postgresql) module documentation for details on how to manage PostgreSQL with Puppet.
+
+The following example uses an external PostgreSQL server.
+
+```puppet
+class { '::sensu::backend':
+  license_source       => 'puppet:///modules/profile/sensu/license.json',
+  datastore            => 'postgresql',
+  postgresql_password  => 'secret',
+  postgresql_host      => 'postgresql.example.com',
+  manage_postgresql_db => false,
+}
+```
 
 ### Installing Plugins
 

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -95,6 +95,27 @@
 #   Hash of sensu_user resources
 # @param sensuctl_chunk_size
 #   Chunk size to use when listing sensuctl resources
+# @param datastore
+#   Datastore to configure for sensu events
+# @param datastore_ensure
+#   The datastore ensure property. If set to `absent` all
+#   datastore parameters must still be defined.
+# @param manage_postgresql_db
+#   Boolean that sets of postgresql database should be managed
+# @param postgresql_name
+#   Name of PostgresConfig that is configured with sensuctl
+# @param postgresql_user
+#   The PostgreSQL database user
+# @param postgresql_password
+#   The PostgreSQL database password
+# @param postgresql_host
+#   The PostgreSQL host
+# @param postgresql_port
+#   The PostgreSQL port
+# @param postgresql_dbname
+#   The name of the PostgreSQL database
+# @param postgresql_pool_size
+#   The PostgreSQL pool size
 #
 class sensu::backend (
   Optional[String] $version = undef,
@@ -139,6 +160,16 @@ class sensu::backend (
   Hash $silencings = {},
   Hash $users = {},
   Optional[Integer] $sensuctl_chunk_size = undef,
+  Optional[Enum['postgresql']] $datastore = undef,
+  Enum['present','absent'] $datastore_ensure = 'present',
+  Boolean $manage_postgresql_db = true,
+  String $postgresql_name = 'postgresql',
+  String $postgresql_user = 'sensu',
+  String $postgresql_password = 'changeme',
+  Stdlib::Host $postgresql_host = 'localhost',
+  Stdlib::Port $postgresql_port = 5432,
+  String $postgresql_dbname = 'sensu',
+  Integer $postgresql_pool_size = 20,
 ) {
 
   if $license_source and $license_content {
@@ -149,6 +180,9 @@ class sensu::backend (
   include ::sensu::backend::resources
   if $manage_tessen {
     include ::sensu::backend::tessen
+  }
+  if $datastore == 'postgresql' {
+    include ::sensu::backend::datastore::postgresql
   }
 
   $etc_dir = $::sensu::etc_dir

--- a/manifests/backend/datastore/postgresql.pp
+++ b/manifests/backend/datastore/postgresql.pp
@@ -1,0 +1,61 @@
+#
+class sensu::backend::datastore::postgresql {
+  include ::sensu
+  include ::sensu::backend
+
+  $config_path = "${::sensu::etc_dir}/postgresql.yaml"
+  $user = $::sensu::backend::postgresql_user
+  $password = $::sensu::backend::postgresql_password
+  $host = $::sensu::backend::postgresql_host
+  $port = $::sensu::backend::postgresql_port
+  $dbname = $::sensu::backend::postgresql_dbname
+  $config = {
+    'type'        => 'PostgresConfig',
+    'api_version' => 'store/v1',
+    'metadata'    => { 'name' => $::sensu::backend::postgresql_name },
+    'spec'        => {
+      'dsn'         => "postgresql://${user}:${password}@${host}:${port}/${dbname}",
+      'pool_size'   => $::sensu::backend::postgresql_pool_size,
+    },
+  }
+  $yaml_config = to_yaml($config)
+
+  case $::sensu::backend::datastore_ensure {
+    'absent': {
+      $sensuctl_command = 'sensuctl delete'
+    }
+    default: {
+      $sensuctl_command = 'sensuctl create'
+    }
+  }
+
+  file { $config_path:
+    ensure    => 'file',
+    owner     => $::sensu::user,
+    group     => $::sensu::group,
+    mode      => '0640',
+    show_diff => false,
+    content   => "${yaml_config}\n# File managed by Puppet\n# ${::sensu::backend::datastore_ensure}\n",
+    require   => Package['sensu-go-backend'],
+    notify    => Exec['sensuctl-postgresql'],
+  }
+
+  exec { 'sensuctl-postgresql':
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+    command     => "${sensuctl_command} --file ${config_path}",
+    refreshonly => true,
+    require     => [
+      Sensu_configure['puppet'],
+      Sensu_user['admin'],
+    ],
+  }
+
+  if $::sensu::backend::manage_postgresql_db and $::sensu::backend::datastore_ensure == 'present' {
+    postgresql::server::db { $dbname:
+      user     => $user,
+      password => postgresql_password($user, $password),
+      before   => Exec['sensuctl-postgresql'],
+    }
+  }
+}
+

--- a/spec/acceptance/06_postgresql_spec.rb
+++ b/spec/acceptance/06_postgresql_spec.rb
@@ -1,0 +1,93 @@
+require 'spec_helper_acceptance'
+
+describe 'postgresql datastore', if: RSpec.configuration.sensu_full do
+  node = hosts_as('sensu_backend')[0]
+  before do
+    if ! RSpec.configuration.sensu_test_enterprise
+      skip("Skipping postgresql tests")
+    end
+  end
+  context 'adds postgresql datastore' do
+    it 'should work without errors and be idempotent' do
+      pp = <<-EOS
+      class { 'postgresql::globals':
+        manage_package_repo => true,
+        version             => '9.6',
+      }
+      class { 'postgresql::server':}
+      class { '::sensu::backend':
+        license_source => '/root/sensu_license.json',
+        datastore      => 'postgresql',
+      }
+      EOS
+      check_pp = <<-EOS
+      sensu_check { 'event-test':
+        command       => 'exit 0',
+        subscriptions => ['entity:sensu_agent'],
+        interval      => 1,
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+      apply_manifest_on(node, check_pp, :catch_failures => true)
+      on node, 'sensuctl check execute event-test'
+    end
+
+    it 'should have an event' do
+      on node, 'sensuctl event info sensu_agent event-test --format json' do
+        data = JSON.parse(stdout)
+        expect(data['check']['status']).to eq(0)
+      end
+    end
+  end
+
+  context 'removes postgresql datastore' do
+    it 'should work without errors and be idempotent' do
+      pp = <<-EOS
+      class { '::sensu::backend':
+        license_source    => '/root/sensu_license.json',
+        datastore         => 'postgresql',
+        datastore_ensure  => 'absent',
+      }
+      EOS
+      check_pp = <<-EOS
+      sensu_check { 'event-test':
+        command       => 'exit 0',
+        subscriptions => ['entity:sensu_agent'],
+        interval      => 1,
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+      apply_manifest_on(node, check_pp, :catch_failures => true)
+      on node, 'sensuctl check execute event-test'
+    end
+
+    it 'should have an event' do
+      on node, 'sensuctl event info sensu_agent event-test --format json' do
+        data = JSON.parse(stdout)
+        expect(data['check']['status']).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/acceptance/nodesets/centos-7.yml
+++ b/spec/acceptance/nodesets/centos-7.yml
@@ -27,7 +27,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - "sed -i -r '/^tsflags/d' /etc/yum.conf"
-      - 'yum install -y wget which'
+      - 'yum install -y wget which initscripts'
     docker_container_name: 'sensu-backend-el7'
 CONFIG:
   log_level: debug

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -68,13 +68,6 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
         expect(data['metadata']['namespace']).to eq('test')
       end
     end
-
-    it 'should have multiple checks' do
-      on node, 'sensuctl check list --format json' do
-        data = JSON.parse(stdout)
-        expect(data.size).to eq(2)
-      end
-    end
   end
 
   context 'with chunk size' do

--- a/spec/classes/backend_datastore_postgresql_spec.rb
+++ b/spec/classes/backend_datastore_postgresql_spec.rb
@@ -1,0 +1,109 @@
+require 'spec_helper'
+
+describe 'sensu::backend::datastore::postgresql', :type => :class do
+  on_supported_os({
+    facterversion: '3.8.0',
+  }).each do |os, facts|
+    if facts[:os]['family'] == 'windows'
+      next
+    end
+    context "on #{os}" do
+      let(:facts) { facts }
+      let(:pre_condition) do
+        <<-EOS
+        class { '::postgresql::server': }
+        class { '::sensu::backend': }
+        EOS
+      end
+
+      it { should compile.with_all_deps }
+
+      let(:config_content) do
+        content = <<-END.gsub(/^\s+\|/, '')
+        |---
+        |type: PostgresConfig
+        |api_version: store/v1
+        |metadata:
+        |  name: postgresql
+        |spec:
+        |  dsn: postgresql://sensu:changeme@localhost:5432/sensu
+        |  pool_size: 20
+        |
+        |# File managed by Puppet
+        |# present
+      END
+        content
+      end
+
+      it do
+        should contain_file('/etc/sensu/postgresql.yaml').with({
+          :ensure   => 'file',
+          :owner    => 'sensu',
+          :group    => 'sensu',
+          :mode     => '0640',
+          :content  => config_content,
+          :require  => 'Package[sensu-go-backend]',
+          :notify   => 'Exec[sensuctl-postgresql]',
+        })
+      end
+
+      it do
+        should contain_exec('sensuctl-postgresql').with({
+          :path => '/usr/bin:/bin:/usr/sbin:/sbin',
+          :command  => 'sensuctl create --file /etc/sensu/postgresql.yaml',
+          :require  => [
+            'Sensu_configure[puppet]',
+            'Sensu_user[admin]',
+          ]
+        })
+      end
+
+      it do
+        should contain_postgresql__server__db('sensu').with({
+          :user     => 'sensu',
+          :password => /md5/,
+        })
+      end
+
+      context 'datastore_ensure => absent' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            datastore_ensure => 'absent',
+          }
+          EOS
+        end
+        let(:config_content) do
+          content = <<-END.gsub(/^\s+\|/, '')
+          |---
+          |type: PostgresConfig
+          |api_version: store/v1
+          |metadata:
+          |  name: postgresql
+          |spec:
+          |  dsn: postgresql://sensu:changeme@localhost:5432/sensu
+          |  pool_size: 20
+          |
+          |# File managed by Puppet
+          |# absent
+        END
+          content
+        end
+        it { should contain_file('/etc/sensu/postgresql.yaml').with_ensure('file').with_content(config_content) }
+        it { should contain_exec('sensuctl-postgresql').with_command('sensuctl delete --file /etc/sensu/postgresql.yaml') }
+        it { should_not contain_postgresql__server__db('sensu') }
+      end
+
+      context 'manage_postgresql => false' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::sensu::backend':
+            manage_postgresql_db => false,
+          }
+          EOS
+        end
+        it { should_not contain_postgresql__server__db('sensu') }
+      end
+    end
+  end
+end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -18,6 +18,7 @@ describe 'sensu::backend', :type => :class do
         it { should contain_class('sensu::ssl').that_comes_before('Sensu_configure[puppet]') }
         it { should contain_class('sensu::backend::default_resources') }
         it { should contain_class('sensu::backend::tessen') }
+        it { should_not contain_class('sensu::backend::datastore::postgresql') }
 
         it {
           should contain_package('sensu-go-cli').with({
@@ -284,6 +285,16 @@ describe 'sensu::backend', :type => :class do
       context 'manage_tessen => false' do
         let(:params) {{ :manage_tessen => false }}
         it { is_expected.not_to contain_class('sensu::backend::tessen') }
+      end
+
+      context 'datastore => postgresql' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::postgresql::server': }
+          EOS
+        end
+        let(:params) {{ :datastore => 'postgresql' }}
+        it { should contain_class('sensu::backend::datastore::postgresql') }
       end
     end
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -60,6 +60,9 @@ RSpec.configure do |c|
     if collection == 'puppet6'
       on setup_nodes, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
     end
+    if RSpec.configuration.sensu_test_enterprise
+      on setup_nodes, puppet('module', 'install', 'puppetlabs-postgresql', '--version', '">= 6.0.0 < 7.0.0"'), { :acceptable_exit_codes => [0,1] }
+    end
     ssldir = File.join(project_dir, 'tests/ssl')
     scp_to(hosts, ssldir, '/etc/puppetlabs/puppet/ssl')
     hosts.each do |host|
@@ -87,7 +90,7 @@ sensu::manage_repo: #{RSpec.configuration.sensu_manage_repo}
 sensu::plugins::manage_repo: true
 EOS
     create_remote_file(setup_nodes, '/etc/puppetlabs/puppet/hiera.yaml', hiera_yaml)
-    on setup_nodes, 'mkdir -m 0755 /etc/puppetlabs/puppet/data'
+    on setup_nodes, 'mkdir -p -m 0755 /etc/puppetlabs/puppet/data'
     create_remote_file(setup_nodes, '/etc/puppetlabs/puppet/data/common.yaml', common_yaml)
 
     if RSpec.configuration.sensu_use_agent


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for PostgreSQL datastore.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1135 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.10 added support for PostgreSQL datastore that has to be setup with `sensuctl`. This adds support for that as well as optionally manages the actual postgresql database.
