### PR TITLE
Fix sensu_asset to work with Sensu Go >= 5.13

### DIFF
--- a/lib/puppet/provider/sensu_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_asset/sensuctl.rb
@@ -10,7 +10,18 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
 
     data = sensuctl_list('asset')
 
+    asset_names = {}
+
     data.each do |d|
+      name = d['metadata']['name']
+      namespace = d['metadata']['namespace']
+      if ! asset_names.key?(name)
+        asset_names[name] = namespace
+      end
+    end
+
+    asset_names.each_pair do |name, namespace|
+      d = sensuctl_info('asset', name, namespace)
       asset = {}
       asset[:ensure] = :present
       asset[:resource_name] = d['metadata']['name']

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -103,6 +103,31 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
     self.class.sensuctl_delete(*args)
   end
 
+  def self.sensuctl_info(command, name, namespace = nil)
+    args = [command]
+    args << 'info'
+    args << name
+    args << '--format'
+    args << 'json'
+    if namespace
+      args << '--namespace'
+      args << namespace
+    end
+    output = sensuctl(args)
+    Puppet.debug("sensuctl #{args.join(' ')}: #{output}")
+    begin
+      data = JSON.parse(output)
+    rescue JSON::ParserError => e
+      Puppet.debug("Unable to parse output from sensuctl #{args.join(' ')}")
+      return {}
+    end
+    return {} if data.nil?
+    data
+  end
+  def sensuctl_info(*args)
+    self.class.sensuctl_info(*args)
+  end
+
   def self.sensuctl_auth_types()
     output = sensuctl(['auth','list','--format','yaml'])
     Puppet.debug("YAML auth list: #{output}")

--- a/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset1_info.json
+++ b/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset1_info.json
@@ -1,0 +1,55 @@
+{
+  "filters": null,
+  "builds": [
+    {
+      "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
+      "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+      "filters": [
+        "entity.system.os == 'linux'",
+        "entity.system.arch == 'amd64'"
+      ],
+      "headers": {
+        "Authorization": "Bearer $TOKEN",
+        "X-Forwarded-For": "client1, proxy1, proxy2"
+      }
+    },
+    {
+      "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz",
+      "sha512": "70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b",
+      "filters": [
+        "entity.system.os == 'linux'",
+        "entity.system.arch == 'arm'",
+        "entity.system.arm_version == 7"
+      ],
+      "headers": {
+        "Authorization": "Bearer $TOKEN",
+        "X-Forwarded-For": "client1, proxy1, proxy2"
+      }
+    },
+    {
+      "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz",
+      "sha512": "10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f",
+      "filters": [
+        "entity.system.os == 'windows'",
+        "entity.system.arch == 'amd64'"
+      ],
+      "headers": {
+        "Authorization": "Bearer $TOKEN",
+        "X-Forwarded-For": "client1, proxy1, proxy2"
+      }
+    }
+  ],
+  "metadata": {
+    "name": "check_cpu",
+    "namespace": "default",
+    "labels": {
+      "origin": "bonsai"
+    },
+    "annotations": {
+      "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+      "version": "0.0.3"
+    }
+  },
+  "headers": null
+}
+

--- a/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset2_info.json
+++ b/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset2_info.json
@@ -1,0 +1,25 @@
+{
+  "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
+  "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+  "filters": [
+    "entity.system.os == 'linux'",
+    "entity.system.arch == 'amd64'"
+  ],
+  "builds": null,
+  "metadata": {
+    "name": "check_cpu_linux_amd64",
+    "namespace": "default",
+    "labels": {
+      "origin": "bonsai"
+    },
+    "annotations": {
+      "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+      "version": "0.0.3"
+    }
+  },
+  "headers": {
+    "Authorization": "Bearer $TOKEN",
+    "X-Forwarded-For": "client1, proxy1, proxy2"
+  }
+}
+

--- a/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset_list.json
+++ b/spec/fixtures/unit/provider/sensu_asset/sensuctl/asset_list.json
@@ -1,17 +1,100 @@
 [
   {
-    "url": "https://github.com/cyphus/test-asset-host/releases/download/0.0.1/check-cpu-sh.tgz",
-    "sha512": "58a4d415f82ac9750ecf92d25a6b782393e00461d66c287e6eca56bb1d1789d78de5d04477ff1994d989916f39d290ef67f3bdeab9299a6fb94c9d6df95fe36b",
-    "filters": null,
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
+    "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
     "headers": {
       "Authorization": "Bearer $TOKEN",
       "X-Forwarded-For": "client1, proxy1, proxy2"
-    },
+    }
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz",
+    "sha512": "70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'arm'",
+      "entity.system.arm_version == 7"
+    ],
+    "builds": null,
     "metadata": {
-      "name": "check-cpu.sh",
+      "name": "check_cpu",
       "namespace": "default",
-      "labels": null,
-      "annotations": null
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz",
+    "sha512": "10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f",
+    "filters": [
+      "entity.system.os == 'windows'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
+    "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "check_cpu_linux_amd64",
+      "namespace": "default",
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
     }
   }
 ]
+

--- a/spec/unit/provider/sensu_asset/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_asset/sensuctl_spec.rb
@@ -12,15 +12,30 @@ describe Puppet::Type.type(:sensu_asset).provider(:sensuctl) do
   end
 
   describe 'self.instances' do
+    let(:fixture) do
+      JSON.parse(my_fixture_read('asset_list.json'))
+    end
+    let(:asset1) do
+      JSON.parse(my_fixture_read('asset1_info.json'))
+    end
+    let(:asset2) do
+      JSON.parse(my_fixture_read('asset2_info.json'))
+    end
+
     it 'should create instances' do
-      allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
-      expect(provider.instances.length).to eq(1)
+      allow(provider).to receive(:sensuctl_list).with('asset').and_return(fixture)
+      allow(provider).to receive(:sensuctl_info).with('asset','check_cpu','default').and_return(asset1)
+      allow(provider).to receive(:sensuctl_info).with('asset','check_cpu_linux_amd64','default').and_return(asset2)
+      expect(provider.instances.length).to eq(2)
     end
 
     it 'should return the resource for a asset' do
-      allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
+      allow(provider).to receive(:sensuctl_list).with('asset').and_return(fixture)
+      allow(provider).to receive(:sensuctl_info).with('asset','check_cpu','default').and_return(asset1)
+      allow(provider).to receive(:sensuctl_info).with('asset','check_cpu_linux_amd64','default').and_return(asset2)
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
-      expect(property_hash[:name]).to eq('check-cpu.sh in default')
+      expect(property_hash[:name]).to eq('check_cpu in default')
+      expect(property_hash[:builds].size).to eq(3)
     end
   end
 

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -93,6 +93,14 @@ describe Puppet::Provider::Sensuctl do
     end
   end
 
+  context 'sensuctl_info' do
+    it 'should get info for a resource' do
+      expected_args = ['check','info','test','--format','json','--namespace','default']
+      expect(subject).to receive(:sensuctl).with(expected_args).and_return("{}\n")
+      subject.sensuctl_info('check', 'test', 'default')
+    end
+  end
+
   context 'sensuctl_auth_types' do
     it 'should return auth and their types' do
       allow(subject).to receive(:sensuctl).with(['auth','list','--format','yaml']).and_return(my_fixture_read('auths.txt'))


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Change how assets are queried to list all assets then use the `info` subcommand to get information about each asset.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #1145 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It seems in Sensu Go 5.13 a change was made so that assets defined using the `builds` property do not show the builds property with `list` but rather show multiple assets. The only way to see the actual properties value is using `info` subcommand.