### PR TITLE
Testing improvements

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --format documentation
+--format ParallelTests::RSpec::SummaryLogger

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,20 +15,24 @@ before_install:
   - 'if [ -n "$encrypted_f942601034d6_key" -a -n "$encrypted_f942601034d6_iv" ]; then openssl aes-256-cbc -K $encrypted_f942601034d6_key -iv $encrypted_f942601034d6_iv -in tests/secrets.tar.enc -out tests/secrets.tar -d; cd tests && tar xvf secrets.tar ; fi'
 sudo: false
 
-script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec strings:generate reference'
+script: 'bundle exec rake $CHECK'
 
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4.4
-    env: PUPPET_GEM_VERSION="~> 5"
-  - rvm: 2.4.4
-    env: PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
+  - rvm: 2.4.5
+    env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 5"
   - rvm: 2.5.3
-    env: PUPPET_GEM_VERSION="~> 6"
+    env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 6"
+  - rvm: 2.4.5
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5"
+  - rvm: 2.4.5
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.3
-    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
-  - rvm: 2.4.4
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6"
+  - rvm: 2.5.3
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
@@ -46,7 +50,7 @@ matrix:
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes
@@ -64,7 +68,7 @@ matrix:
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes BEAKER_sensu_use_agent=yes
@@ -76,7 +80,7 @@ matrix:
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes BEAKER_sensu_use_agent=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes
@@ -88,7 +92,7 @@ matrix:
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes BEAKER_sensu_use_agent=yes
@@ -106,7 +110,7 @@ matrix:
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
@@ -136,7 +140,7 @@ matrix:
     env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
@@ -154,7 +158,7 @@ matrix:
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
@@ -172,7 +176,7 @@ matrix:
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet5
@@ -190,7 +194,7 @@ matrix:
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet5
@@ -208,7 +212,7 @@ matrix:
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_ci_build=yes
     bundler_args:
     script: bundle exec rake beaker
-  - rvm: 2.4.4
+  - rvm: 2.4.5
     sudo: required
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet5
@@ -227,10 +231,10 @@ matrix:
     bundler_args:
     script: bundle exec rake beaker
   allow_failures:
-  - rvm: 2.4.4
-    env: PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
+  - rvm: 2.4.5
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.3
-    env: PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.3
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_ci_build=yes
   - rvm: 2.5.3

--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ group :development, :unit_tests do
   gem 'rspec-puppet',                                     :require => false
   gem 'rspec-puppet-facts',                               :require => false
   gem 'rspec-mocks',                                      :require => false
+  gem 'parallel_tests',                                   :require => false
   gem 'puppetlabs_spec_helper',                           :require => false
   gem 'metadata-json-lint',                               :require => false
   gem 'puppet-blacksmith',                                :require => false

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -157,6 +157,12 @@ describe 'sensu::agent', :type => :class do
         let(:pre_condition) do
           "class { 'sensu': manage_repo => false }"
         end
+        # Unknown bug in rspec-puppet fails to compile windows paths
+        # when they are used for file source of sensu_ssl_ca, issue with windows mocking
+        # https://github.com/rodjek/rspec-puppet/issues/750
+        if facts[:os]['family'] != 'windows'
+          it { should compile.with_all_deps }
+        end
         it { should contain_package('sensu-go-agent').without_require }
       end
 

--- a/spec/classes/backend_datastore_postgresql_spec.rb
+++ b/spec/classes/backend_datastore_postgresql_spec.rb
@@ -90,6 +90,7 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
         END
           content
         end
+        it { should compile.with_all_deps }
         it { should contain_file('/etc/sensu/postgresql.yaml').with_ensure('file').with_content(config_content) }
         it { should contain_exec('sensuctl-postgresql').with_command('sensuctl delete --file /etc/sensu/postgresql.yaml') }
         it { should_not contain_postgresql__server__db('sensu') }
@@ -103,6 +104,7 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should_not contain_postgresql__server__db('sensu') }
       end
     end

--- a/spec/classes/backend_default_resources_spec.rb
+++ b/spec/classes/backend_default_resources_spec.rb
@@ -8,7 +8,7 @@ describe 'sensu::backend::default_resources', :type => :class do
     context "on #{os}" do
       let(:facts) { facts }
       context 'with default values for all parameters' do
-        it { should compile }
+        it { should compile.with_all_deps }
         it { should have_sensu_namespace_resource_count(1) }
         it { should contain_sensu_namespace('default').with_ensure('present') }
         it { should have_sensu_user_resource_count(2) }

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -22,6 +22,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_ad_auth('ad') }
       end
       context 'assets defined' do
@@ -37,6 +38,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_asset('test') }
       end
       context 'checks defined' do
@@ -54,6 +56,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_check('test') }
       end
       context 'cluster_members defined' do
@@ -68,6 +71,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_cluster_member('test') }
       end
       context 'cluster_role_bindings defined' do
@@ -83,6 +87,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_cluster_role_binding('test') }
       end
       context 'cluster_roles defined' do
@@ -97,6 +102,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_cluster_role('test') }
       end
       context 'configs defined' do
@@ -111,6 +117,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_config('format') }
       end
       context 'entities defined' do
@@ -125,6 +132,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_entity('test') }
       end
       context 'events defined' do
@@ -137,6 +145,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_event('checkalive for test') }
       end
       context 'filters defined' do
@@ -152,6 +161,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_filter('test') }
       end
       context 'handlers defined' do
@@ -169,6 +179,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_handler('test') }
       end
       context 'hooks defined' do
@@ -181,6 +192,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_hook('test') }
       end
       context 'ldap_auths defined' do
@@ -198,6 +210,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_ldap_auth('ldap') }
       end
       context 'mutators defined' do
@@ -210,6 +223,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_mutator('test') }
       end
       context 'namespaces defined' do
@@ -222,6 +236,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_namespace('test') }
       end
       context 'role_bindings defined' do
@@ -237,6 +252,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_role_binding('test') }
       end
       context 'roles defined' do
@@ -251,6 +267,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_role('test') }
       end
       context 'silencings defined' do
@@ -263,6 +280,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_silenced('test') }
       end
       context 'users defined' do
@@ -275,6 +293,7 @@ describe 'sensu::backend::resources', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it { should contain_sensu_user('test') }
       end
     end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -156,6 +156,7 @@ describe 'sensu::backend', :type => :class do
           "class { 'sensu': use_ssl => false }"
         end
 
+        it { should compile.with_all_deps }
         it {
           should contain_sensu_api_validator('sensu').with({
             'sensu_api_server' => 'test.example.com',
@@ -198,12 +199,12 @@ describe 'sensu::backend', :type => :class do
 
         context 'when puppet_hostcert undefined' do
           let(:facts) { facts.merge(puppet_hostcert: nil) }
-          it { should compile }
+          it { should compile.with_all_deps }
         end
 
         context 'when puppet_hostprivkey undefined' do
           let(:facts) { facts.merge(puppet_hostprivkey: nil) }
-          it { should compile }
+          it { should compile.with_all_deps }
         end
       end
 
@@ -216,17 +217,20 @@ describe 'sensu::backend', :type => :class do
         let(:pre_condition) do
           "class { 'sensu': manage_repo => false }"
         end
+        it { should compile.with_all_deps }
         it { should contain_package('sensu-go-cli').without_require }
         it { should contain_package('sensu-go-backend').without_require }
       end
 
       context 'with include_default_resources => false' do
         let(:params) {{ :include_default_resources => false }}
+        it { should compile.with_all_deps }
         it { should_not contain_class('sensu::backend::default_resources') }
       end
 
       context 'with license_source defined' do
         let(:params) {{ :license_source => 'puppet:///modules/site_sensu/license.json' }}
+        it { should compile.with_all_deps }
         it {
           should contain_file('sensu_license').with({
             'ensure'    => 'file',
@@ -252,6 +256,7 @@ describe 'sensu::backend', :type => :class do
 
       context 'with license_content defined' do
         let(:params) {{ :license_content => '{ }' }}
+        it { should compile.with_all_deps }
         it {
           should contain_file('sensu_license').with({
             'ensure'    => 'file',
@@ -284,6 +289,7 @@ describe 'sensu::backend', :type => :class do
 
       context 'manage_tessen => false' do
         let(:params) {{ :manage_tessen => false }}
+        it { should compile.with_all_deps }
         it { is_expected.not_to contain_class('sensu::backend::tessen') }
       end
 
@@ -295,6 +301,7 @@ describe 'sensu::backend', :type => :class do
           EOS
         end
         let(:params) {{ :datastore => 'postgresql' }}
+        it { should compile.with_all_deps }
         it { should contain_class('sensu::backend::datastore::postgresql') }
       end
     end

--- a/spec/classes/backend_tessen_spec.rb
+++ b/spec/classes/backend_tessen_spec.rb
@@ -13,6 +13,7 @@ describe 'sensu::backend::tessen', :type => :class do
           class { '::sensu::backend': }
           EOS
         end
+        it { should compile.with_all_deps }
         it do
           should contain_exec('sensuctl tessen opt-in').with({
             :path => '/usr/bin:/bin:/usr/sbin:/sbin',
@@ -32,6 +33,7 @@ describe 'sensu::backend::tessen', :type => :class do
           }
           EOS
         end
+        it { should compile.with_all_deps }
         it do
           should contain_exec('sensuctl tessen opt-out --skip-confirm').with({
             :path => '/usr/bin:/bin:/usr/sbin:/sbin',

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,7 +9,7 @@ describe 'sensu', :type => :class do
         # when they are used for file source of sensu_ssl_ca, issue with windows mocking
         # https://github.com/rodjek/rspec-puppet/issues/750
         if facts[:os]['family'] != 'windows'
-          it { should compile }
+          it { should compile.with_all_deps }
         end
 
         it { should contain_class('sensu')}
@@ -33,11 +33,12 @@ describe 'sensu', :type => :class do
 
       context 'with use_ssl => false' do
         let(:params) { { :use_ssl => false } }
+        it { should compile.with_all_deps }
         it { should_not contain_class('sensu::ssl') }
 
         context 'when puppet_localcacert undefined' do
           let(:facts) { facts.merge!(puppet_localcacert: nil) }
-          it { should compile }
+          it { should compile.with_all_deps }
         end
       end
 

--- a/spec/classes/plugins_spec.rb
+++ b/spec/classes/plugins_spec.rb
@@ -11,7 +11,7 @@ describe 'sensu::plugins', :type => :class do
         next
       end
       context 'with default values for all parameters' do
-        it { should compile }
+        it { should compile.with_all_deps }
 
         it { should create_class('sensu::plugins')}
         it { should contain_class('sensu')}
@@ -31,11 +31,13 @@ describe 'sensu::plugins', :type => :class do
 
       context 'with plugins array' do
         let(:params) {{ :plugins => ['disk-checks'] }}
+        it { should compile.with_all_deps }
         it { should contain_sensu_plugin('disk-checks').with_ensure('present') }
       end
 
       context 'with plugins hash' do
         let(:params) {{ :plugins => {'disk-checks' => {'version' => '4.0.0'}} }}
+        it { should compile.with_all_deps }
         it {
           should contain_sensu_plugin('disk-checks').with({
             'ensure'  => 'present',
@@ -46,12 +48,14 @@ describe 'sensu::plugins', :type => :class do
 
       context 'with extensions array' do
         let(:params) {{ :extensions => ['test'] }}
+        it { should compile.with_all_deps }
         it { should contain_sensu_plugin('test').with_ensure('present') }
         it { should contain_sensu_plugin('test').with_extension('true') }
       end
 
       context 'with extensions hash' do
         let(:params) {{ :extensions => {'test' => {'version' => '1.0.0'}} }}
+        it { should compile.with_all_deps }
         it {
           should contain_sensu_plugin('test').with({
             'ensure'    => 'present',
@@ -63,16 +67,19 @@ describe 'sensu::plugins', :type => :class do
 
       context 'remove plugins' do
         let(:params) {{ :plugins => {'disk-checks' => {'ensure' => 'absent'}} }}
+        it { should compile.with_all_deps }
         it { should contain_sensu_plugin('disk-checks').with_ensure('absent') }
       end
 
       context 'remove extensions' do
         let(:params) {{ :extensions => {'test' => {'ensure' => 'absent'}} }}
+        it { should compile.with_all_deps }
         it { should contain_sensu_plugin('test').with_ensure('absent') }
       end
 
       context 'dependencies => []' do
         let(:params) {{ :dependencies => [] }}
+        it { should compile.with_all_deps }
         platforms[facts[:osfamily]][:plugins_dependencies].each do |package|
           it { should_not contain_package(package) }
         end
@@ -82,6 +89,7 @@ describe 'sensu::plugins', :type => :class do
         let(:pre_condition) do
           "class { 'sensu': manage_repo => false }"
         end
+        it { should compile.with_all_deps }
         it { should_not contain_class('sensu::repo::community') }
         it { should contain_package('sensu-plugins-ruby').without_require }
       end

--- a/spec/classes/repo_community_spec.rb
+++ b/spec/classes/repo_community_spec.rb
@@ -16,6 +16,7 @@ describe 'sensu::repo::community', :type => :class do
       else
         baseurl = nil
       end
+      it { should compile.with_all_deps }
       if facts[:osfamily] == 'RedHat'
         it {
           should contain_yumrepo('sensu_community').with({

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -16,6 +16,7 @@ describe 'sensu::repo', :type => :class do
       else
         baseurl = nil
       end
+      it { should compile.with_all_deps }
       if facts[:osfamily] == 'RedHat'
         it {
           should contain_yumrepo('sensu').with({

--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -9,7 +9,7 @@ describe 'sensu::ssl', :type => :class do
         # when they are used for file source of sensu_ssl_ca, issue with windows mocking
         # https://github.com/rodjek/rspec-puppet/issues/750
         if facts[:os]['family'] != 'windows'
-          it { should compile }
+          it { should compile.with_all_deps }
         end
 
         it { should create_class('sensu::ssl') }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add a test for all contexts to ensure the catalog can compile.
Use parallel_spec to run unit tests
Update travis matrix to make it a bit clearer which test is which by using `$CHECK` pattern.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I discovered that invalid resources would not cause test failures without testing that the catalog compiles. This noticed while working on #1133 and `role_ref` was still a String for some tests but it wasn't failing because we were not testing compile.

Using parallel_spec is causing the tests to go from 4 minutes to 1 minute on my desktop.

Using the `$CHECK` pattern is something that makes it really clear in Travis which tests failed since the env is what shows in the matrix UI.