### PR TITLE
Replace unit test instance variables with let

### DIFF
--- a/spec/unit/provider/sensu_ad_auth/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_ad_auth/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_ad_auth).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_ad_auth)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_ad_auth) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :servers => [{'host' => 'test', 'port' => 389}],
       :server_binding => {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}},
@@ -15,15 +15,15 @@ describe Puppet::Type.type(:sensu_ad_auth).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
-      allow(@provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      expect(@provider.instances.length).to eq(2)
+      allow(provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
+      allow(provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      expect(provider.instances.length).to eq(2)
     end
 
     it 'should return the resource for a auth' do
-      allow(@provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
-      allow(@provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
+      allow(provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('activedirectory')
     end
   end
@@ -49,9 +49,9 @@ describe Puppet::Type.type(:sensu_ad_auth).provider(:sensuctl) do
           'user_search' => {'base_dn' => 'ou=People','attribute' => 'sAMAccountName','name_attribute' => 'displayName','object_class' => 'person'},
         }]
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ad', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('ad', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should create an auth without binding' do
@@ -73,15 +73,15 @@ describe Puppet::Type.type(:sensu_ad_auth).provider(:sensuctl) do
           'user_search' => {'base_dn' => 'ou=People','attribute' => 'sAMAccountName','name_attribute' => 'displayName','object_class' => 'person'},
         }]
       }
-      @resource = @type.new({
+      resource = type.new({
         :name => 'test',
         :servers => [{'host' => 'test', 'port' => 389}],
         :server_group_search => {'test' => {'base_dn' => 'ou=Groups'}},
         :server_user_search => {'test' => {'base_dn' => 'ou=People'}},
       })
-      expect(@resource.provider).to receive(:sensuctl_create).with('ad', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('ad', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -109,17 +109,17 @@ describe Puppet::Type.type(:sensu_ad_auth).provider(:sensuctl) do
         :groups_prefix => nil,
         :username_prefix => nil,
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ad', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.server_binding = {'test' => {'user_dn' => 'cn=foo', 'password' => 'bar'}}
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('ad', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.server_binding = {'test' => {'user_dn' => 'cn=foo', 'password' => 'bar'}}
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete an auth' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('auth', 'test')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('auth', 'test')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_asset/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_asset/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_asset)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_asset) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :url => 'http://127.0.0.1',
       :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'
@@ -13,20 +13,20 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a asset' do
-      allow(@provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('check-cpu.sh in default')
     end
   end
 
   describe 'create' do
     it 'should create a asset' do
-      @resource[:filters] = ["entity.system.os == 'linux'"]
+      resource[:filters] = ["entity.system.os == 'linux'"]
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -36,16 +36,16 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
         :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
         :filters => ["entity.system.os == 'linux'"],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
 
   describe 'flush' do
     it 'should update a asset filters' do
-      @resource[:filters] = ["entity.system.os == 'linux'"]
+      resource[:filters] = ["entity.system.os == 'linux'"]
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -55,12 +55,12 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
         :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
         :filters => ["entity.system.os == 'windows'"],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
-      @resource.provider.filters = ["entity.system.os == 'windows'"]
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
+      resource.provider.filters = ["entity.system.os == 'windows'"]
+      resource.provider.flush
     end
     it 'should remove filters' do
-      @resource[:filters] = ["entity.system.os == 'linux'"]
+      resource[:filters] = ["entity.system.os == 'linux'"]
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -70,17 +70,17 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
         :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
         :filters => nil,
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
-      @resource.provider.filters = :absent
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('Asset', expected_metadata, expected_spec)
+      resource.provider.filters = :absent
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a asset' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('asset', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('asset', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_check/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_check/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_check)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_check) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :command => 'foobar',
       :subscriptions => ['demo'],
@@ -15,24 +15,24 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('check').and_return(JSON.parse(my_fixture_read('check_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('check').and_return(JSON.parse(my_fixture_read('check_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a check' do
-      allow(@provider).to receive(:sensuctl_list).with('check').and_return(JSON.parse(my_fixture_read('check_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('check').and_return(JSON.parse(my_fixture_read('check_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('check-cpu in default')
     end
   end
 
   describe 'create' do
     it 'should create a check' do
-      @resource[:command] = 'check_ntp'
-      @resource[:handlers] = ['email', 'slack']
-      @resource[:stdin] = true
-      @resource[:publish] = false
-      @resource[:proxy_requests_entity_attributes] = ["entity.Class == 'proxy'"]
+      resource[:command] = 'check_ntp'
+      resource[:handlers] = ['email', 'slack']
+      resource[:stdin] = true
+      resource[:publish] = false
+      resource[:proxy_requests_entity_attributes] = ["entity.Class == 'proxy'"]
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -46,16 +46,16 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
         :publish => false,
         :proxy_requests => { :entity_attributes => ["entity.Class == 'proxy'"] }
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
 
   describe 'flush' do
     it 'should update a check proxy_requests' do
-      @resource[:proxy_requests_splay] = true
+      resource[:proxy_requests_splay] = true
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -69,9 +69,9 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
         :handlers => ['slack'],
         :proxy_requests => { :splay => true, :entity_attributes => ["entity.Class == 'proxy'"] }
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
-      @resource.provider.proxy_requests_entity_attributes = ["entity.Class == 'proxy'"]
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
+      resource.provider.proxy_requests_entity_attributes = ["entity.Class == 'proxy'"]
+      resource.provider.flush
     end
     it 'should update a check' do
       expected_metadata = {
@@ -86,9 +86,9 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
         :handlers => ['slack'],
         :interval => 20
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
-      @resource.provider.interval = 20
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
+      resource.provider.interval = 20
+      resource.provider.flush
     end
     it 'should remove ttl' do
       expected_metadata = {
@@ -104,18 +104,18 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
         :handlers => ['slack'],
         :ttl => nil,
       }
-      @resource[:ttl] = 120
-      expect(@resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
-      @resource.provider.ttl = :absent
-      @resource.provider.flush
+      resource[:ttl] = 120
+      expect(resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
+      resource.provider.ttl = :absent
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a check' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('check', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('check', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_cluster_member/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_cluster_member/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_cluster_member).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_cluster_member)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_cluster_member) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :peer_urls => ['http://127.0.0.1:2380'],
     })
@@ -12,13 +12,13 @@ describe Puppet::Type.type(:sensu_cluster_member).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl).with('cluster', 'member-list', '--format', 'json').and_return(my_fixture_read('cluster_member_list.json'))
-      expect(@provider.instances.length).to eq(3)
+      allow(provider).to receive(:sensuctl).with('cluster', 'member-list', '--format', 'json').and_return(my_fixture_read('cluster_member_list.json'))
+      expect(provider.instances.length).to eq(3)
     end
 
     it 'should return the resource for a cluster_member' do
-      allow(@provider).to receive(:sensuctl).with('cluster', 'member-list', '--format', 'json').and_return(my_fixture_read('cluster_member_list.json'))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl).with('cluster', 'member-list', '--format', 'json').and_return(my_fixture_read('cluster_member_list.json'))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('backend3')
       expect(property_hash[:id]).to eq('74ae9e813b87882d')
     end
@@ -26,38 +26,38 @@ describe Puppet::Type.type(:sensu_cluster_member).provider(:sensuctl) do
 
   describe 'create' do
     it 'should add a cluster_member' do
-      expect(@resource.provider).to receive(:sensuctl).with('cluster', 'member-add', 'test', 'http://127.0.0.1:2380').and_return('output')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl).with('cluster', 'member-add', 'test', 'http://127.0.0.1:2380').and_return('output')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
 
   describe 'flush' do
     before(:each) do
-      hash = @resource.provider.instance_variable_get(:@property_hash)
+      hash = resource.provider.instance_variable_get(:@property_hash)
       hash[:id] = '74ae9e813b87882d'
-      @resource.provider.instance_variable_set(:@property_hash, hash)
+      resource.provider.instance_variable_set(:@property_hash, hash)
     end
 
     it 'should update a cluster_member' do
-      expect(@resource.provider).to receive(:sensuctl).with('cluster', 'member-update', '74ae9e813b87882d', 'http://localhost:2380').and_return('output')
-      @resource.provider.peer_urls = ['http://localhost:2380']
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl).with('cluster', 'member-update', '74ae9e813b87882d', 'http://localhost:2380').and_return('output')
+      resource.provider.peer_urls = ['http://localhost:2380']
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     before(:each) do
-      hash = @resource.provider.instance_variable_get(:@property_hash)
+      hash = resource.provider.instance_variable_get(:@property_hash)
       hash[:id] = '74ae9e813b87882d'
-      @resource.provider.instance_variable_set(:@property_hash, hash)
+      resource.provider.instance_variable_set(:@property_hash, hash)
     end
 
     it 'should delete a cluster_member' do
-      expect(@resource.provider).to receive(:sensuctl).with('cluster', 'member-remove', '74ae9e813b87882d')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl).with('cluster', 'member-remove', '74ae9e813b87882d')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_cluster_role/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_cluster_role/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_cluster_role).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_cluster_role)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_cluster_role) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :rules => [{'verbs' => ['get','list'], 'resources' => ['checks'], 'resource_names' => ['']}]
     })
@@ -12,13 +12,13 @@ describe Puppet::Type.type(:sensu_cluster_role).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('cluster-role', false).and_return(JSON.parse(my_fixture_read('cluster_role_list.json')))
-      expect(@provider.instances.length).to eq(6)
+      allow(provider).to receive(:sensuctl_list).with('cluster-role', false).and_return(JSON.parse(my_fixture_read('cluster_role_list.json')))
+      expect(provider.instances.length).to eq(6)
     end
 
     it 'should return the resource for a cluster_role' do
-      allow(@provider).to receive(:sensuctl_list).with('cluster-role', false).and_return(JSON.parse(my_fixture_read('cluster_role_list.json')))
-      property_hash = @provider.instances.select {|i| i.name == 'cluster-admin'}[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('cluster-role', false).and_return(JSON.parse(my_fixture_read('cluster_role_list.json')))
+      property_hash = provider.instances.select {|i| i.name == 'cluster-admin'}[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('cluster-admin')
       expect(property_hash[:rules]).to include({'verbs' => ['*'], 'resources' => ['*'], 'resource_names' => nil})
     end
@@ -32,9 +32,9 @@ describe Puppet::Type.type(:sensu_cluster_role).provider(:sensuctl) do
       expected_spec = {
         :rules => [{'verbs' => ['get','list'], 'resources' => ['checks'], 'resource_names' => ['']}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ClusterRole', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('ClusterRole', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -47,17 +47,17 @@ describe Puppet::Type.type(:sensu_cluster_role).provider(:sensuctl) do
       expected_spec = {
         :rules => [{'verbs' => ['get','list'], 'resources' => ['*'], 'resource_names' => ['']}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ClusterRole', expected_metadata, expected_spec)
-      @resource.provider.rules = [{'verbs' => ['get','list'], 'resources' => ['*'], 'resource_names' => ['']}]
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('ClusterRole', expected_metadata, expected_spec)
+      resource.provider.rules = [{'verbs' => ['get','list'], 'resources' => ['*'], 'resource_names' => ['']}]
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a cluster_role' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('cluster-role', 'test')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('cluster-role', 'test')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_cluster_role_binding/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_cluster_role_binding/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_cluster_role_binding)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_cluster_role_binding) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :role_ref => {'type' => 'ClusterRole', 'name' => 'test-role'},
       :subjects => [{'type' => 'User', 'name' => 'test-user'}],
@@ -13,13 +13,13 @@ describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('cluster-role-binding', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      expect(@provider.instances.length).to eq(3)
+      allow(provider).to receive(:sensuctl_list).with('cluster-role-binding', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      expect(provider.instances.length).to eq(3)
     end
 
     it 'should return the resource for a cluster_role_binding' do
-      allow(@provider).to receive(:sensuctl_list).with('cluster-role-binding', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      property_hash = @provider.instances.select {|i| i.name == 'cluster-admin'}[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('cluster-role-binding', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      property_hash = provider.instances.select {|i| i.name == 'cluster-admin'}[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('cluster-admin')
       expect(property_hash[:role_ref]).to eq({'type' => 'ClusterRole', 'name' => 'cluster-admin'})
     end
@@ -34,9 +34,9 @@ describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
         :role_ref => {'type' => 'ClusterRole', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test-user'}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ClusterRoleBinding', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('ClusterRoleBinding', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -50,17 +50,17 @@ describe Puppet::Type.type(:sensu_cluster_role_binding).provider(:sensuctl) do
         :role_ref => {'type' => 'ClusterRole', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test'}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ClusterRoleBinding', expected_metadata, expected_spec)
-      @resource.provider.subjects = [{'type' => 'User', 'name' => 'test'}]
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('ClusterRoleBinding', expected_metadata, expected_spec)
+      resource.provider.subjects = [{'type' => 'User', 'name' => 'test'}]
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a cluster_role_binding' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('cluster-role-binding', 'test')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('cluster-role-binding', 'test')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_config/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_config/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_config).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_config)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_config) }
+  let(:resource) do
+    type.new({
       :name => 'format',
       :value => 'json',
     })
@@ -12,38 +12,38 @@ describe Puppet::Type.type(:sensu_config).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl).with('config','view','--format','json').and_return(my_fixture_read('config_list.json'))
-      expect(@provider.instances.length).to eq(3)
+      allow(provider).to receive(:sensuctl).with('config','view','--format','json').and_return(my_fixture_read('config_list.json'))
+      expect(provider.instances.length).to eq(3)
     end
 
     it 'should return the resource for a config' do
-      allow(@provider).to receive(:sensuctl).with('config','view','--format','json').and_return(my_fixture_read('config_list.json'))
-      property_hash = @provider.instances.select { |i| i.name == 'format' }[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl).with('config','view','--format','json').and_return(my_fixture_read('config_list.json'))
+      property_hash = provider.instances.select { |i| i.name == 'format' }[0].instance_variable_get("@property_hash")
       expect(property_hash[:value]).to eq('tabular')
     end
   end
 
   describe 'create' do
     it 'should create a config' do
-      expect(@resource.provider).to receive(:sensuctl).with('config', 'set-format', 'json')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl).with('config', 'set-format', 'json')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
 
   describe 'flush' do
     it 'should update a config' do
-      expect(@resource.provider).to receive(:sensuctl).with('config', 'set-format', 'foobar')
-      @resource.provider.value = 'foobar'
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl).with('config', 'set-format', 'foobar')
+      resource.provider.value = 'foobar'
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should not support deleting a config' do
       expect(Puppet).to receive(:warning).with(/sensu_config does not support ensure=absent/)
-      @resource.provider.destroy
+      resource.provider.destroy
     end
   end
 end

--- a/spec/unit/provider/sensu_configure/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_configure/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_configure)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_configure) }
+  let(:resource) do
+    type.new({
       :name => 'puppet',
       :username => 'admin',
       :password => 'foobar',
@@ -14,36 +14,36 @@ describe Puppet::Type.type(:sensu_configure).provider(:sensuctl) do
 
   describe 'create' do
     it 'should run sensuctl configure' do
-      expect(@resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
-      @resource.provider.create
+      expect(resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
+      resource.provider.create
     end
     it 'should run sensuctl configure without SSL' do
-      @resource[:trusted_ca_file] = 'absent'
-      expect(@resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
-      @resource.provider.create
+      resource[:trusted_ca_file] = 'absent'
+      expect(resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
+      resource.provider.create
     end
   end
 
   describe 'flush' do
     it 'should update a configure' do
-      expect(@resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
-      @resource.provider.url = 'https://localhost:8080'
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
+      resource.provider.url = 'https://localhost:8080'
+      resource.provider.flush
     end
     it 'should remove SSL trusted ca' do
-      allow(@resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
-      expect(@resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
+      allow(resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
+      expect(resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       expect(File).to receive(:delete).with('/root/.config/sensu/sensuctl/cluster')
-      @resource.provider.trusted_ca_file = 'absent'
-      @resource.provider.flush
+      resource.provider.trusted_ca_file = 'absent'
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should not support deleting a configure' do
-      allow(@resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
+      allow(resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
       expect(File).to receive(:delete).with('/root/.config/sensu/sensuctl/cluster')
-      @resource.provider.destroy
+      resource.provider.destroy
     end
   end
 end

--- a/spec/unit/provider/sensu_entity/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_entity/sensuctl_spec.rb
@@ -1,27 +1,25 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_entity).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @resource = Puppet::Type.type(:sensu_entity).new({name: 'test'})
-  end
+  let(:provider) { described_class }
+  let(:resource) { Puppet::Type.type(:sensu_entity).new({name: 'test'}) }
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('entity').and_return(JSON.parse(my_fixture_read('entity_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('entity').and_return(JSON.parse(my_fixture_read('entity_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
-    it 'should return the @resource for a entity' do
-      allow(@provider).to receive(:sensuctl_list).with('entity').and_return(JSON.parse(my_fixture_read('entity_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+    it 'should return the resource for a entity' do
+      allow(provider).to receive(:sensuctl_list).with('entity').and_return(JSON.parse(my_fixture_read('entity_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('sensu-backend.example.com in default')
     end
   end
 
   describe 'create' do
     it 'should create a entity' do
-      @resource[:entity_class] = 'proxy'
+      resource[:entity_class] = 'proxy'
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -30,9 +28,9 @@ describe Puppet::Type.type(:sensu_entity).provider(:sensuctl) do
         :entity_class => 'proxy',
         :deregister => false,
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Entity', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('Entity', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -47,17 +45,17 @@ describe Puppet::Type.type(:sensu_entity).provider(:sensuctl) do
       expected_spec = {
         :deregister => false,
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Entity', expected_metadata, expected_spec)
-      @resource.provider.labels = {'foo' => 'bar'}
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('Entity', expected_metadata, expected_spec)
+      resource.provider.labels = {'foo' => 'bar'}
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a entity' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('entity', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('entity', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_filter/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_filter/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_filter).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_filter)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_filter) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :action => 'allow',
       :expressions => ["event.entity.labels.environment == 'production'"],
@@ -13,13 +13,13 @@ describe Puppet::Type.type(:sensu_filter).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('filter').and_return(JSON.parse(my_fixture_read('filter_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('filter').and_return(JSON.parse(my_fixture_read('filter_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a filter' do
-      allow(@provider).to receive(:sensuctl_list).with('filter').and_return(JSON.parse(my_fixture_read('filter_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('filter').and_return(JSON.parse(my_fixture_read('filter_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('production_filter in default')
     end
   end
@@ -34,9 +34,9 @@ describe Puppet::Type.type(:sensu_filter).provider(:sensuctl) do
         :action => :allow,
         :expressions => ["event.entity.labels.environment == 'production'"],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('EventFilter', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('EventFilter', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -51,17 +51,17 @@ describe Puppet::Type.type(:sensu_filter).provider(:sensuctl) do
         :action => 'deny',
         :expressions => ["event.entity.labels.environment == 'production'"],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('EventFilter', expected_metadata, expected_spec)
-      @resource.provider.action = 'deny'
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('EventFilter', expected_metadata, expected_spec)
+      resource.provider.action = 'deny'
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a filter' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('filter', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('filter', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_handler/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_handler/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_handler)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_handler) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :command => 'test',
       :type => 'pipe'
@@ -13,22 +13,22 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('handler').and_return(JSON.parse(my_fixture_read('handler_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('handler').and_return(JSON.parse(my_fixture_read('handler_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a handler' do
-      allow(@provider).to receive(:sensuctl_list).with('handler').and_return(JSON.parse(my_fixture_read('handler_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('handler').and_return(JSON.parse(my_fixture_read('handler_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('tcp_handler in default')
     end
   end
 
   describe 'create' do
     it 'should create a handler' do
-      @resource[:filters] = ["recurrence", "production"]
-      @resource[:socket_host] = "localhost"
-      @resource[:socket_port] = 9000
+      resource[:filters] = ["recurrence", "production"]
+      resource[:socket_host] = "localhost"
+      resource[:socket_port] = 9000
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -39,18 +39,18 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
         :filters => ["recurrence", "production"],
         :socket => {:host => "localhost", :port => 9000}
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
 
   describe 'flush' do
     it 'should update a handler socket' do
-      @resource[:type] = 'tcp'
-      @resource[:socket_host] = "localhost"
-      @resource[:socket_port] = 9000
+      resource[:type] = 'tcp'
+      resource[:socket_host] = "localhost"
+      resource[:socket_port] = 9000
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -60,9 +60,9 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
         :command => 'test',
         :socket => { :host => 'localhost', :port => 9001 }
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
-      @resource.provider.socket_port = 9001
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
+      resource.provider.socket_port = 9001
+      resource.provider.flush
     end
     it 'should remove timeout' do
       expected_metadata = {
@@ -74,10 +74,10 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
         :command => 'test',
         :timeout => nil,
       }
-      @resource[:timeout] = 60
-      expect(@resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
-      @resource.provider.timeout = :absent
-      @resource.provider.flush
+      resource[:timeout] = 60
+      expect(resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
+      resource.provider.timeout = :absent
+      resource.provider.flush
     end
     it 'should remove handlers' do
       expected_metadata = {
@@ -89,18 +89,18 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
         :command => 'test',
         :handlers => nil
       }
-      @resource[:handlers] = ['foo','bar']
-      expect(@resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
-      @resource.provider.handlers = :absent
-      @resource.provider.flush
+      resource[:handlers] = ['foo','bar']
+      expect(resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
+      resource.provider.handlers = :absent
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a handler' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('handler', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('handler', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_hook/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_hook/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_hook).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_hook)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_hook) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :command => 'test',
     })
@@ -12,13 +12,13 @@ describe Puppet::Type.type(:sensu_hook).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('hook').and_return(JSON.parse(my_fixture_read('hook_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('hook').and_return(JSON.parse(my_fixture_read('hook_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a hook' do
-      allow(@provider).to receive(:sensuctl_list).with('hook').and_return(JSON.parse(my_fixture_read('hook_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('hook').and_return(JSON.parse(my_fixture_read('hook_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('process_tree in default')
     end
   end
@@ -34,9 +34,9 @@ describe Puppet::Type.type(:sensu_hook).provider(:sensuctl) do
         :timeout => 60,
         :stdin => false,
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('HookConfig', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('HookConfig', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -52,17 +52,17 @@ describe Puppet::Type.type(:sensu_hook).provider(:sensuctl) do
         :timeout => 120,
         :stdin => false,
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('HookConfig', expected_metadata, expected_spec)
-      @resource.provider.timeout = 120
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('HookConfig', expected_metadata, expected_spec)
+      resource.provider.timeout = 120
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a hook' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('hook', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('hook', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_ldap_auth/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_ldap_auth/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_ldap_auth)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_ldap_auth) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :servers => [{'host' => 'test', 'port' => 389}],
       :server_binding => {'test' => {'user_dn' => 'cn=foo','password' => 'foo'}},
@@ -15,15 +15,15 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
-      allow(@provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
+      allow(provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a auth' do
-      allow(@provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
-      allow(@provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
+      allow(provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('openldap')
     end
   end
@@ -47,9 +47,9 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
           'user_search' => {'base_dn' => 'ou=People','attribute' => 'uid','name_attribute' => 'cn','object_class' => 'person'},
         }]
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should create an auth without binding' do
@@ -69,15 +69,15 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
           'user_search' => {'base_dn' => 'ou=People','attribute' => 'uid','name_attribute' => 'cn','object_class' => 'person'},
         }]
       }
-      @resource = @type.new({
+      resource = type.new({
         :name => 'test',
         :servers => [{'host' => 'test', 'port' => 389}],
         :server_group_search => {'test' => {'base_dn' => 'ou=Groups'}},
         :server_user_search => {'test' => {'base_dn' => 'ou=People'}},
       })
-      expect(@resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -103,17 +103,17 @@ describe Puppet::Type.type(:sensu_ldap_auth).provider(:sensuctl) do
         :groups_prefix => nil,
         :username_prefix => nil,
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.server_binding = {'test' => {'user_dn' => 'cn=foo', 'password' => 'bar'}}
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('ldap', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.server_binding = {'test' => {'user_dn' => 'cn=foo', 'password' => 'bar'}}
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete an auth' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('auth', 'test')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('auth', 'test')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_mutator/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_mutator/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_mutator).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_mutator)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_mutator) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :command => 'test',
     })
@@ -12,13 +12,13 @@ describe Puppet::Type.type(:sensu_mutator).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('mutator').and_return(JSON.parse(my_fixture_read('mutator_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('mutator').and_return(JSON.parse(my_fixture_read('mutator_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a mutator' do
-      allow(@provider).to receive(:sensuctl_list).with('mutator').and_return(JSON.parse(my_fixture_read('mutator_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('mutator').and_return(JSON.parse(my_fixture_read('mutator_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('example-mutator in default')
     end
   end
@@ -32,9 +32,9 @@ describe Puppet::Type.type(:sensu_mutator).provider(:sensuctl) do
       expected_spec = {
         :command => 'test',
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Mutator', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('Mutator', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -49,9 +49,9 @@ describe Puppet::Type.type(:sensu_mutator).provider(:sensuctl) do
         :command => 'test',
         :timeout => 60
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Mutator', expected_metadata, expected_spec)
-      @resource.provider.timeout = 60
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('Mutator', expected_metadata, expected_spec)
+      resource.provider.timeout = 60
+      resource.provider.flush
     end
     it 'should remove timeout' do
       expected_metadata = {
@@ -62,18 +62,18 @@ describe Puppet::Type.type(:sensu_mutator).provider(:sensuctl) do
         :command => 'test',
         :timeout => nil,
       }
-      @resource[:timeout] = 60
-      expect(@resource.provider).to receive(:sensuctl_create).with('Mutator', expected_metadata, expected_spec)
-      @resource.provider.timeout = :absent
-      @resource.provider.flush
+      resource[:timeout] = 60
+      expect(resource.provider).to receive(:sensuctl_create).with('Mutator', expected_metadata, expected_spec)
+      resource.provider.timeout = :absent
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a mutator' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('mutator', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('mutator', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_namespace/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_namespace/sensuctl_spec.rb
@@ -1,23 +1,19 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_namespace).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_namespace)
-    @resource = @type.new({
-      :name => 'test',
-    })
-  end
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_namespace) }
+  let(:resource) { type.new({:name => 'test' }) }
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('namespace', false).and_return(JSON.parse(my_fixture_read('namespace_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('namespace', false).and_return(JSON.parse(my_fixture_read('namespace_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a namespace' do
-      allow(@provider).to receive(:sensuctl_list).with('namespace', false).and_return(JSON.parse(my_fixture_read('namespace_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('namespace', false).and_return(JSON.parse(my_fixture_read('namespace_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('default')
     end
   end
@@ -27,18 +23,18 @@ describe Puppet::Type.type(:sensu_namespace).provider(:sensuctl) do
       expected_spec = {
         :name => 'test',
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Namespace', {}, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('Namespace', {}, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
 
   describe 'destroy' do
     it 'should delete a namespace' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('namespace', 'test')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('namespace', 'test')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_oidc_auth/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_oidc_auth/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_oidc_auth).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_oidc_auth)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_oidc_auth) }
+  let(:resource) do
+    type.new({
       :name => 'oidc',
       :client_id => 'id',
       :client_secret => 'secret',
@@ -14,15 +14,15 @@ describe Puppet::Type.type(:sensu_oidc_auth).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP", "oidc" => "OIDC"})
-      allow(@provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP", "oidc" => "OIDC"})
+      allow(provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a auth' do
-      allow(@provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP", "oidc" => "OIDC"})
-      allow(@provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_auth_types).and_return({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP", "oidc" => "OIDC"})
+      allow(provider).to receive(:sensuctl_list).with('auth', false).and_return(JSON.parse(my_fixture_read('list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('oidc')
     end
   end
@@ -37,9 +37,9 @@ describe Puppet::Type.type(:sensu_oidc_auth).provider(:sensuctl) do
         :client_secret => 'secret',
         :server => 'https://idp.example.com',
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('oidc', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('oidc', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -55,17 +55,17 @@ describe Puppet::Type.type(:sensu_oidc_auth).provider(:sensuctl) do
         :server => 'https://idp.example.com',
         :username_claim => 'email',
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('oidc', expected_metadata, expected_spec, 'authentication/v2')
-      @resource.provider.username_claim = 'email'
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('oidc', expected_metadata, expected_spec, 'authentication/v2')
+      resource.provider.username_claim = 'email'
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete an auth' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('auth', 'oidc')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('auth', 'oidc')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_plugin/sensu_install_spec.rb
+++ b/spec/unit/provider/sensu_plugin/sensu_install_spec.rb
@@ -1,13 +1,13 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_plugin).provider(:sensu_install) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_plugin)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_plugin) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :ensure => 'present',
-      :provider => @provider.name,
+      :provider => provider.name,
     })
     #allow(Puppet::Util).to receive(:which).with('sensu-install').and_return('/bin/sensu-install')
   end
@@ -29,21 +29,21 @@ sensu-plugins-nvidia (1.0.0, 0.0.2, 0.0.1)
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:gem).with('list','--local','^sensu-(plugins|extensions)').and_return(list_local_output)
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:gem).with('list','--local','^sensu-(plugins|extensions)').and_return(list_local_output)
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a plugin' do
-      allow(@provider).to receive(:gem).with('list','--local','^sensu-(plugins|extensions)').and_return(list_local_output)
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:gem).with('list','--local','^sensu-(plugins|extensions)').and_return(list_local_output)
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('disk-plugins')
     end
   end
 
   describe 'self.latest_versions' do
     it 'should return latest versions' do
-      allow(@provider).to receive(:gem).with('search', '--remote', '--all', "^sensu-(plugins|extensions)-").and_return(list_remote_output)
-      latest_versions = @provider.latest_versions
+      allow(provider).to receive(:gem).with('search', '--remote', '--all', "^sensu-(plugins|extensions)-").and_return(list_remote_output)
+      latest_versions = provider.latest_versions
       expect(latest_versions).to eq({'check-dependencies' => '1.1.0', 'nvidia' => '1.0.0'})
     end
   end
@@ -54,78 +54,78 @@ sensu-plugins-nvidia (1.0.0, 0.0.2, 0.0.1)
         '--plugin', 'test',
         '--clean', 
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should install an extension' do
-      @resource[:extension] = :true
+      resource[:extension] = :true
       expected_args = [
         '--extension', 'test',
         '--clean', 
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should install specific version' do
-      @resource[:version] = '1.0.0'
+      resource[:version] = '1.0.0'
       expected_args = [
         '--plugin', 'sensu-plugins-test:1.0.0',
         '--clean', 
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'installs latest version' do
-      @resource[:name] = 'nvidia'
-      @resource[:version] = :latest
-      allow(@provider).to receive(:gem).with('search', '--remote', '--all', "^sensu-(plugins|extensions)-").and_return(list_remote_output)
+      resource[:name] = 'nvidia'
+      resource[:version] = :latest
+      allow(provider).to receive(:gem).with('search', '--remote', '--all', "^sensu-(plugins|extensions)-").and_return(list_remote_output)
       expected_args = [
         '--plugin', 'sensu-plugins-nvidia:1.0.0',
         '--clean', 
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should install a plugin without clean' do
-      @resource[:clean] = :false
+      resource[:clean] = :false
       expected_args = [
         '--plugin', 'test',
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should install a plugin with source' do
-      @resource[:source] = 'http://foo'
+      resource[:source] = 'http://foo'
       expected_args = [
         '--plugin', 'test',
         '--clean',
         '--source', 'http://foo',
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should install a plugin with proxy' do
-      @resource[:proxy] = 'http://foo'
+      resource[:proxy] = 'http://foo'
       expected_args = [
         '--plugin', 'test',
         '--clean',
         '--proxy', 'http://foo',
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -136,9 +136,9 @@ sensu-plugins-nvidia (1.0.0, 0.0.2, 0.0.1)
         '--plugin', 'sensu-plugins-test:1.0.0',
         '--clean', 
       ]
-      expect(@resource.provider).to receive(:sensu_install).with(expected_args)
-      @resource.provider.version = '1.0.0'
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensu_install).with(expected_args)
+      resource.provider.version = '1.0.0'
+      resource.provider.flush
     end
   end
 
@@ -148,32 +148,32 @@ sensu-plugins-nvidia (1.0.0, 0.0.2, 0.0.1)
         'uninstall', 'sensu-plugins-test',
         '--executables', '--all'
       ]
-      expect(@resource.provider).to receive(:gem).with(expected_args)
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:gem).with(expected_args)
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
     it 'should uninstall an extension' do
-      @resource[:extension] = :true
+      resource[:extension] = :true
       expected_args = [
         'uninstall', 'sensu-extensions-test',
         '--executables', '--all'
       ]
-      expect(@resource.provider).to receive(:gem).with(expected_args)
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:gem).with(expected_args)
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
     it 'should uninstall a plugin by version' do
-      @resource[:version] = '1.0.0'
+      resource[:version] = '1.0.0'
       expected_args = [
         'uninstall', 'sensu-plugins-test',
         '--executables',
         '--version', '1.0.0',
       ]
-      expect(@resource.provider).to receive(:gem).with(expected_args)
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:gem).with(expected_args)
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_role/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_role/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_role).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_role)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_role) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :rules => [{'verbs' => ['get','list'], 'resources' => ['checks'], 'resource_names' => ['']}]
     })
@@ -12,13 +12,13 @@ describe Puppet::Type.type(:sensu_role).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('role').and_return(JSON.parse(my_fixture_read('role_list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('role').and_return(JSON.parse(my_fixture_read('role_list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a role' do
-      allow(@provider).to receive(:sensuctl_list).with('role').and_return(JSON.parse(my_fixture_read('role_list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('role').and_return(JSON.parse(my_fixture_read('role_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('prod-admin in default')
       expect(property_hash[:rules]).to include({'verbs' => ['get','list','create','update','delete'], 'resources' => ['*'], 'resource_names' => []})
     end
@@ -33,9 +33,9 @@ describe Puppet::Type.type(:sensu_role).provider(:sensuctl) do
       expected_spec = {
         :rules => [{'verbs' => ['get','list'], 'resources' => ['checks'], 'resource_names' => ['']}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Role', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('Role', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -49,17 +49,17 @@ describe Puppet::Type.type(:sensu_role).provider(:sensuctl) do
       expected_spec = {
         :rules => [{'verbs' => ['get','list'], 'resources' => ['*'], 'resource_names' => ['']}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('Role', expected_metadata, expected_spec)
-      @resource.provider.rules = [{'verbs' => ['get','list'], 'resources' => ['*'], 'resource_names' => ['']}]
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('Role', expected_metadata, expected_spec)
+      resource.provider.rules = [{'verbs' => ['get','list'], 'resources' => ['*'], 'resource_names' => ['']}]
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a role' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('role', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('role', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_role_binding/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_role_binding)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_role_binding) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :role_ref => {'type' => 'Role', 'name' => 'test-role'},
       :subjects => [{'type' => 'User', 'name' => 'test-user'}],
@@ -13,13 +13,13 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('role-binding').and_return(JSON.parse(my_fixture_read('list.json')))
-      expect(@provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('role-binding').and_return(JSON.parse(my_fixture_read('list.json')))
+      expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a role_binding' do
-      allow(@provider).to receive(:sensuctl_list).with('role-binding').and_return(JSON.parse(my_fixture_read('list.json')))
-      property_hash = @provider.instances[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('role-binding').and_return(JSON.parse(my_fixture_read('list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('test in default')
       expect(property_hash[:role_ref]).to eq({'type' => 'Role', 'name' => 'test'})
     end
@@ -35,9 +35,9 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
         :role_ref => {'type' => 'Role', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test-user'}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('RoleBinding', expected_metadata, expected_spec)
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_create).with('RoleBinding', expected_metadata, expected_spec)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
@@ -52,17 +52,17 @@ describe Puppet::Type.type(:sensu_role_binding).provider(:sensuctl) do
         :role_ref => {'type' => 'Role', 'name' => 'test-role'},
         :subjects => [{'type' => 'User', 'name' => 'test'}],
       }
-      expect(@resource.provider).to receive(:sensuctl_create).with('RoleBinding', expected_metadata, expected_spec)
-      @resource.provider.subjects = [{'type' => 'User', 'name' => 'test'}]
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl_create).with('RoleBinding', expected_metadata, expected_spec)
+      resource.provider.subjects = [{'type' => 'User', 'name' => 'test'}]
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a role_binding' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('role-binding', 'test', 'default')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('role-binding', 'test', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensu_user/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_user/sensuctl_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:sensu_user).provider(:sensuctl) do
-  before(:each) do
-    @provider = described_class
-    @type = Puppet::Type.type(:sensu_user)
-    @resource = @type.new({
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_user) }
+  let(:resource) do
+    type.new({
       :name => 'test',
       :password => 'P@ssw0rd!',
       :groups => ['test'],
@@ -13,13 +13,13 @@ describe Puppet::Type.type(:sensu_user).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(@provider).to receive(:sensuctl_list).with('user', false).and_return(JSON.parse(my_fixture_read('user_list.json')))
-      expect(@provider.instances.length).to eq(2)
+      allow(provider).to receive(:sensuctl_list).with('user', false).and_return(JSON.parse(my_fixture_read('user_list.json')))
+      expect(provider.instances.length).to eq(2)
     end
 
     it 'should return the resource for a user' do
-      allow(@provider).to receive(:sensuctl_list).with('user', false).and_return(JSON.parse(my_fixture_read('user_list.json')))
-      property_hash = @provider.instances.select {|i| i.name == 'admin'}[0].instance_variable_get("@property_hash")
+      allow(provider).to receive(:sensuctl_list).with('user', false).and_return(JSON.parse(my_fixture_read('user_list.json')))
+      property_hash = provider.instances.select {|i| i.name == 'admin'}[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('admin')
       expect(property_hash[:groups]).to eq(['cluster-admins'])
     end
@@ -27,83 +27,83 @@ describe Puppet::Type.type(:sensu_user).provider(:sensuctl) do
 
   describe 'create' do
     it 'should create a user' do
-      expect(@resource.provider).to receive(:sensuctl).with(['user', 'create', 'test', '--password', 'P@ssw0rd!', '--groups', 'test'])
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl).with(['user', 'create', 'test', '--password', 'P@ssw0rd!', '--groups', 'test'])
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
     it 'should create user and reconfigure sensuctl' do
-      @resource[:configure] = true
-      expect(@resource.provider).to receive(:sensuctl).with(['user', 'create', 'test', '--password', 'P@ssw0rd!', '--groups', 'test'])
-      expect(@resource.provider).to receive(:sensuctl).with('configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','P@ssw0rd!')
-      @resource.provider.create
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      resource[:configure] = true
+      expect(resource.provider).to receive(:sensuctl).with(['user', 'create', 'test', '--password', 'P@ssw0rd!', '--groups', 'test'])
+      expect(resource.provider).to receive(:sensuctl).with('configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','P@ssw0rd!')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
     end
   end
 
   describe 'flush' do
     before(:each) do
-      hash = @resource.provider.instance_variable_get(:@property_hash)
+      hash = resource.provider.instance_variable_get(:@property_hash)
       hash[:groups] = ['admin']
-      @resource.provider.instance_variable_set(:@property_hash, hash)
+      resource.provider.instance_variable_set(:@property_hash, hash)
     end
 
     it 'should update a user password' do
-      @resource[:old_password] = 'foo'
-      expect(@resource.provider).to receive(:password_insync?).with('test', 'foo').and_return(true)
-      expect(@resource.provider).to receive(:sensuctl).with('user', 'change-password', 'test', '--current-password', 'foo', '--new-password', 'foobar')
-      @resource.provider.password = 'foobar'
-      @resource.provider.flush
+      resource[:old_password] = 'foo'
+      expect(resource.provider).to receive(:password_insync?).with('test', 'foo').and_return(true)
+      expect(resource.provider).to receive(:sensuctl).with('user', 'change-password', 'test', '--current-password', 'foo', '--new-password', 'foobar')
+      resource.provider.password = 'foobar'
+      resource.provider.flush
     end
     it 'should update a user password and reconfigure' do
-      @resource[:configure] = true
-      @resource[:old_password] = 'foo'
-      expect(@resource.provider).to receive(:password_insync?).with('test', 'foo').and_return(true)
-      expect(@resource.provider).to receive(:sensuctl).with('user', 'change-password', 'test', '--current-password', 'foo', '--new-password', 'foobar')
-      expect(@resource.provider).to receive(:sensuctl).with('configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','foobar')
-      @resource.provider.password = 'foobar'
-      @resource.provider.flush
+      resource[:configure] = true
+      resource[:old_password] = 'foo'
+      expect(resource.provider).to receive(:password_insync?).with('test', 'foo').and_return(true)
+      expect(resource.provider).to receive(:sensuctl).with('user', 'change-password', 'test', '--current-password', 'foo', '--new-password', 'foobar')
+      expect(resource.provider).to receive(:sensuctl).with('configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','foobar')
+      resource.provider.password = 'foobar'
+      resource.provider.flush
     end
     it 'should require old_password to update a user password' do
-      @resource.provider.password = 'foobar'
-      expect { @resource.provider.flush }.to raise_error(Puppet::Error, /old_password is manditory when changing a password/)
+      resource.provider.password = 'foobar'
+      expect { resource.provider.flush }.to raise_error(Puppet::Error, /old_password is manditory when changing a password/)
     end
     it 'should fail if old_password is invalid' do
-      @resource[:old_password] = 'foo'
-      @resource.provider.password = 'foobar'
-      expect(@resource.provider).to receive(:password_insync?).with('test', 'foo').and_return(false)
-      expect { @resource.provider.flush }.to raise_error(Puppet::Error, /old_password given for test is incorrect/)
+      resource[:old_password] = 'foo'
+      resource.provider.password = 'foobar'
+      expect(resource.provider).to receive(:password_insync?).with('test', 'foo').and_return(false)
+      expect { resource.provider.flush }.to raise_error(Puppet::Error, /old_password given for test is incorrect/)
     end
     it 'should add missing groups' do
-      expect(@resource.provider).to receive(:sensuctl).with('user','add-group','test','test')
-      @resource.provider.groups = ['admin','test']
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl).with('user','add-group','test','test')
+      resource.provider.groups = ['admin','test']
+      resource.provider.flush
     end
     it 'should remove groups' do
-      expect(@resource.provider).to receive(:sensuctl).with('user','remove-group','test','admin')
-      @resource.provider.groups = []
-      @resource.provider.flush
+      expect(resource.provider).to receive(:sensuctl).with('user','remove-group','test','admin')
+      resource.provider.groups = []
+      resource.provider.flush
     end
     it 'should disable a user' do
-      @resource[:disabled] = false
-      expect(@resource.provider).to receive(:sensuctl).with('user','disable','test','--skip-confirm')
-      @resource.provider.disabled = true
-      @resource.provider.flush
+      resource[:disabled] = false
+      expect(resource.provider).to receive(:sensuctl).with('user','disable','test','--skip-confirm')
+      resource.provider.disabled = true
+      resource.provider.flush
     end
     it 'should disable a user' do
-      @resource[:disabled] = true
-      expect(@resource.provider).to receive(:sensuctl).with('user','reinstate','test')
-      @resource.provider.disabled = false
-      @resource.provider.flush
+      resource[:disabled] = true
+      expect(resource.provider).to receive(:sensuctl).with('user','reinstate','test')
+      resource.provider.disabled = false
+      resource.provider.flush
     end
   end
 
   describe 'destroy' do
     it 'should delete a user' do
-      expect(@resource.provider).to receive(:sensuctl_delete).with('user', 'test')
-      @resource.provider.destroy
-      property_hash = @resource.provider.instance_variable_get("@property_hash")
+      expect(resource.provider).to receive(:sensuctl_delete).with('user', 'test')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash).to eq({})
     end
   end

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -43,44 +43,44 @@ describe Puppet::Provider::Sensuctl do
   end
 
   context 'sensuctl_create' do
+    let(:tmp) { Tempfile.new() }
     before(:each) do
-      @tmp = Tempfile.new()
-      allow(Tempfile).to receive(:new).with('sensuctl').and_return(@tmp)
-      allow(subject).to receive(:sensuctl).with(['create','--file',@tmp.path])
+      allow(Tempfile).to receive(:new).with('sensuctl').and_return(tmp)
+      allow(subject).to receive(:sensuctl).with(['create','--file',tmp.path])
     end
 
     it 'should have JSON with type' do
       subject.sensuctl_create('Test', {name: 'test'}, {foo: 'bar'})
-      j = JSON.parse(File.read(@tmp.path))
+      j = JSON.parse(File.read(tmp.path))
       expect(j['type']).to eq('Test')
     end
 
     it 'should have JSON with api_version' do
       subject.sensuctl_create('Test', {name: 'test'}, {foo: 'bar'})
-      j = JSON.parse(File.read(@tmp.path))
+      j = JSON.parse(File.read(tmp.path))
       expect(j['api_version']).to eq('core/v2')
     end
 
     it 'should have JSON with metadata' do
       subject.sensuctl_create('Test', {name: 'test'}, {foo: 'bar'})
-      j = JSON.parse(File.read(@tmp.path))
+      j = JSON.parse(File.read(tmp.path))
       expect(j['metadata']).to eq('name' => 'test')
     end
 
     it 'should have JSON with spec' do
       subject.sensuctl_create('Test', {name: 'test'}, {foo: 'bar'})
-      j = JSON.parse(File.read(@tmp.path))
+      j = JSON.parse(File.read(tmp.path))
       expect(j['spec']).to eq({'foo' => 'bar'})
     end
 
     it 'should have JSON with only valid keys' do
       subject.sensuctl_create('Test', {name: 'test'}, {foo: 'bar'})
-      j = JSON.parse(File.read(@tmp.path))
+      j = JSON.parse(File.read(tmp.path))
       expect(j.keys).to eq(['type','api_version','metadata','spec'])
     end
 
     it 'should create a resource' do
-      expect(subject).to receive(:sensuctl).with(['create','--file',@tmp.path])
+      expect(subject).to receive(:sensuctl).with(['create','--file',tmp.path])
       subject.sensuctl_create('Test', {name: 'test'}, {foo: 'bar'})
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace use of instance variables with `let` for unit tests. This is a better practice and something a tool like rubocop for rspec would have pointed out.

I opted to not modify the files for sensu_event and sensu_silenced to avoid conflicts with #1141. This will likely conflict with #1142 and #1140 