### PR TITLE
BREAKING: Refactor how sensu_ldap_auth and sensu_ad_auth define servers

### DIFF
--- a/lib/puppet/provider/sensu_ldap_auth/sensuctl.rb
+++ b/lib/puppet/provider/sensu_ldap_auth/sensuctl.rb
@@ -18,30 +18,9 @@ Puppet::Type.type(:sensu_ldap_auth).provide(:sensuctl, :parent => Puppet::Provid
       if auth_types[auth[:name]] != 'LDAP'
         next
       end
+      auth[:servers] = d['servers']
       auth[:groups_prefix] = d['groups_prefix']
       auth[:username_prefix] = d['username_prefix']
-      binding = {}
-      group_search = {}
-      user_search = {}
-      servers = []
-      d['servers'].each do |server|
-        s = {}
-        s['host'] = server['host']
-        s['port'] = server['port']
-        s['insecure'] = server['insecure']
-        s['security'] = server['security']
-        s['trusted_ca_file'] = server['trusted_ca_file']
-        s['client_cert_file'] = server['client_cert_file']
-        s['client_key_file'] = server['client_key_file']
-        binding[s['host']] = server['binding']
-        group_search[s['host']] = server['group_search']
-        user_search[s['host']] = server['user_search']
-        servers << s
-      end
-      auth[:servers] = servers
-      auth[:server_binding] = binding
-      auth[:server_group_search] = group_search
-      auth[:server_user_search] = user_search
       auths << new(auth)
     end
     auths
@@ -75,14 +54,7 @@ Puppet::Type.type(:sensu_ldap_auth).provide(:sensuctl, :parent => Puppet::Provid
     spec = {}
     metadata = {}
     metadata[:name] = resource[:name]
-    spec[:servers] = []
-    resource[:servers].each do |server|
-      host = server['host']
-      server['binding'] = resource[:server_binding][host] if resource[:server_binding]
-      server['group_search'] = resource[:server_group_search][host]
-      server['user_search'] = resource[:server_user_search][host]
-      spec[:servers] << server
-    end
+    spec[:servers] = resource[:servers]
     spec[:groups_prefix] = resource[:groups_prefix] if resource[:groups_prefix]
     spec[:username_prefix] = resource[:username_prefix] if resource[:username_prefix]
     begin
@@ -98,36 +70,9 @@ Puppet::Type.type(:sensu_ldap_auth).provide(:sensuctl, :parent => Puppet::Provid
       spec = {}
       metadata = {}
       metadata[:name] = resource[:name]
-      spec[:servers] = []
-      (@property_flush[:servers] || resource[:servers]).each do |server|
-        host = server['host']
-        if @property_flush[:server_binding]
-          server['binding'] = @property_flush[:server_binding][host]
-        else
-          server['binding'] = resource[:server_binding][host] if resource[:server_binding]
-        end
-        if @property_flush[:server_group_search]
-          server['group_search'] = @property_flush[:server_group_search][host]
-        else
-          server['group_search'] = resource[:server_group_search][host]
-        end
-        if @property_flush[:server_user_search]
-          server['user_search'] = @property_flush[:server_user_search][host]
-        else
-          server['user_search'] = resource[:server_user_search][host]
-        end
-        spec[:servers] << server
-      end
-      if @property_flush[:groups_prefix]
-        spec[:groups_prefix] = @property_flush[:groups_prefix]
-      else
-        spec[:groups_prefix] = resource[:groups_prefix]
-      end
-      if @property_flush[:username_prefix]
-        spec[:username_prefix] = @property_flush[:username_prefix]
-      else
-        spec[:username_prefix] = resource[:username_prefix]
-      end
+      spec[:servers] = @property_flush[:servers] || resource[:servers]
+      spec[:groups_prefix] = @property_flush[:groups_prefix] || resource[:groups_prefix]
+      spec[:username_prefix] = @property_flush[:username_prefix] || resource[:username_prefix]
       begin
         sensuctl_create('ldap', metadata, spec, 'authentication/v2')
       rescue Exception => e

--- a/lib/puppet/type/sensu_ldap_auth.rb
+++ b/lib/puppet/type/sensu_ldap_auth.rb
@@ -14,24 +14,18 @@ Puppet::Type.newtype(:sensu_ldap_auth) do
       {
         'host' => '127.0.0.1',
         'port' => 389,
+        'binding' => {
+          'user_dn' => 'cn=binder,dc=acme,dc=org',
+          'password' => 'P@ssw0rd!'
+        },
+        'group_search' => {
+          'base_dn' => 'dc=acme,dc=org',
+        },
+        'user_search'  => {
+          'base_dn' => 'dc=acme,dc=org',
+        },
       },
     ],
-    server_binding      => {
-      '127.0.0.1' => {
-        'user_dn' => 'cn=binder,dc=acme,dc=org',
-        'password' => 'P@ssw0rd!'
-      }
-    },
-    server_group_search => {
-      '127.0.0.1' => {
-        'base_dn' => 'dc=acme,dc=org',
-      }
-    },
-    server_user_search  => {
-      '127.0.0.1' => {
-        'base_dn' => 'dc=acme,dc=org',
-      }
-    },
   }
 
 **Autorequires**:
@@ -63,17 +57,34 @@ DESC
     Keys:
     * host: required
     * port: required
+    * group_search: required
+    * user_search: required
+    * binding: optional Hash
     * insecure: default is `false`
     * security: default is `tls`
     * trusted_ca_file: default is `""`
     * client_cert_file: default is `""`
     * client_key_file: default is `""`
+    * default_upn_domain: default is `""`
+    group_search keys:
+    * base_dn: required
+    * attribute: default is `member`
+    * name_attribute: default is `cn`
+    * object_class: default is `groupOfNames`
+    user_search Keys:
+    * base_dn: required
+    * attribute: default is `uid`
+    * name_attribute: default is `cn`
+    * object_class: default is `person`
+    binding keys:
+    * user_dn: required
+    * password: required
     EOS
     validate do |server|
       if ! server.is_a?(Hash)
         raise ArgumentError, "Each server must be a Hash not #{server.class}"
       end
-      required_keys = ['host','port']
+      required_keys = ['host','port','group_search','user_search']
       server_keys = server.keys.map { |k| k.to_s }
       required_keys.each do |k|
         if ! server_keys.include?(k)
@@ -89,7 +100,39 @@ DESC
       if server.key?('security') && ! ['tls','starttls','insecure'].include?(server['security'].to_s)
         raise ArgumentError, "server security must be tls, starttls or insecure, not #{server['security']}"
       end
-      valid_keys = ['host','port','insecure','security','trusted_ca_file','client_cert_file','client_key_file']
+      if server.key?('binding')
+        if ! server['binding'].is_a?(Hash)
+          raise ArgumentError, "server binding must be a hash, not #{server['binding'].class}"
+        end
+        if server['binding'].keys.sort != ['password','user_dn']
+          raise ArgumentError, "server binding must contain keys 'password' and 'user_dn'"
+        end
+      end
+      if ! server['group_search'].is_a?(Hash)
+        raise ArgumentError, "group_search must be a Hash not #{server['group_search'].class}"
+      end
+      if ! server['group_search'].key?('base_dn')
+        raise ArgumentError, "group_search requires base_dn"
+      end
+      group_search_valid_keys = ['base_dn','attribute','name_attribute','object_class']
+      server['group_search'].keys.each do |key|
+        if ! group_search_valid_keys.include?(key)
+          raise ArgumentError, "#{key} is not a valid key for group_search"
+        end
+      end
+      if ! server['user_search'].is_a?(Hash)
+        raise ArgumentError, "user_search must be a Hash not #{server['user_search'].class}"
+      end
+      if ! server['user_search'].key?('base_dn')
+        raise ArgumentError, "user_search requires base_dn"
+      end
+      user_search_valid_keys = ['base_dn','attribute','name_attribute','object_class']
+      server['user_search'].keys.each do |key|
+        if ! user_search_valid_keys.include?(key)
+          raise ArgumentError, "#{key} is not a valid key for user_search"
+        end
+      end
+      valid_keys = ['host','port','insecure','security','trusted_ca_file','client_cert_file','client_key_file', 'default_upn_domain', 'binding', 'group_search', 'user_search']
       server.keys.each do |key|
         if ! valid_keys.include?(key)
           raise ArgumentError, "#{key} is not a valid key for server"
@@ -103,137 +146,66 @@ DESC
       if ! server.key?('security')
         server['security'] = 'tls'
       end
-      ['trusted_ca_file','client_cert_file','client_key_file'].each do |k|
+      ['trusted_ca_file','client_cert_file','client_key_file','default_upn_domain'].each do |k|
         if ! server.key?(k)
           server[k] = ''
         end
       end
-      server
-    end
-  end
-
-  newproperty(:server_binding, :parent => PuppetX::Sensu::HashProperty) do
-    desc "LDAP server bindings"
-    validate do |bindings|
-      super(bindings)
-      bindings.each_pair do |server,binding|
-        if ! binding.is_a?(Hash)
-          raise ArgumentError, "binding must be a Hash not #{binding.class}"
-        end
-        if ! binding.key?('user_dn')
-          raise ArgumentError, "binding requires user_dn"
-        end
-        if ! binding.key?('password')
-          raise ArgumentError, "binding requires password"
-        end
-        valid_keys = ['user_dn','password']
-        binding.keys.each do |key|
-          if ! valid_keys.include?(key)
-            raise ArgumentError, "#{key} is not a valid key for binding"
-          end
-        end
-      end
-    end
-    
-    def change_to_s(currentvalue, newvalue)
-      return "changed server bindings"
-    end
-    def is_to_s(currentvalue)
-      return '[old server bindings redacted]'
-    end
-    def should_to_s(newvalue)
-      return '[new server bindings redacted]'
-    end
-  end
-
-  newproperty(:server_group_search, :parent => PuppetX::Sensu::HashProperty) do
-    desc <<-EOS
-    Search configuration for groups.
-    Keys:
-    * base_dn: required
-    * attribute: default is `member`
-    * name_attribute: default is `cn`
-    * object_class: default is `groupOfNames`
-    EOS
-    validate do |server_group_search|
-      super(server_group_search)
-      server_group_search.each_pair do |server, group_search|
-        if ! group_search.is_a?(Hash)
-          raise ArgumentError, "group_search must be a Hash not #{group_search.class}"
-        end
-        if ! group_search.key?('base_dn')
-          raise ArgumentError, "group_search requires base_dn"
-        end
-        valid_keys = ['base_dn','attribute','name_attribute','object_class']
-        group_search.keys.each do |key|
-          if ! valid_keys.include?(key)
-            raise ArgumentError, "#{key} is not a valid key for group_search"
-          end
-        end
-      end
-    end
-    munge do |server_group_search|
-      n = {}
-      defaults = {
+      group_search_defaults = {
         'attribute' => 'member',
         'name_attribute' => 'cn',
         'object_class' => 'groupOfNames',
       }
-      server_group_search.each_pair do |server, group_search|
-        defaults.each_pair do |k,v|
-          if ! group_search.key?(k)
-            group_search[k] = v
-          end
-        end
-        n[server] = group_search
-      end
-      n
-    end
-  end
-
-  newproperty(:server_user_search, :parent => PuppetX::Sensu::HashProperty) do
-    desc <<-EOS
-    Search configuration for users.
-    Keys:
-    * base_dn: required
-    * attribute: default is `uid`
-    * name_attribute: default is `cn`
-    * object_class: default is `person`
-    EOS
-    validate do |server_user_search|
-      super(server_user_search)
-      server_user_search.each_pair do |server, user_search|
-        if ! user_search.is_a?(Hash)
-          raise ArgumentError, "user_search must be a Hash not #{user_search.class}"
-        end
-        if ! user_search.key?('base_dn')
-          raise ArgumentError, "user_search requires base_dn"
-        end
-        valid_keys = ['base_dn','attribute','name_attribute','object_class']
-        user_search.keys.each do |key|
-          if ! valid_keys.include?(key)
-            raise ArgumentError, "#{key} is not a valid key for user_search"
-          end
+      group_search_defaults.each_pair do |k,v|
+        if ! server['group_search'].key?(k)
+          server['group_search'][k] = v
         end
       end
-    end
-    munge do |server_user_search|
-      n = {}
-      defaults = {
+      user_search_defaults = {
         'attribute' => 'uid',
         'name_attribute' => 'cn',
         'object_class' => 'person',
       }
-      server_user_search.each_pair do |server, user_search|
-        defaults.each_pair do |k,v|
-          if ! user_search.key?(k)
-            user_search[k] = v
+      user_search_defaults.each_pair do |k,v|
+        if ! server['user_search'].key?(k)
+          server['user_search'][k] = v
+        end
+      end
+      server
+    end
+
+    def change_to_s(currentvalue, newvalue)
+      currentv = currentvalue.to_s
+      if currentvalue.is_a?(Array)
+        currentvalue.each_with_index do |c,i|
+          if c.key?('binding')
+            currentv.gsub!(currentvalue[i]['binding']['password'], '*****')
           end
         end
-        n[server] = user_search
       end
-      n
+      newv = newvalue.to_s
+      if newvalue.is_a?(Array)
+        newvalue.each_with_index do |n,i|
+          if n.key?('binding')
+            newv.gsub!(newvalue[i]['binding']['password'], '****')
+          end
+        end
+      end
+      super(currentv, newv)
     end
+
+    def is_to_s(currentvalue)
+      currentv = currentvalue.to_s
+      if currentvalue.is_a?(Array)
+        currentvalue.each_with_index do |c,i|
+          if c.key?('binding')
+            currentv.gsub!(currentvalue[i]['binding']['password'], '*****')
+          end
+        end
+      end
+      currentv
+    end
+    alias :should_to_s :is_to_s
   end
 
   newproperty(:groups_prefix) do
@@ -251,40 +223,10 @@ DESC
   validate do
     required_properties = [
       :servers,
-      :server_group_search,
-      :server_user_search,
     ]
     required_properties.each do |property|
       if self[:ensure] == :present && self[property].nil?
         fail "You must provide a #{property}"
-      end
-    end
-    if self[:ensure] == :present
-      servers = self[:servers].map { |s| s['host'] }.sort
-      if self[:server_binding]
-        self[:server_binding].keys.each do |server|
-          if ! servers.include?(server)
-            fail "Server binding for #{server} not found in servers property"
-          end
-        end
-      end
-      self[:server_group_search].keys.each do |server|
-        if ! servers.include?(server)
-          fail "Server group_search for #{server} not found in servers property"
-        end
-      end
-      self[:server_user_search].keys.each do |server|
-        if ! servers.include?(server)
-          fail "Server user_search for #{server} not found in servers property"
-        end
-      end
-      servers.each do |server|
-        if ! self[:server_group_search].keys.include?(server)
-          fail "server #{server} has no group_search defined"
-        end
-        if ! self[:server_user_search].keys.include?(server)
-          fail "server #{server} has no user_search defined"
-        end
       end
     end
   end

--- a/spec/acceptance/sensu_ad_auth_spec.rb
+++ b/spec/acceptance/sensu_ad_auth_spec.rb
@@ -19,24 +19,18 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
           {
             'host' => '127.0.0.1',
             'port' => 389,
-          },
-        ],
-        server_binding      => {
-          '127.0.0.1' => {
-            'user_dn' => 'cn=binder,dc=acme,dc=org',
-            'password' => 'P@ssw0rd!'
+            'binding'      => {
+              'user_dn' => 'cn=binder,dc=acme,dc=org',
+              'password' => 'P@ssw0rd!'
+            },
+            'group_search' => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
+            'user_search'  => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
           }
-        },
-        server_group_search => {
-          '127.0.0.1' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
-        server_user_search  => {
-          '127.0.0.1' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
+        ]
       }
       EOS
 
@@ -84,24 +78,18 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
             'port' => 636,
             'default_upn_domain' => 'example.com',
             'include_nested_groups' => true,
-          },
-        ],
-        server_binding      => {
-          'localhost' => {
-            'user_dn' => 'cn=test,dc=acme,dc=org',
-            'password' => 'password'
+            'binding'      => {
+              'user_dn' => 'cn=test,dc=acme,dc=org',
+              'password' => 'password'
+            },
+            'group_search' => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
+            'user_search'  => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
           }
-        },
-        server_group_search => {
-          'localhost' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
-        server_user_search  => {
-          'localhost' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
+        ]
       }
       EOS
 

--- a/spec/acceptance/sensu_ldap_auth_spec.rb
+++ b/spec/acceptance/sensu_ldap_auth_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_check', if: RSpec.configuration.sensu_full do
+describe 'sensu_ldap_auth', if: RSpec.configuration.sensu_full do
   node = hosts_as('sensu_backend')[0]
   before do
     if ! RSpec.configuration.sensu_test_enterprise
@@ -17,26 +17,20 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
         ensure              => 'present',
         servers             => [
           {
-            'host' => '127.0.0.1',
-            'port' => 389,
-          },
-        ],
-        server_binding      => {
-          '127.0.0.1' => {
-            'user_dn' => 'cn=binder,dc=acme,dc=org',
-            'password' => 'P@ssw0rd!'
+            'host'         => '127.0.0.1',
+            'port'         => 389,
+            'binding'      => {
+              'user_dn' => 'cn=binder,dc=acme,dc=org',
+              'password' => 'P@ssw0rd!'
+            },
+            'group_search' => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
+            'user_search'  => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
           }
-        },
-        server_group_search => {
-          '127.0.0.1' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
-        server_user_search  => {
-          '127.0.0.1' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
+        ]
       }
       EOS
 
@@ -80,24 +74,18 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
           {
             'host' => 'localhost',
             'port' => 636,
-          },
-        ],
-        server_binding      => {
-          'localhost' => {
-            'user_dn' => 'cn=test,dc=acme,dc=org',
-            'password' => 'password'
+            'binding'      => {
+              'user_dn' => 'cn=test,dc=acme,dc=org',
+              'password' => 'password'
+            },
+            'group_search' => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
+            'user_search'  => {
+              'base_dn' => 'dc=acme,dc=org',
+            },
           }
-        },
-        server_group_search => {
-          'localhost' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
-        server_user_search  => {
-          'localhost' => {
-            'base_dn' => 'dc=acme,dc=org',
-          }
-        },
+        ]
       }
       EOS
 

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -13,10 +13,12 @@ describe 'sensu::backend::resources', :type => :class do
           class { '::sensu::backend':
             ad_auths => {
               'ad' => {
-                'servers'             => [{'host' => 'test', 'port' => 389}],
-                'server_binding'      => {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}},
-                'server_group_search' => {'test' => {'base_dn' => 'ou=Groups'}},
-                'server_user_search'  => {'test' => {'base_dn' => 'ou=People'}},
+                'servers'             => [{
+                  'host'         => 'test', 'port' => 389,
+                  'binding'      => {'user_dn' => 'cn=foo','password' => 'foo'},
+                  'group_search' => {'base_dn' => 'ou=Groups'},
+                  'user_search'  => {'base_dn' => 'ou=People'},
+                }],
               }
             }
           }
@@ -238,10 +240,12 @@ describe 'sensu::backend::resources', :type => :class do
           class { '::sensu::backend':
             ldap_auths => {
               'ldap' => {
-                'servers'             => [{'host' => 'test', 'port' => 389}],
-                'server_binding'      => {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}},
-                'server_group_search' => {'test' => {'base_dn' => 'ou=Groups'}},
-                'server_user_search'  => {'test' => {'base_dn' => 'ou=People'}},
+                'servers'             => [{
+                  'host'         => 'test', 'port' => 389,
+                  'binding'      => {'user_dn' => 'cn=foo','password' => 'foo'},
+                  'group_search' => {'base_dn' => 'ou=Groups'},
+                  'user_search'  => {'base_dn' => 'ou=People'},
+                }]
               }
             }
           }

--- a/spec/unit/provider/sensu_ldap_auth/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_ldap_auth/sensuctl_spec.rb
@@ -3,14 +3,19 @@ require 'spec_helper'
 describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
   let(:provider) { described_class }
   let(:type) { Puppet::Type.type(:sensu_ldap_auth) }
-  let(:resource) do
-    type.new({
+  let(:config) do
+    {
       :name => 'test',
-      :servers => [{'host' => 'test', 'port' => 389}],
-      :server_binding => {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}},
-      :server_group_search => {'test' => {'base_dn' => 'ou=Groups'}},
-      :server_user_search => {'test' => {'base_dn' => 'ou=People'}},
-    })
+      :servers => [{
+        'host' => 'test', 'port' => 389,
+        'binding' => {'user_dn' => 'cn=foo','password' => 'foo'},
+        'group_search' => {'base_dn' => 'ou=Groups'},
+        'user_search' => {'base_dn' => 'ou=People'},
+      }],
+    }
+  end
+  let(:resource) do
+    type.new(config)
   end
 
   describe 'self.instances' do
@@ -42,6 +47,7 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
           'trusted_ca_file' => '',
           'client_cert_file' => '',
           'client_key_file' => '',
+          'default_upn_domain' => '',
           'binding' => {'user_dn' => 'cn=foo', 'password' => 'foo'},
           'group_search' => {'base_dn' => 'ou=Groups','attribute' => 'member','name_attribute' => 'cn','object_class' => 'groupOfNames'},
           'user_search' => {'base_dn' => 'ou=People','attribute' => 'uid','name_attribute' => 'cn','object_class' => 'person'},
@@ -65,21 +71,17 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
           'trusted_ca_file' => '',
           'client_cert_file' => '',
           'client_key_file' => '',
+          'default_upn_domain' => '',
           'group_search' => {'base_dn' => 'ou=Groups','attribute' => 'member','name_attribute' => 'cn','object_class' => 'groupOfNames'},
           'user_search' => {'base_dn' => 'ou=People','attribute' => 'uid','name_attribute' => 'cn','object_class' => 'person'},
         }]
       }
-      resource = type.new({
-        :name => 'test',
-        :servers => [{'host' => 'test', 'port' => 389}],
-        :server_group_search => {'test' => {'base_dn' => 'ou=Groups'}},
-        :server_user_search => {'test' => {'base_dn' => 'ou=People'}},
-      })
+      config[:servers][0].delete('binding')
       expect(resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
       resource.provider.create
       property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
-    end
+    end 
   end
 
   describe 'flush' do
@@ -96,6 +98,7 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
           'trusted_ca_file' => '',
           'client_cert_file' => '',
           'client_key_file' => '',
+          'default_upn_domain' => '',
           'binding' => {'user_dn' => 'cn=foo', 'password' => 'bar'},
           'group_search' => {'base_dn' => 'ou=Groups','attribute' => 'member','name_attribute' => 'cn','object_class' => 'groupOfNames'},
           'user_search' => {'base_dn' => 'ou=People','attribute' => 'uid','name_attribute' => 'cn','object_class' => 'person'},
@@ -103,8 +106,9 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
         :groups_prefix => nil,
         :username_prefix => nil,
       }
+      config[:servers][0]['binding'] = {'user_dn' => 'cn=foo', 'password' => 'bar'}
       expect(resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
-      resource.provider.server_binding = {'test' => {'user_dn' => 'cn=foo', 'password' => 'bar'}}
+      resource.provider.servers = config[:servers]
       resource.provider.flush
     end
   end

--- a/spec/unit/sensu_ad_auth_spec.rb
+++ b/spec/unit/sensu_ad_auth_spec.rb
@@ -5,11 +5,11 @@ describe Puppet::Type.type(:sensu_ad_auth) do
   let(:default_config) do
     {
       name: 'ad',
-      servers: [
-        {'host' => 'test', 'port' => 389},
-      ],
-      server_group_search: {'test' => {'base_dn' => 'ou=Groups'}},
-      server_user_search: {'test' => {'base_dn' => 'ou=People'}},
+      servers: [{
+        'host' => 'test', 'port' => 389,
+        'group_search' => {'base_dn' => 'ou=Groups'},
+        'user_search' => {'base_dn' => 'ou=People'},
+      }],
     }
   end
   let(:config) do
@@ -180,7 +180,8 @@ describe Puppet::Type.type(:sensu_ad_auth) do
         'client_cert_file' => '',
         'client_key_file' => '',
         'default_upn_domain' => '',
-        'include_nested_groups' => nil,
+        'group_search' => {'base_dn' => 'ou=Groups','attribute' => 'member','name_attribute' => 'cn','object_class' => 'group'},
+        'user_search' => {'base_dn' => 'ou=People','attribute' => 'sAMAccountName','name_attribute' => 'displayName','object_class' => 'person'},
       }]
       expect(auth[:servers]).to eq(expected)
     end
@@ -201,110 +202,64 @@ describe Puppet::Type.type(:sensu_ad_auth) do
       expect { auth }.to raise_error(Puppet::Error, /is not a valid key for server/)
     end
     it 'should require boolean for insecure' do
-      config[:servers] = [{'host' => 'test', 'port' => 389, 'insecure' => 'true'}]
+      config[:servers][0]['insecure'] = 'true'
       expect { auth }.to raise_error(Puppet::Error, /server insecure must be a Boolean/)
     end
     it 'should require valid security' do
-      config[:servers] = [{'host' => 'test', 'port' => 389, 'security' => 'foo'}]
+      config[:servers][0]['security'] = 'foo'
       expect { auth }.to raise_error(Puppet::Error, /server security must be tls, starttls or insecure/)
     end
-    it 'should require boolean for include_nested_groups' do
-      config[:servers] = [{'host' => 'test', 'port' => 389, 'include_nested_groups' => 'true'}]
-      expect { auth }.to raise_error(Puppet::Error, /server include_nested_groups must be a Boolean/)
+    it 'should accept valid value for binding' do
+      config[:servers][0]['binding'] = {'user_dn' => 'cn=foo','password' => 'foo'}
+      expect(auth[:servers][0]['binding']).to eq({'user_dn' => 'cn=foo','password' => 'foo'})
     end
-  end
-
-  describe 'server_binding' do
-    it 'should accept valid value' do
-      config[:server_binding] = {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}}
-      expect(auth[:server_binding]).to eq({'test' => {'user_dn' => 'cn=foo','password' => 'foo'}})
+    it 'should require a hash for binding' do
+      config[:servers][0]['binding'] = 'foo'
+      expect { auth }.to raise_error(Puppet::Error, /must be a hash/)
     end
-    it 'should require a hash' do
-      config[:server_binding] = 'foo'
-      expect { auth }.to raise_error(Puppet::Error, /should be a Hash/)
+    it 'should require user_dn for binding' do
+      config[:servers][0]['binding'] = {'password' => 'foo'}
+      expect { auth }.to raise_error(Puppet::Error, /server binding must contain keys/)
     end
-    it 'should require a binding hash' do
-      config[:server_binding] = { 'foo' => 'bar' }
-      expect { auth }.to raise_error(Puppet::Error, /binding must be a Hash/)
+    it 'should require password for binding' do
+      config[:servers][0]['binding'] = {'user_dn' => 'cn=foo'}
+      expect { auth }.to raise_error(Puppet::Error, /server binding must contain keys/)
     end
-    it 'should require user_dn' do
-      config[:server_binding] = {'test' => {'password' => 'foo'}}
-      expect { auth }.to raise_error(Puppet::Error, /binding requires user_dn/)
+    it 'should not accept invalid key for binding' do
+      config[:servers][0]['binding'] = {'user_dn' => 'cn=foo','password' => 'foo','foo' => 'bar'}
+      expect { auth }.to raise_error(Puppet::Error, /server binding must contain keys/)
     end
-    it 'should require password' do
-      config[:server_binding] = {'test' => {'user_dn' => 'cn=foo'}}
-      expect { auth }.to raise_error(Puppet::Error, /binding requires password/)
+    it 'should require a hash for group_search' do
+      config[:servers][0]['group_search'] = 'foo'
+      expect { auth }.to raise_error(Puppet::Error, /must be a Hash/)
     end
-    it 'should not accept invalid key' do
-      config[:server_binding] = {'test' => {'user_dn' => 'cn=foo','password' => 'foo','foo' => 'bar'}}
-      expect { auth }.to raise_error(Puppet::Error, /is not a valid key for binding/)
-    end
-    it 'should fail if server not defined' do
-      config[:server_binding] = {'foo' => {'user_dn' => 'cn=foo','password' => 'foo'}}
-      expect { auth }.to raise_error(Puppet::Error, /Server binding for foo not found in servers property/)
-    end
-  end
-
-  describe 'server_group_search' do
-    it 'should accept valid value and apply defaults' do
-      expect(auth[:server_group_search]).to eq({'test' => {'base_dn' => 'ou=Groups','attribute' => 'member','name_attribute' => 'cn','object_class' => 'group'}})
-    end
-    it 'should require a hash' do
-      config[:server_group_search] = 'foo'
-      expect { auth }.to raise_error(Puppet::Error, /should be a Hash/)
-    end
-    it 'should require a group_search hash' do
-      config[:server_group_search] = { 'foo' => 'bar' }
-      expect { auth }.to raise_error(Puppet::Error, /group_search must be a Hash/)
-    end
-    it 'should require base_dn' do
-      config[:server_group_search] = {'test' => {}}
+    it 'should require base_dn for group_search' do
+      config[:servers][0]['group_search'] = {}
       expect { auth }.to raise_error(Puppet::Error, /group_search requires base_dn/)
     end
-    it 'should not accept invalid key' do
-      config[:server_group_search]['test']['foo'] = 'bar'
+    it 'should not accept invalid key for group_search' do
+      config[:servers][0]['group_search'] = {'base_dn' => 'foo', 'foo' => 'bar'}
       expect { auth }.to raise_error(Puppet::Error, /is not a valid key for group_search/)
     end
-    it 'should fail if server not defined' do
-      config[:server_group_search] = {'foo' => {'base_dn' => 'ou=Groups'}}
-      expect { auth }.to raise_error(Puppet::Error, /Server group_search for foo not found in servers property/)
+    it 'should fail if group_search not defined' do
+      config[:servers][0].delete('group_search')
+      expect { auth }.to raise_error(Puppet::Error, /requires key group_search/)
     end
-    it 'should fail if group_search missing' do
-      config[:servers] << {'host' => 'foo' , 'port' => 389}
-      config[:server_binding] = {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}, 'foo' => {'user_dn' => 'cn=foo','password' => 'foo'}}
-      expect { auth }.to raise_error(Puppet::Error, /server foo has no group_search defined/)
+    it 'should require a hash for user_search' do
+      config[:servers][0]['user_search'] = 'foo'
+      expect { auth }.to raise_error(Puppet::Error, /must be a Hash/)
     end
-  end
-
-  describe 'server_user_search' do
-    it 'should accept valid value and apply defaults' do
-      expect(auth[:server_user_search]).to eq({'test' => {'base_dn' => 'ou=People','attribute' => 'sAMAccountName','name_attribute' => 'displayName','object_class' => 'person'}})
-    end
-    it 'should require a hash' do
-      config[:server_user_search] = 'foo'
-      expect { auth }.to raise_error(Puppet::Error, /should be a Hash/)
-    end
-    it 'should require a user_search hash' do
-      config[:server_user_search] = { 'foo' => 'bar' }
-      expect { auth }.to raise_error(Puppet::Error, /user_search must be a Hash/)
-    end
-    it 'should require base_dn' do
-      config[:server_user_search] = {'test' => {}}
+    it 'should require base_dn for user_search' do
+      config[:servers][0]['user_search'] = {}
       expect { auth }.to raise_error(Puppet::Error, /user_search requires base_dn/)
     end
-    it 'should not accept invalid key' do
-      config[:server_user_search]['test']['foo'] = 'bar'
+    it 'should not accept invalid key for user_search' do
+      config[:servers][0]['user_search'] = {'base_dn' => 'foo', 'foo' => 'bar'}
       expect { auth }.to raise_error(Puppet::Error, /is not a valid key for user_search/)
     end
-    it 'should fail if server not defined' do
-      config[:server_user_search] = {'foo' => {'base_dn' => 'ou=People'}}
-      expect { auth }.to raise_error(Puppet::Error, /Server user_search for foo not found in servers property/)
-    end
-    it 'should fail if user_search missing' do
-      config[:servers] << {'host' => 'foo' , 'port' => 389}
-      config[:server_binding] = {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}, 'foo' => {'user_dn' => 'cn=foo','password' => 'foo'}}
-      config[:server_group_search] = {'test' => {'base_dn' => 'ou=Groups'}, 'foo' => {'base_dn' => 'ou=Groups'}}
-      expect { auth }.to raise_error(Puppet::Error, /server foo has no user_search defined/)
+    it 'should fail if user_search not defined' do
+      config[:servers][0].delete('user_search')
+      expect { auth }.to raise_error(Puppet::Error, /requires key user_search/)
     end
   end
 
@@ -324,8 +279,6 @@ describe Puppet::Type.type(:sensu_ad_auth) do
 
   [
     :servers,
-    :server_group_search,
-    :server_user_search,
   ].each do |property|
     it "should require property when ensure => present" do
       config.delete(property)


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Refactor `sensu_ldap_auth` and `sensu_ad_auth` on how properties are defined.

Move server_binding, server_group_search and server_user_search into servers property

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This makes the `servers` property match the Sensu Go docs for LDAP and AD authentication specs.
