### PR TITLE
Deprecate defining single asset builds

### DIFF
--- a/lib/puppet_x/sensu/type.rb
+++ b/lib/puppet_x/sensu/type.rb
@@ -40,6 +40,12 @@ module PuppetX
           raise Puppet::Error, "Sensu namespace '#{resource[:namespace]}' must be defined or exist"
         end
       end
+
+      # Used to take type class name and name to generate friendly error prefix
+      # Puppet::Type::Sensu_asset[test] becomes Sensu_asset[test]
+      def self.error_prefix(s)
+        "#{s.class.to_s.split(':').last}[#{s[:name]}]:"
+      end
     end
   end
 end

--- a/spec/acceptance/sensu_asset_spec.rb
+++ b/spec/acceptance/sensu_asset_spec.rb
@@ -6,7 +6,7 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
     it 'should work without errors' do
       pp = <<-EOS
       include ::sensu::backend
-      sensu_asset { 'test':
+      sensu_asset { 'test2':
         url      => 'http://example.com/asset/example.tar',
         sha512   => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
         filters  => ["entity.system.os == 'linux'"],
@@ -15,16 +15,12 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
           "X-Forwarded-For" => "client1, proxy1, proxy2"
         },
       }
-      sensu_asset { 'test2':
+      sensu_asset { 'test':
         ensure => 'present',
         builds => [
         {
           "url" => "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
           "sha512" => "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
-          "headers"  => {
-            "Authorization" => 'Bearer $TOKEN',
-            "X-Forwarded-For" => "client1, proxy1, proxy2"
-          }
         },
         {
           "url" => "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz",
@@ -33,7 +29,11 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
             "entity.system.os == 'linux'",
             "entity.system.arch == 'arm'",
             "entity.system.arm_version == 7"
-          ]
+          ],
+          "headers" => {
+            "Authorization" => 'Bearer $TOKEN',
+            "X-Forwarded-For" => "client1, proxy1, proxy2"
+          },
         },
         {
           "url" => "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz",
@@ -41,13 +41,13 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
           "filters" => [
             "entity.system.os == 'windows'",
             "entity.system.arch == 'amd64'"
-          ]
+          ],
+          "headers" => {
+            "Authorization" => 'Bearer $TOKEN',
+            "X-Forwarded-For" => "client1, proxy1, proxy2"
+          },
         }
         ],
-        headers  => {
-          "Authorization" => 'Bearer $TOKEN',
-          "X-Forwarded-For" => "client1, proxy1, proxy2"
-        },
       }
       EOS
 
@@ -64,31 +64,19 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
       end
     end
 
-    it 'should have a valid asset' do
-      on node, 'sensuctl asset info test --format json' do
-        data = JSON.parse(stdout)
-        expect(data['url']).to eq('http://example.com/asset/example.tar')
-        expect(data['filters']).to eq(["entity.system.os == 'linux'"])
-        expect(data['headers']['Authorization']).to eq('Bearer $TOKEN')
-        expect(data['headers']['X-Forwarded-For']).to eq('client1, proxy1, proxy2')
-      end
-    end
-
     it 'should have a valid asset with multiple builds' do
-      on node, 'sensuctl asset info test2 --format json' do
+      on node, 'sensuctl asset info test --format json' do
         data = JSON.parse(stdout)
         expect(data['builds'].size).to eq(3)
         expect(data['builds'][0]['url']).to eq('https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz')
         expect(data['builds'][0]['sha512']).to eq('487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3')
         expect(data['builds'][0]['filters']).to be_nil
-        expect(data['builds'][0]['headers']['Authorization']).to eq('Bearer $TOKEN')
-        expect(data['builds'][0]['headers']['X-Forwarded-For']).to eq('client1, proxy1, proxy2')
+        expect(data['builds'][0]['headers']).to be_nil
         expect(data['builds'][1]['url']).to eq('https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz')
         expect(data['builds'][1]['sha512']).to eq('70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b')
         expect(data['builds'][1]['filters'].size).to eq(3)
-        expect(data['builds'][1]['headers']).to be_nil
-        expect(data['headers']['Authorization']).to eq('Bearer $TOKEN')
-        expect(data['headers']['X-Forwarded-For']).to eq('client1, proxy1, proxy2')
+        expect(data['builds'][1]['headers']['Authorization']).to eq('Bearer $TOKEN')
+        expect(data['builds'][1]['headers']['X-Forwarded-For']).to eq('client1, proxy1, proxy2')
       end
     end
   end
@@ -98,14 +86,6 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
       pp = <<-EOS
       include ::sensu::backend
       sensu_asset { 'test':
-        url      => 'http://example.com/asset/example.zip',
-        sha512   => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
-        filters  => ["entity.system.os == 'windows'"],
-        headers  => {
-          "X-Forwarded-For" => "client1, proxy1"
-        },
-      }
-      sensu_asset { 'test2':
         ensure => 'present',
         builds => [
         {
@@ -127,7 +107,11 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
             "entity.system.os == 'linux'",
             "entity.system.arch == 'arm'",
             "entity.system.arm_version == 7"
-          ]
+          ],
+          "headers" => {
+            "Authorization" => 'Bearer $TOKEN',
+            "X-Forwarded-For" => "client1, proxy1"
+          },
         },
         {
           "url" => "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz",
@@ -135,13 +119,13 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
           "filters" => [
             "entity.system.os == 'windows'",
             "entity.system.arch == 'amd64'"
-          ]
+          ],
+          "headers" => {
+            "Authorization" => 'Bearer $TOKEN',
+            "X-Forwarded-For" => "client1, proxy1"
+          },
         }
         ],
-        headers  => {
-          "Authorization" => 'Bearer $TOKEN',
-          "X-Forwarded-For" => "client1, proxy1"
-        },
       }
       EOS
 
@@ -158,18 +142,8 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
       end
     end
 
-    it 'should have a valid asset with updated propery' do
-      on node, 'sensuctl asset info test --format json' do
-        data = JSON.parse(stdout)
-        expect(data['url']).to eq('http://example.com/asset/example.zip')
-        expect(data['filters']).to eq(["entity.system.os == 'windows'"])
-        expect(data['headers']['Authorization']).to be_nil
-        expect(data['headers']['X-Forwarded-For']).to eq('client1, proxy1')
-      end
-    end
-
     it 'should have a valid asset with multiple builds with updated properties' do
-      on node, 'sensuctl asset info test2 --format json' do
+      on node, 'sensuctl asset info test --format json' do
         data = JSON.parse(stdout)
         expect(data['builds'].size).to eq(3)
         expect(data['builds'][0]['url']).to eq('https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.4_linux_amd64.tar.gz')
@@ -180,9 +154,8 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
         expect(data['builds'][1]['url']).to eq('https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.4_linux_armv7.tar.gz')
         expect(data['builds'][1]['sha512']).to eq('70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68c')
         expect(data['builds'][1]['filters'].size).to eq(3)
-        expect(data['builds'][1]['headers']).to be_nil
-        expect(data['headers']['Authorization']).to eq('Bearer $TOKEN')
-        expect(data['headers']['X-Forwarded-For']).to eq('client1, proxy1')
+        expect(data['builds'][1]['headers']['Authorization']).to eq('Bearer $TOKEN')
+        expect(data['builds'][1]['headers']['X-Forwarded-For']).to eq('client1, proxy1')
       end
     end
   end
@@ -208,9 +181,6 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_full do
     end
 
     describe command('sensuctl asset info test'), :node => node do
-      its(:exit_status) { should_not eq 0 }
-    end
-    describe command('sensuctl asset info test2'), :node => node do
       its(:exit_status) { should_not eq 0 }
     end
   end

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -31,8 +31,10 @@ describe 'sensu::backend::resources', :type => :class do
           class { '::sensu::backend':
             assets => {
               'test' => {
-                'url'    => 'http://localhost',
-                'sha512' => '0e3e75234abc68f4378a86b3f4b32a198ba301845b0cd6e50106e874345700cc6663a86c1ea125dc5e92be17c98f9a0f85ca9d5f595db2012f7cc3571945c123',
+                'builds' => [{
+                  'url'    => 'http://localhost',
+                  'sha512' => '0e3e75234abc68f4378a86b3f4b32a198ba301845b0cd6e50106e874345700cc6663a86c1ea125dc5e92be17c98f9a0f85ca9d5f595db2012f7cc3571945c123',
+                }]
               }
             }
           }

--- a/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset_list.json
+++ b/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset_list.json
@@ -1,17 +1,85 @@
 [
   {
-    "url": "https://github.com/cyphus/test-asset-host/releases/download/0.0.1/check-cpu-sh.tgz",
-    "sha512": "58a4d415f82ac9750ecf92d25a6b782393e00461d66c287e6eca56bb1d1789d78de5d04477ff1994d989916f39d290ef67f3bdeab9299a6fb94c9d6df95fe36b",
     "filters": null,
-    "headers": {
-      "Authorization": "Bearer $TOKEN",
-      "X-Forwarded-For": "client1, proxy1, proxy2"
-    },
+    "builds": [
+      {
+        "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
+        "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+        "filters": [
+          "entity.system.os == 'linux'",
+          "entity.system.arch == 'amd64'"
+        ],
+        "headers": {
+          "Authorization": "Bearer $TOKEN",
+          "X-Forwarded-For": "client1, proxy1, proxy2"
+        }
+      },
+      {
+        "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz",
+        "sha512": "70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b",
+        "filters": [
+          "entity.system.os == 'linux'",
+          "entity.system.arch == 'arm'",
+          "entity.system.arm_version == 7"
+        ],
+        "headers": {
+          "Authorization": "Bearer $TOKEN",
+          "X-Forwarded-For": "client1, proxy1, proxy2"
+        }
+      },
+      {
+        "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz",
+        "sha512": "10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f",
+        "filters": [
+          "entity.system.os == 'windows'",
+          "entity.system.arch == 'amd64'"
+        ],
+        "headers": {
+          "Authorization": "Bearer $TOKEN",
+          "X-Forwarded-For": "client1, proxy1, proxy2"
+        }
+      }
+    ],
     "metadata": {
-      "name": "check-cpu.sh",
+      "name": "check_cpu",
       "namespace": "default",
-      "labels": null,
-      "annotations": null
-    }
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": null
+  },
+  {
+    "url": "http://example.com/asset.tar.gz",
+    "sha512": "4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b",
+    "filters": null,
+    "builds": [
+      {
+        "url": "http://example.com/asset-linux-amd64.tar.gz",
+        "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+        "filters": null,
+        "headers": null
+      },
+      {
+        "url": "http://example.com/asset-linux-armv7.tar.gz",
+        "sha512": "70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b",
+        "filters": [
+          "entity.system.os == 'linux'",
+          "entity.system.arch == 'arm'",
+          "entity.system.arm_version == 7"
+        ],
+        "headers": null
+      }
+    ],
+    "metadata": {
+      "name": "test",
+      "namespace": "default"
+    },
+    "headers": null
   }
 ]
+

--- a/spec/unit/provider/sensu_asset/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_asset/sensuctl_spec.rb
@@ -6,35 +6,40 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
   let(:resource) do
     type.new({
       :name => 'test',
-      :url => 'http://127.0.0.1',
-      :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'
+      :builds => [{
+        "url" => 'http://127.0.0.1',
+        "sha512" => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'
+      }]
     })
   end
 
   describe 'self.instances' do
     it 'should create instances' do
       allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
-      expect(provider.instances.length).to eq(1)
+      expect(provider.instances.length).to eq(2)
     end
 
     it 'should return the resource for a asset' do
       allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('check-cpu.sh in default')
+      expect(property_hash[:name]).to eq('check_cpu in default')
     end
   end
 
   describe 'create' do
     it 'should create a asset' do
-      resource[:filters] = ["entity.system.os == 'linux'"]
+      resource[:builds][0]["filters"] = ["entity.system.os == 'linux'"]
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
       }
       expected_spec = {
-        :url => 'http://127.0.0.1',
-        :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
-        :filters => ["entity.system.os == 'linux'"],
+        :builds => [{
+          "url" => 'http://127.0.0.1',
+          "sha512" => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
+          "filters" => ["entity.system.os == 'linux'"],
+          "headers" => nil,
+        }]
       }
       expect(resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
       resource.provider.create
@@ -45,33 +50,42 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
 
   describe 'flush' do
     it 'should update a asset filters' do
-      resource[:filters] = ["entity.system.os == 'linux'"]
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
       }
       expected_spec = {
-        :url => 'http://127.0.0.1',
-        :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
-        :filters => ["entity.system.os == 'windows'"],
+        :builds => [{
+          "url" => 'http://127.0.0.1',
+          "sha512" => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
+          "filters" => ["entity.system.os == 'windows'"],
+          "headers" => nil,
+        }]
       }
       expect(resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
-      resource.provider.filters = ["entity.system.os == 'windows'"]
+      resource.provider.builds = [{
+          "url" => 'http://127.0.0.1',
+          "sha512" => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
+          "filters" => ["entity.system.os == 'windows'"],
+          "headers" => nil,
+      }]
       resource.provider.flush
     end
     it 'should remove filters' do
-      resource[:filters] = ["entity.system.os == 'linux'"]
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
       }
       expected_spec = {
-        :url => 'http://127.0.0.1',
-        :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
-        :filters => nil,
+        :builds => [{
+          "url" => 'http://127.0.0.1',
+          "sha512" => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
+          "filters" => nil,
+          "headers" => nil,
+        }]
       }
       expect(resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
-      resource.provider.filters = :absent
+      resource.provider.builds = resource[:builds]
       resource.provider.flush
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Deprecate ability to define assets via `url`, `sha512`, `filters` and `headers` property in favor of just using `builds` for defining assets with multiple builds. All previous properties still supported but deprecated ones will issue Puppet warning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.12 deprecated defining single assets not using `builds` so this change matches that deprecation.