### PR TITLE
Fix sensu_plugin version insync? check

### DIFF
--- a/lib/puppet/type/sensu_plugin.rb
+++ b/lib/puppet/type/sensu_plugin.rb
@@ -43,14 +43,17 @@ DESC
     desc "Specific version to install, or latest"
     newvalues(:latest, /[0-9\.]+/)
     def insync?(is)
-      @should.each do |should|
-        if should == :latest || should == 'latest'
-          latest_versions = provider.class.latest_versions
-          @latest = latest_versions[@resource.name]
-          return is == @latest
-        else
-          super
-        end
+      if @should.is_a?(Array)
+        should = @should[0]
+      else
+        should = @should
+      end
+      if should == :latest || should == 'latest'
+        latest_versions = provider.class.latest_versions
+        @latest = latest_versions[@resource.name]
+        return is == @latest
+      else
+        super(is)
       end
     end
     def should_to_s(newvalue)

--- a/spec/acceptance/sensu_plugin_spec.rb
+++ b/spec/acceptance/sensu_plugin_spec.rb
@@ -70,6 +70,68 @@ describe 'sensu_plugin', if: RSpec.configuration.sensu_full do
     end
   end
 
+  context 'downgrade plugin' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::agent
+      include ::sensu::plugins
+      sensu_plugin { 'cpu-checks':
+        ensure  => 'present',
+        version => '2.0.0',
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_agent' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on agent, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on agent, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(agent, pp, :catch_failures => true)
+        apply_manifest_on(agent, pp, :catch_changes  => true)
+      end
+    end
+
+    it 'should have plugin installed' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^sensu-plugins-cpu-checks \(2.0.0\)/)
+      end
+    end
+  end
+
+  context 'upgrade plugin' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::agent
+      include ::sensu::plugins
+      sensu_plugin { 'cpu-checks':
+        ensure  => 'present',
+        version => '3.0.0',
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_agent' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on agent, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on agent, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(agent, pp, :catch_failures => true)
+        apply_manifest_on(agent, pp, :catch_changes  => true)
+      end
+    end
+
+    it 'should have plugin installed' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^sensu-plugins-cpu-checks \(3.0.0\)/)
+      end
+    end
+  end
+
   context 'uninstall plugin' do
     it 'should work without errors' do
       pp = <<-EOS

--- a/spec/unit/sensu_plugin_spec.rb
+++ b/spec/unit/sensu_plugin_spec.rb
@@ -186,6 +186,28 @@ describe Puppet::Type.type(:sensu_plugin) do
       config[:version] = 'foo'
       expect { plugin }.to raise_error(Puppet::Error, /Invalid value/)
     end
+    it 'should be in sync' do
+      config[:version] = '1.0.0'
+      expect(plugin.property(:version).insync?('1.0.0')).to eq(true)
+    end
+    it 'should not be in sync' do
+      config[:version] = '1.1.0'
+      expect(plugin.property(:version).insync?('1.0.0')).to eq(false)
+      expect(plugin.property(:version).should_to_s('1.1.0')).to eq("'1.1.0'")
+    end
+    it 'should be in sync with latest' do
+      config[:provider] = 'sensu_install'
+      allow(Puppet::Type::Sensu_plugin::ProviderSensu_install).to receive(:latest_versions).and_return({config[:name] => '1.1.0', 'foo' => '1.2.0'})
+      config[:version] = 'latest'
+      expect(plugin.property(:version).insync?('1.1.0')).to eq(true)
+    end
+    it 'should not be in sync with latest' do
+      config[:provider] = 'sensu_install'
+      allow(Puppet::Type::Sensu_plugin::ProviderSensu_install).to receive(:latest_versions).and_return({config[:name] => '1.1.0', 'foo' => '1.2.0'})
+      config[:version] = 'latest'
+      expect(plugin.property(:version).insync?('1.0.0')).to eq(false)
+      expect(plugin.property(:version).should_to_s('latest')).to eq("'1.1.0'")
+    end
   end
 
   it 'should autorequire sensu-plugins-ruby' do


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The previous logic of `insync?` for `sensu_plugin` version property was not capable of upgrades or downgrades when the new value for `version` was something other than `latest`.

I ran the acceptance tests with new changes but not updating `insync?` and the upgrade and downgrade tests failed because nothing actually happened.