### PR TITLE
Add sensu_bonsai_asset type

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
         * [Adding backend members to an existing cluster](#adding-backend-members-to-an-existing-cluster)
     * [Large Environment Considerations](#large-environment-considerations)
     * [Composite Names for Namespaces](#composite-names-for-namespaces)
+    * [Installing Bonsai Assets](#installing-bonsai-assets)
 4. [Reference](#reference)
     * [Facts](#facts)
 5. [Limitations - OS compatibility, etc.](#limitations)
@@ -547,6 +548,32 @@ sensu_check { 'check-cpu in team1':
 The example above would add the `check-cpu` check to both the `default` and `team1` namespaces.
 
 **NOTE:** If you use composite names for namespaces, the `namespace` property takes precedence.
+
+### Installing Bonsai Assets
+Install a bonsai asset. The latest version will be installed but not automatically upgraded.
+
+```puppet
+sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+  ensure  => 'present',
+}
+```
+
+Install specific version of a bonsai asset.
+
+```puppet
+sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+  ensure  => 'present',
+  version => '1.2.0',
+}
+```
+
+Install latest version of a bonsai asset. Puppet will update the Bonsai asset if a new version is released.
+```puppet
+sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+  ensure  => 'present',
+  version => 'latest',
+}
+```
 
 ## Reference
 

--- a/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
@@ -1,0 +1,143 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sensuctl'))
+
+Puppet::Type.type(:sensu_bonsai_asset).provide(:sensuctl, :parent => Puppet::Provider::Sensuctl) do
+  desc "Provider sensu_bonsai_asset using sensuctl"
+
+  mk_resource_methods
+
+  def self.instances
+    assets = []
+
+    data = sensuctl_list('asset')
+    found_assets = []
+
+    data.each do |d|
+      asset = {}
+      asset[:ensure] = :present
+      asset[:bonsai_namespace] = d['metadata'].dig('annotations', 'io.sensu.bonsai.namespace')
+      asset[:bonsai_name] = d['metadata'].dig('annotations', 'io.sensu.bonsai.name')
+      asset[:version] = d['metadata'].dig('annotations', 'io.sensu.bonsai.version')
+      if asset[:bonsai_namespace].nil? || asset[:bonsai_name].nil?
+        Puppet.debug("Asset #{d['metadata']['name']} from bonsai.sensu.io lacks bonsai annotations")
+        next
+      end
+      asset[:rename] = d['metadata']['name']
+      if found_assets.include?(asset[:rename])
+        next
+      end
+      found_assets << asset[:rename]
+      asset[:namespace] = d['metadata']['namespace']
+      asset[:name] = "#{asset[:bonsai_namespace]}/#{asset[:bonsai_name]} in #{asset[:namespace]}"
+      assets << new(asset)
+    end
+    assets
+  end
+
+  def self.prefetch(resources)
+    assets = instances
+    resources.keys.each do |name|
+      if provider = assets.find { |c| c.rename == resources[name][:rename] && c.namespace == resources[name][:namespace] }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def self.latest_version(namespace, name)
+    return @latest_version if @latest_version
+    @latest_version = nil
+    return nil if namespace.nil? || name.nil?
+    versions = []
+    bonsai_asset = self.get_bonsai_asset("#{namespace}/#{name}")
+    (bonsai_asset['versions'] || []).each do |bonsai_version|
+      version = bonsai_version['version']
+      next unless version =~ /^[0-9]/
+      versions << version
+    end
+    versions = versions.sort_by { |v| Gem::Version.new(v) }
+    @latest_version = versions.last
+    @latest_version
+  end
+
+  def self.get_bonsai_asset(name)
+    data = {}
+    url = "https://bonsai.sensu.io/api/v1/assets/#{name}"
+    uri = URI(url)
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl = true
+    #http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    request = Net::HTTP::Get.new(uri.path)
+    request.add_field("Accept", "application/json")
+    Puppet.debug("GET: #{url}")
+    response = http.request(request)
+    if valid_json?(response.body)
+      data = JSON.parse(response.body)
+      Puppet.debug("BODY: #{JSON.pretty_generate(data)}")
+    else
+      Puppet.debug("BODY: Not valid JSON")
+    end
+    unless response.kind_of?(Net::HTTPSuccess)
+      Puppet.notice "Unable to connect to bonsai at #{url}"
+      return {}
+    end
+  rescue Exception => e
+    Puppet.notice "Unable to connect to bonsai at #{url}: #{e.message}"
+    return {}
+  else
+    return data
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  type_properties.each do |prop|
+    define_method "#{prop}=".to_sym do |value|
+      @property_flush[prop] = value
+    end
+  end
+
+  def asset_add(version)
+    cmd = ['asset', 'add']
+    name = "#{resource[:bonsai_namespace]}/#{resource[:bonsai_name]}"
+    if version && version.to_s != 'latest'
+      name = "#{name}:#{version}"
+    end
+    cmd << name
+    cmd << '--rename'
+    cmd << resource[:rename]
+    cmd << '--namespace'
+    cmd << resource[:namespace]
+    begin
+      sensuctl(cmd)
+    rescue Exception => e
+      raise Puppet::Error, "#{cmd.join(' ')} failed\nError message: #{e.message}"
+    end
+  end
+
+  def create
+    asset_add(resource[:version])
+    @property_hash[:ensure] = :present
+  end
+
+  def flush
+    if !@property_flush.empty?
+      asset_add(@property_flush[:version])
+    end
+    @property_hash = resource.to_hash
+  end
+
+  def destroy
+    begin
+      sensuctl_delete('asset', resource[:rename], resource[:namespace])
+    rescue Exception => e
+      raise Puppet::Error, "sensuctl delete asset #{resource[:name]} failed\nError message: #{e.message}"
+    end
+    @property_hash.clear
+  end
+end
+

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -132,5 +132,15 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
   def namespaces()
     self.class.namespaces()
   end
+
+  def self.valid_json?(json)
+    JSON.parse(json)
+    return true
+  rescue JSON::ParseError => e
+    return false
+  end
+  def valid_json?(json)
+    self.class.valid_json?(json)
+  end
 end
 

--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -79,7 +79,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the asset."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ /^[\w\.\-\/]+$/
         raise ArgumentError, "sensu_asset name invalid"
       end
     end
@@ -163,6 +163,11 @@ DESC
     desc "Arbitrary, non-identifying metadata to include with event data."
   end
 
+  newparam(:bonsai, :boolean => true) do
+    desc "Private property used by sensu_bonsai_asset type"
+    newvalues(:true, :false)
+  end
+
   def self.title_patterns
     [
       [
@@ -183,6 +188,10 @@ DESC
   end
 
   def pre_run_check
+    # Do not validate bonsai assets
+    if self[:bonsai]
+      return
+    end
     if ! self[:builds]
       required_properties = [
         :url,

--- a/lib/puppet/type/sensu_bonsai_asset.rb
+++ b/lib/puppet/type/sensu_bonsai_asset.rb
@@ -1,0 +1,144 @@
+require_relative '../../puppet_x/sensu/type'
+require_relative '../../puppet_x/sensu/array_property'
+require_relative '../../puppet_x/sensu/hash_property'
+require_relative '../../puppet_x/sensu/integer_property'
+
+Puppet::Type.newtype(:sensu_bonsai_asset) do
+  desc <<-DESC
+@summary Manages Sensu Bonsai assets
+@example Install a bonsai asset
+  sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+    ensure  => 'present',
+  }
+
+@example Install specific version of a bonsai asset
+  sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+    ensure  => 'present',
+    version => '1.2.0',
+  }
+
+@example Install latest version of a bonsai asset
+  sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+    ensure  => 'present',
+    version => 'latest',
+  }
+
+**Autorequires**:
+* `Package[sensu-go-cli]`
+* `Service[sensu-backend]`
+* `Sensu_configure[puppet]`
+* `Sensu_api_validator[sensu]`
+* `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
+DESC
+
+  extend PuppetX::Sensu::Type
+  add_autorequires()
+
+  ensurable do
+    desc "Bonsai asset state for Sensu Go asset"
+    self.defaultvalues
+    defaultto(:present)
+  end
+    
+  newparam(:name, :namevar => true) do
+    desc "Bonsai asset name"
+  end
+
+  newparam(:bonsai_namespace, :namevar => true) do
+    desc "Bonsai asset namespace"
+  end
+
+  newparam(:bonsai_name, :namevar => true) do
+    desc "Bonsai asset name"
+  end
+
+  newproperty(:version) do
+    desc "Specific version to install, or latest"
+    newvalues(:latest, /[0-9\.]+/)
+    def insync?(is)
+      if @should.is_a?(Array) && @should.size == 1
+        should = @should[0]
+      else
+        should = @should
+      end
+      if should == :latest || should == 'latest'
+        latest_version = provider.class.latest_version(@resource[:bonsai_namespace], @resource[:bonsai_name])
+        @latest = latest_version
+        return is == @latest
+      else
+        super(is)
+      end
+    end
+    def should_to_s(newvalue)
+      if @latest
+        super(@latest)
+      else
+        super(newvalue)
+      end
+    end
+  end
+
+  newparam(:namespace, :namevar => true) do
+    desc "The Sensu RBAC namespace that this asset belongs to."
+    defaultto 'default'
+  end
+
+  newparam(:rename) do
+    desc "Name for Sensu Go asset"
+    defaultto do
+      @resource[:name]
+    end
+  end
+
+  # Generate sensu_asset resource to avoid resource purging deleting
+  # sensu_bonsai_asset resources
+  def generate
+    asset_opts = {}
+    asset_opts[:ensure] = self[:ensure]
+    asset_opts[:name] = "#{self[:rename]} in #{self[:namespace]}"
+    asset_opts[:require] = "Sensu_bonsai_asset[#{self[:name]}]"
+    asset_opts[:bonsai] = true
+    asset = Puppet::Type.type(:sensu_asset).new(asset_opts)
+    [asset]
+  end
+
+  def self.title_patterns
+    [
+      [
+        /^((\S+)\/(\S+) in (\S+))$/,
+        [
+          [:name],
+          [:bonsai_namespace],
+          [:bonsai_name],
+          [:namespace],
+        ],
+      ],
+      [
+        /^((\S+)\/(\S+))$/,
+        [
+          [:name],
+          [:bonsai_namespace],
+          [:bonsai_name],
+        ],
+      ],
+      [
+        /(.*)/,
+        [
+          [:name],
+        ],
+      ],
+    ]
+  end
+
+  validate do
+    if self[:name] !~ /^(\S+)\/(\S+)$/
+      if self[:bonsai_namespace].nil? || self[:bonsai_name].nil?
+        fail("Sensu_bonsai_asset[#{self[:name]}] needs to be '<bonsai_namespace>/<bonsai_name>' or bonsai_namespace and bonsai_name properties defined")
+      end
+    end
+  end
+
+  def pre_run_check
+    PuppetX::Sensu::Type.validate_namespace(self)
+  end
+end

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -59,6 +59,8 @@
 #   Hash of sensu_ad_auth resources
 # @param assets
 #   Hash of sensu_asset resources
+# @param bonsai_assets
+#   Hash of sensu_bonsai_asset resources
 # @param checks
 #   Hash of sensu_check resources
 # @param cluster_members
@@ -144,6 +146,7 @@ class sensu::backend (
   Enum['present','absent'] $tessen_ensure = 'present',
   Hash $ad_auths = {},
   Hash $assets = {},
+  Hash $bonsai_assets = {},
   Hash $checks = {},
   Hash $cluster_members = {},
   Hash $cluster_role_bindings = {},

--- a/manifests/backend/resources.pp
+++ b/manifests/backend/resources.pp
@@ -13,6 +13,11 @@ class sensu::backend::resources {
       * => $asset,
     }
   }
+  $::sensu::backend::bonsai_assets.each |$name, $bonsai_asset| {
+    sensu_bonsai_asset { $name:
+      * => $bonsai_asset,
+    }
+  }
   $::sensu::backend::checks.each |$name, $check| {
     sensu_check { $name:
       * => $check,

--- a/spec/acceptance/sensu_bonsai_asset.rb
+++ b/spec/acceptance/sensu_bonsai_asset.rb
@@ -1,0 +1,194 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
+  node = hosts_as('sensu_backend')[0]
+  context 'install bonsai asset' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+        ensure  => 'present',
+        version => '1.1.0',
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    it 'should have bonsai asset' do
+      on node, 'sensuctl asset info sensu/sensu-pagerduty-handler --format json' do
+        data = JSON.parse(stdout)
+        version = data['metadata']['annotations']['io.sensu.bonsai.version']
+        expect(version).to eq('1.1.0')
+      end
+    end
+  end
+
+  context 'install bonsai asset - latest' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+        ensure  => 'present',
+        version => 'latest',
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    it 'should have bonsai asset' do
+      on node, 'sensuctl asset info sensu/sensu-pagerduty-handler --format json' do
+        data = JSON.parse(stdout)
+        version = data['metadata']['annotations']['io.sensu.bonsai.version']
+        upgraded = (Gem::Version.new(version) > Gem::Version.new('1.1.0'))
+        expect(version).not_to eq('1.1.0')
+        expect(upgraded).to eq(true)
+      end
+    end
+  end
+
+  context 'downgrade bonsai asset' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+        ensure  => 'present',
+        version => '1.1.0',
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    it 'should have bonsai asset' do
+      on node, 'sensuctl asset info sensu/sensu-pagerduty-handler --format json' do
+        data = JSON.parse(stdout)
+        version = data['metadata']['annotations']['io.sensu.bonsai.version']
+        expect(version).to eq('1.1.0')
+      end
+    end
+  end
+
+  context 'upgrade bonsai asset' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+        ensure  => 'present',
+        version => '1.2.0',
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    it 'should have bonsai asset' do
+      on node, 'sensuctl asset info sensu/sensu-pagerduty-handler --format json' do
+        data = JSON.parse(stdout)
+        version = data['metadata']['annotations']['io.sensu.bonsai.version']
+        expect(version).to eq('1.2.0')
+      end
+    end
+  end
+
+  context 'asset purging' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+        ensure  => 'present',
+        version => '1.2.0',
+      }
+      resources { 'sensu_asset': purge => true }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    it 'should have bonsai asset' do
+      on node, 'sensuctl asset info sensu/sensu-pagerduty-handler --format json' do
+        data = JSON.parse(stdout)
+        version = data['metadata']['annotations']['io.sensu.bonsai.version']
+        expect(version).to eq('1.2.0')
+      end
+    end
+  end
+
+  context 'remove bonsai asset' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      include ::sensu::backend
+      sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+        ensure  => 'absent',
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    describe command('sensuctl asset info sensu/sensu-pagerduty-handler'), :node => node do
+      its(:exit_status) { should_not eq 0 }
+    end
+  end
+end

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -41,6 +41,19 @@ describe 'sensu::backend::resources', :type => :class do
         it { should compile.with_all_deps }
         it { should contain_sensu_asset('test') }
       end
+      context 'bonsai_assets defined' do
+        let(:pre_condition) do
+          <<-EOS
+            class { '::sensu::backend':
+              bonsai_assets => {
+                'sensu/sensu-pagerduty-handler' => { 'ensure' => 'present' }
+              }
+            }
+          EOS
+        end
+        it { should compile.with_all_deps }
+        it { should contain_sensu_bonsai_asset('sensu/sensu-pagerduty-handler') }
+      end
       context 'checks defined' do
         let(:pre_condition) do
           <<-EOS

--- a/spec/fixtures/unit/provider/sensu_bonsai_asset/sensuctl/asset_list.json
+++ b/spec/fixtures/unit/provider/sensu_bonsai_asset/sensuctl/asset_list.json
@@ -1,0 +1,261 @@
+[
+  {
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
+    "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_armv7.tar.gz",
+    "sha512": "70df8b7e9aa36cf942b972e1781af04815fa560441fcdea1d1538374066a4603fc5566737bfd6c7ffa18314edb858a9f93330a57d430deeb7fd6f75670a8c68b",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'arm'",
+      "entity.system.arm_version == 7"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_windows_amd64.tar.gz",
+    "sha512": "10d6411e5c8bd61349897cf8868087189e9ba59c3c206257e1ebc1300706539cf37524ac976d0ed9c8099bdddc50efadacf4f3c89b04a1a8bf5db581f19c157f",
+    "filters": [
+      "entity.system.os == 'windows'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "check_cpu",
+      "namespace": "default",
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/981307deb10ebf1f1433a80da5504c3c53d5c44f/sensu-go-cpu-check_0.0.3_linux_amd64.tar.gz",
+    "sha512": "487ab34b37da8ce76d2657b62d37b35fbbb240c3546dd463fa0c37dc58a72b786ef0ca396a0a12c8d006ac7fa21923e0e9ae63419a4d56aec41fccb574c1a5d3",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "check_cpu_linux_amd64",
+      "namespace": "default",
+      "labels": {
+        "origin": "bonsai"
+      },
+      "annotations": {
+        "project_url": "https://bonsai.sensu.io/assets/asachs01/sensu-go-cpu-check",
+        "version": "0.0.3"
+      }
+    },
+    "headers": {
+      "Authorization": "Bearer $TOKEN",
+      "X-Forwarded-For": "client1, proxy1, proxy2"
+    }
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_amd64.tar.gz",
+    "sha512": "e93ec4465af5a2057664e8c3cd68e9352457b81315b97578eaae5e21f0cf7419d4fc36feb0155eeb0dd5a227e267307a58ee58a9f3e85bf3d44da3738bf691ca",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu/sensu-pagerduty-handler",
+      "namespace": "default",
+      "annotations": {
+        "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.name": "sensu-pagerduty-handler",
+        "io.sensu.bonsai.namespace": "sensu",
+        "io.sensu.bonsai.tags": "handler",
+        "io.sensu.bonsai.tier": "Supported",
+        "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.version": "1.1.0"
+      }
+    },
+    "headers": null
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_386.tar.gz",
+    "sha512": "5f11f22704b4dddf1798bafcdcce1fec43380842a7c7ec48d8c48e9408abfb9e384b7bec3a4512bc92b1239f5867a4b43f6c45fb569a6546a749e0d11ad83a8f",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == '386'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu/sensu-pagerduty-handler",
+      "namespace": "default",
+      "annotations": {
+        "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.name": "sensu-pagerduty-handler",
+        "io.sensu.bonsai.namespace": "sensu",
+        "io.sensu.bonsai.tags": "handler",
+        "io.sensu.bonsai.tier": "Supported",
+        "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.version": "1.1.0"
+      }
+    },
+    "headers": null
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_arm64.tar.gz",
+    "sha512": "1eec6b24b4201e060e5fc4c3071be67f74b12250d75954d2195b3a57346f0dd7a34d6515b136453032d594d5de225e9dc80b20c9f7123f1565420bd483c3d181",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'arm64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu/sensu-pagerduty-handler",
+      "namespace": "default",
+      "annotations": {
+        "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.name": "sensu-pagerduty-handler",
+        "io.sensu.bonsai.namespace": "sensu",
+        "io.sensu.bonsai.tags": "handler",
+        "io.sensu.bonsai.tier": "Supported",
+        "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.version": "1.1.0"
+      }
+    },
+    "headers": null
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_armv7.tar.gz",
+    "sha512": "ddcf3cab808b0baa71f333e529ba76f10eec48f42e48f8164f3d9d911a4966ca6e64b2682d1d780bc448c6893d89df2aa8f3877f0dc742524381735a2f521ef4",
+    "filters": [
+      "entity.system.os == 'linux'",
+      "entity.system.arch == 'armv7'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu/sensu-pagerduty-handler",
+      "namespace": "default",
+      "annotations": {
+        "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.name": "sensu-pagerduty-handler",
+        "io.sensu.bonsai.namespace": "sensu",
+        "io.sensu.bonsai.tags": "handler",
+        "io.sensu.bonsai.tier": "Supported",
+        "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.version": "1.1.0"
+      }
+    },
+    "headers": null
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_darwin_amd64.tar.gz",
+    "sha512": "dc9f25c4c8576cfed4cb8ebb16aac842c8a03bf5b84d4351ef233b750b4adc0187aadf0403b770ad7df5c247fc77803592df206e40d5658c84c3baa38e4ba7aa",
+    "filters": [
+      "entity.system.os == 'darwin'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu/sensu-pagerduty-handler",
+      "namespace": "default",
+      "annotations": {
+        "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.name": "sensu-pagerduty-handler",
+        "io.sensu.bonsai.namespace": "sensu",
+        "io.sensu.bonsai.tags": "handler",
+        "io.sensu.bonsai.tier": "Supported",
+        "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.version": "1.1.0"
+      }
+    },
+    "headers": null
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_darwin_386.tar.gz",
+    "sha512": "d59ef175a4d379b8fe21fa0d97b2b6dfa7fcf796aa9bcc4375950f283322e5b208941fdb4bab65737201c4e5c6da592d280a3e8034bb96df4c858bbfd6e30458",
+    "filters": [
+      "entity.system.os == 'darwin'",
+      "entity.system.arch == '386'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu/sensu-pagerduty-handler",
+      "namespace": "default",
+      "annotations": {
+        "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.name": "sensu-pagerduty-handler",
+        "io.sensu.bonsai.namespace": "sensu",
+        "io.sensu.bonsai.tags": "handler",
+        "io.sensu.bonsai.tier": "Supported",
+        "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.version": "1.1.0"
+      }
+    },
+    "headers": null
+  },
+  {
+    "url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_windows_amd64.tar.gz",
+    "sha512": "09fd04a0ee0bd049105b92e5ac672369defcd7ae7409d682362f7e56bf4a128fd0147745e72eb605c26634507b8cd8ca5479213bb0cd6ce7198a0c634ca7d798",
+    "filters": [
+      "entity.system.os == 'darwin'",
+      "entity.system.arch == 'amd64'"
+    ],
+    "builds": null,
+    "metadata": {
+      "name": "sensu/sensu-pagerduty-handler",
+      "namespace": "default",
+      "annotations": {
+        "io.sensu.bonsai.api_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.name": "sensu-pagerduty-handler",
+        "io.sensu.bonsai.namespace": "sensu",
+        "io.sensu.bonsai.tags": "handler",
+        "io.sensu.bonsai.tier": "Supported",
+        "io.sensu.bonsai.url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler",
+        "io.sensu.bonsai.version": "1.1.0"
+      }
+    },
+    "headers": null
+  }
+]
+

--- a/spec/fixtures/unit/provider/sensu_bonsai_asset/sensuctl/bonsai_asset.json
+++ b/spec/fixtures/unit/provider/sensu_bonsai_asset/sensuctl/bonsai_asset.json
@@ -1,0 +1,405 @@
+{
+    "description": "Sensu Go PagerDuty Handler",
+    "download_url": "https://bonsai.sensu.io/assets/sensu/sensu-pagerduty-handler/download",
+    "github_url": "https://github.com/sensu/sensu-pagerduty-handler",
+    "name": "sensu/sensu-pagerduty-handler",
+    "url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler",
+    "versions": [
+        {
+            "assets": [],
+            "version": "master"
+        },
+        {
+            "assets": [
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "528633012b5e377a28afb78f30ed0bf53762e709851fd551a141ba39cae320644c2db0be527e1fc7d504264a412e06f7bdcac50043e097575b332243c721fd57",
+                    "asset_url": "https://assets.bonsai.sensu.io/ee009a3fa2c6e7fb1dc7b3a5fddc69a1bc3e7060/sensu-pagerduty-handler_1.0.2_windows_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.2/Windows/amd64/release_asset",
+                    "filter": [
+                        "System.OS == darwin",
+                        "System.Arch == amd64"
+                    ],
+                    "last_modified": "2019-09-09T00:03:57.000Z",
+                    "platform": "Windows"
+                },
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "7b94f4dfb456f4625be6767f066c58dd84f27a3f44ea8ac75978dd21f2f793edfda26c3ecb42f6cbc0b880b22240c44f8154bf3e74316ba1373f50d45227ad21",
+                    "asset_url": "https://assets.bonsai.sensu.io/ee009a3fa2c6e7fb1dc7b3a5fddc69a1bc3e7060/sensu-pagerduty-handler_1.0.2_darwin_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.2/OSX/386/release_asset",
+                    "filter": [
+                        "System.OS == darwin",
+                        "System.Arch == 386"
+                    ],
+                    "last_modified": "2019-09-09T00:03:56.000Z",
+                    "platform": "OSX"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "65e280e916b693a5041cdf25c6c2e6bd10f1bed37b0f710171cf9a7123bf8c683049ee1cd0ee137344ded19156a69966f5e36ff4313f9306cc59613e1b2d7822",
+                    "asset_url": "https://assets.bonsai.sensu.io/ee009a3fa2c6e7fb1dc7b3a5fddc69a1bc3e7060/sensu-pagerduty-handler_1.0.2_linux_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.2/linux/amd64/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == amd64"
+                    ],
+                    "last_modified": "2019-09-09T00:03:50.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "b1026656358382e88cf41c8a4cdcae1075be4b002dc6dc9c8eb903ecedc42e7c778aa4cd40f5849c6f42ea66d0a03501c12a519ab50afcb372ac191bf0602322",
+                    "asset_url": "https://assets.bonsai.sensu.io/ee009a3fa2c6e7fb1dc7b3a5fddc69a1bc3e7060/sensu-pagerduty-handler_1.0.2_linux_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.2/linux/386/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == 386"
+                    ],
+                    "last_modified": "2019-09-09T00:03:51.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "arm64",
+                    "asset_sha": "49b28511054e3699db083662846373c8210d53011e4b062e2ab860268bde16b6d65ca9d79a0ecbc21f165c3af056df30c5b6d35ce8795635a5062ef25617dbba",
+                    "asset_url": "https://assets.bonsai.sensu.io/ee009a3fa2c6e7fb1dc7b3a5fddc69a1bc3e7060/sensu-pagerduty-handler_1.0.2_linux_arm64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.2/linux/arm64/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == arm64"
+                    ],
+                    "last_modified": "2019-09-09T00:03:52.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "armv7",
+                    "asset_sha": "c74932c17638880a031f9acda4b057217e504a4b7bb995967af1b9fa01f045147dc80076bb336bcb3d910c674186bd7ebe646ff3f3ce43827217523752032a14",
+                    "asset_url": "https://assets.bonsai.sensu.io/ee009a3fa2c6e7fb1dc7b3a5fddc69a1bc3e7060/sensu-pagerduty-handler_1.0.2_linux_armv7.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.2/linux/armv7/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == armv7"
+                    ],
+                    "last_modified": "2019-09-09T00:03:53.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "7c1793eec88df9379a2dbe2315763926e0a01ed5222c5cade66c431fcd0fcac1a299da35b614ef3e0275cacde1d73b6ed93ccb255dc77b356da2bafedf2bafb8",
+                    "asset_url": "https://assets.bonsai.sensu.io/ee009a3fa2c6e7fb1dc7b3a5fddc69a1bc3e7060/sensu-pagerduty-handler_1.0.2_darwin_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.2/OSX/amd64/release_asset",
+                    "filter": [
+                        "System.OS == darwin",
+                        "System.Arch == amd64"
+                    ],
+                    "last_modified": "2019-09-09T00:03:55.000Z",
+                    "platform": "OSX"
+                }
+            ],
+            "version": "1.0.2"
+        },
+        {
+            "assets": [
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "5be236b5b9ccceb10920d3a171ada4ac4f4caaf87f822475cd48bd7f2fab3235fa298f79ef6f97b0eb6498205740bb1af1120ca036fd3381edfebd9fb15aaa99",
+                    "asset_url": "https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_linux_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.2.0/linux/amd64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == 'amd64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:33.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "1665884187b9915c930ccaabf898109fb7597242cf7e6a83b1634cd1b6f017a894ed096f9ad2444a656367ab9a8329a385f309f45636e5b0043b96312cffc229",
+                    "asset_url": "https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_linux_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.2.0/linux/386/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == '386'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:34.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "arm64",
+                    "asset_sha": "3519de0a1d3f3e1a4f9929f62eff1f217974208fbaed2b78c945b6712d5f2871a476f20d9ea05deb098065810ed7820f1a6dd4a5563c4a5f7eb90997ac7eb53e",
+                    "asset_url": "https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_linux_arm64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.2.0/linux/arm64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == 'arm64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:35.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "armv7",
+                    "asset_sha": "7313e5155b4ab9956b7a28d4e033977e106350498bc02f1cd0bfc23ec8a3e77b1f9b1747defaa649a61f90cb950449489ed0edf431ed49520b86b0ddb494ebfd",
+                    "asset_url": "https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_linux_armv7.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.2.0/linux/armv7/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == 'armv7'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:36.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "06ac514b64670a5f21835c09e1aea96669aa5eaf9f90e70083783eb8cdd082003ad2238d7afab483f82e47eeb2b9a37e9b2e0a6b53bb7d1c1b3bb77da6c02386",
+                    "asset_url": "https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_darwin_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.2.0/OSX/amd64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'darwin'",
+                        "entity.system.arch == 'amd64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:37.000Z",
+                    "platform": "OSX"
+                },
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "cfbfed2e5a5a2acf6bd4bd143abc53d5e6642611626868b0a69de81cba4971fb96738f11218ea85cacb6bfceb501b367d3963d46c6aa79f78ac35b7c3a6a165d",
+                    "asset_url": "https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_darwin_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.2.0/OSX/386/release_asset",
+                    "filter": [
+                        "entity.system.os == 'darwin'",
+                        "entity.system.arch == '386'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:38.000Z",
+                    "platform": "OSX"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "a5fd30f016ea7fc0d5bce276337244dcf7dcea9426937603e0cfefdbbca331c0d65872c6b397217bd9ea7c2ad56d6952f7c473688da91a75e72c8aedc6754997",
+                    "asset_url": "https://assets.bonsai.sensu.io/02fc48fb7cbfd27f36915489af2725034a046772/sensu-pagerduty-handler_1.2.0_windows_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.2.0/Windows/amd64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'darwin'",
+                        "entity.system.arch == 'amd64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:39.000Z",
+                    "platform": "Windows"
+                }
+            ],
+            "version": "1.2.0"
+        },
+        {
+            "assets": [
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "b47b33af890f9fbfa8652b804b7441b7a1ba64a71a63fe876e043ccd28421d0ed326d7637c8b11f43fb0b589cad6d63515a4ae84ba04b4c062bb20c819f22f95",
+                    "asset_url": "https://assets.bonsai.sensu.io/e8dcfbb4b7e01608ca29f36c7c5ca6bf9618f07b/sensu-pagerduty-handler_1.0.1_linux_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.1/linux/386/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == 386"
+                    ],
+                    "last_modified": "2019-09-09T00:04:01.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "armv7",
+                    "asset_sha": "ac6a02e0c632de3ee3e03de90db122365c1c16968d1fa11d1b119bbceea3943c8861856bec6326cadbb181489b8f5e0ef283906e0430e7232f45ded6f1db4acb",
+                    "asset_url": "https://assets.bonsai.sensu.io/e8dcfbb4b7e01608ca29f36c7c5ca6bf9618f07b/sensu-pagerduty-handler_1.0.1_linux_armv7.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.1/linux/armv7/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == armv7"
+                    ],
+                    "last_modified": "2019-09-09T00:04:03.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "7cdb60324ef8ce8dc9c9690341680ea4564ae2bc423b5993cfe7ac210c0cb714bff2ef8dbef6e93531df137a62fb3ef3c68a859a803bf7b85a44738e7dce08a4",
+                    "asset_url": "https://assets.bonsai.sensu.io/e8dcfbb4b7e01608ca29f36c7c5ca6bf9618f07b/sensu-pagerduty-handler_1.0.1_darwin_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.1/OSX/amd64/release_asset",
+                    "filter": [
+                        "System.OS == darwin",
+                        "System.Arch == amd64"
+                    ],
+                    "last_modified": "2019-09-09T00:04:04.000Z",
+                    "platform": "OSX"
+                },
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "f29af962eb1e987c233d3161e94e10b4c3050c49360084c10e039c18087eed6e606357a7b754837e9b3c2f21f6cbaff9965d2155d90dfef8da02f3df19fab9bb",
+                    "asset_url": "https://assets.bonsai.sensu.io/e8dcfbb4b7e01608ca29f36c7c5ca6bf9618f07b/sensu-pagerduty-handler_1.0.1_darwin_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.1/OSX/386/release_asset",
+                    "filter": [
+                        "System.OS == darwin",
+                        "System.Arch == 386"
+                    ],
+                    "last_modified": "2019-09-09T00:04:07.000Z",
+                    "platform": "OSX"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "311994675a3d655f24058aa4e869992556052ae6ccdcf58082902bd4c8cee078d8f973941951548312bfa1d1547f654131b0318e82546471c119a27c72b2b064",
+                    "asset_url": "https://assets.bonsai.sensu.io/e8dcfbb4b7e01608ca29f36c7c5ca6bf9618f07b/sensu-pagerduty-handler_1.0.1_windows_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.1/Windows/amd64/release_asset",
+                    "filter": [
+                        "System.OS == darwin",
+                        "System.Arch == amd64"
+                    ],
+                    "last_modified": "2019-09-09T00:04:09.000Z",
+                    "platform": "Windows"
+                },
+                {
+                    "annotations": {},
+                    "arch": "arm64",
+                    "asset_sha": "26c936afbef32772f16d4589948af19a4b08ebc6c47566d0d3aee22e15c740bc41a418d9cc806a1391b693d4ff5f2adc732888e987b50e287d8885bb5626f6a7",
+                    "asset_url": "https://assets.bonsai.sensu.io/e8dcfbb4b7e01608ca29f36c7c5ca6bf9618f07b/sensu-pagerduty-handler_1.0.1_linux_arm64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.1/linux/arm64/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == arm64"
+                    ],
+                    "last_modified": "2019-09-09T00:04:02.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "5facfb0706e5e36edc5d13993ecc813a4689c5ca502d70670268ca1c0679e9e2af79af75ee4f7a423b48f2e55524f6d81ce81485975eb3b70048cfa58f4af961",
+                    "asset_url": "https://assets.bonsai.sensu.io/e8dcfbb4b7e01608ca29f36c7c5ca6bf9618f07b/sensu-pagerduty-handler_1.0.1_linux_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.0.1/linux/amd64/release_asset",
+                    "filter": [
+                        "System.OS == linux",
+                        "System.Arch == amd64"
+                    ],
+                    "last_modified": "2019-09-09T00:04:00.000Z",
+                    "platform": "linux"
+                }
+            ],
+            "version": "1.0.1"
+        },
+        {
+            "assets": [],
+            "version": "1.0.0"
+        },
+        {
+            "assets": [],
+            "version": "0.0.3"
+        },
+        {
+            "assets": [
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "e93ec4465af5a2057664e8c3cd68e9352457b81315b97578eaae5e21f0cf7419d4fc36feb0155eeb0dd5a227e267307a58ee58a9f3e85bf3d44da3738bf691ca",
+                    "asset_url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.1.0/linux/amd64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == 'amd64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:41.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "5f11f22704b4dddf1798bafcdcce1fec43380842a7c7ec48d8c48e9408abfb9e384b7bec3a4512bc92b1239f5867a4b43f6c45fb569a6546a749e0d11ad83a8f",
+                    "asset_url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.1.0/linux/386/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == '386'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:42.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "arm64",
+                    "asset_sha": "1eec6b24b4201e060e5fc4c3071be67f74b12250d75954d2195b3a57346f0dd7a34d6515b136453032d594d5de225e9dc80b20c9f7123f1565420bd483c3d181",
+                    "asset_url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_arm64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.1.0/linux/arm64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == 'arm64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:43.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "armv7",
+                    "asset_sha": "ddcf3cab808b0baa71f333e529ba76f10eec48f42e48f8164f3d9d911a4966ca6e64b2682d1d780bc448c6893d89df2aa8f3877f0dc742524381735a2f521ef4",
+                    "asset_url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_linux_armv7.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.1.0/linux/armv7/release_asset",
+                    "filter": [
+                        "entity.system.os == 'linux'",
+                        "entity.system.arch == 'armv7'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:44.000Z",
+                    "platform": "linux"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "dc9f25c4c8576cfed4cb8ebb16aac842c8a03bf5b84d4351ef233b750b4adc0187aadf0403b770ad7df5c247fc77803592df206e40d5658c84c3baa38e4ba7aa",
+                    "asset_url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_darwin_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.1.0/OSX/amd64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'darwin'",
+                        "entity.system.arch == 'amd64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:45.000Z",
+                    "platform": "OSX"
+                },
+                {
+                    "annotations": {},
+                    "arch": "386",
+                    "asset_sha": "d59ef175a4d379b8fe21fa0d97b2b6dfa7fcf796aa9bcc4375950f283322e5b208941fdb4bab65737201c4e5c6da592d280a3e8034bb96df4c858bbfd6e30458",
+                    "asset_url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_darwin_386.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.1.0/OSX/386/release_asset",
+                    "filter": [
+                        "entity.system.os == 'darwin'",
+                        "entity.system.arch == '386'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:46.000Z",
+                    "platform": "OSX"
+                },
+                {
+                    "annotations": {},
+                    "arch": "amd64",
+                    "asset_sha": "09fd04a0ee0bd049105b92e5ac672369defcd7ae7409d682362f7e56bf4a128fd0147745e72eb605c26634507b8cd8ca5479213bb0cd6ce7198a0c634ca7d798",
+                    "asset_url": "https://assets.bonsai.sensu.io/698710262d59c72ace3e31524960630dc1e4f190/sensu-pagerduty-handler_1.1.0_windows_amd64.tar.gz",
+                    "details_url": "https://bonsai.sensu.io/api/v1/assets/sensu/sensu-pagerduty-handler/1.1.0/Windows/amd64/release_asset",
+                    "filter": [
+                        "entity.system.os == 'darwin'",
+                        "entity.system.arch == 'amd64'"
+                    ],
+                    "last_modified": "2019-09-09T00:03:47.000Z",
+                    "platform": "Windows"
+                }
+            ],
+            "version": "1.1.0"
+        }
+    ]
+}

--- a/spec/unit/provider/sensu_bonsai_asset/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_bonsai_asset/sensuctl_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensuctl) do
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_bonsai_asset) }
+  let(:config) do
+    { :name => 'sensu/sensu-pagerduty-handler' }
+  end
+  let(:resource) do
+    type.new(config)
+  end
+
+  describe 'self.instances' do
+    it 'should create instances' do
+      allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
+      expect(provider.instances.length).to eq(1)
+    end
+
+    it 'should return the resource for a asset' do
+      allow(provider).to receive(:sensuctl_list).with('asset').and_return(JSON.parse(my_fixture_read('asset_list.json')))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
+      expect(property_hash[:name]).to eq('sensu/sensu-pagerduty-handler in default')
+    end
+  end
+
+  describe 'self.latest_version' do
+    it 'should return latest version' do
+      allow(provider).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler').and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
+      latest_version = provider.latest_version('sensu', 'sensu-pagerduty-handler')
+      expect(latest_version).to eq('1.2.0')
+    end
+  end
+
+  describe 'create' do
+    it 'should create a bonsai_asset' do
+      expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should create a bonsai_asset for latest' do
+      config[:version] = 'latest'
+      expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'should create a bonsai_asset for a version' do
+      config[:version] = '1.2.0'
+      expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler:1.2.0','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+  end
+
+  describe 'flush' do
+    it 'should install latest bonsai asset' do
+      expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      resource.provider.version = 'latest'
+      resource.provider.flush
+    end
+    it 'should install a version of bonsai asset' do
+      expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler:1.2.0','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      resource.provider.version = '1.2.0'
+      resource.provider.flush
+    end
+  end
+
+  describe 'destroy' do
+    it 'should delete a asset' do
+      expect(resource.provider).to receive(:sensuctl_delete).with('asset', 'sensu/sensu-pagerduty-handler', 'default')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash).to eq({})
+    end
+  end
+end
+


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support installing Bonsai assets directly using `sensuctl asset add`. If `version` is set to `latest` the versions available are pulled from Bonsai API.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #1145 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.13 added supporting for installing assets directly from Bonsai. This adds a type to support that operation.