### PR TITLE
Install Windows agent via chocolatey

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -7,6 +7,14 @@ fixtures:
     yumrepo_core:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       puppet_version: ">= 6.0.0"
+    chocolatey:
+      repo: git://github.com/puppetlabs/puppetlabs-chocolatey.git
+    # Needed by chocolatey
+    registry:
+      repo: git://github.com/puppetlabs/puppetlabs-registry.git
+    # Needed by chocolatey
+    powershell:
+      repo: git://github.com/puppetlabs/puppetlabs-powershell.git
     # Need by postgresql
     augeas_core:
       repo: git://github.com/puppetlabs/puppetlabs-augeas_core

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -10,6 +10,17 @@ fixtures:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1
       puppet_version: ">= 6.0.0"
+    chocolatey:
+      repo: git://github.com/puppetlabs/puppetlabs-chocolatey.git
+      ref: 3.0.0
+    # Needed by chocolatey
+    registry:
+      repo: git://github.com/puppetlabs/puppetlabs-registry.git
+      ref: 1.0.0
+    # Needed by chocolatey
+    powershell:
+      repo: git://github.com/puppetlabs/puppetlabs-powershell.git
+      ref: 1.0.1
     # Need by postgresql
     augeas_core:
       repo: git://github.com/puppetlabs/puppetlabs-augeas_core

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ This module has a soft dependency on the [puppetlabs/apt](https://forge.puppet.c
 
 If using Puppet >= 6.0.0 there is a soft dependency on the [puppetlabs/yumrepo_core](https://forge.puppet.com/puppetlabs/yumrepo_core) module (`>= 1.0.1 < 2.0.0`) for systems using `yum`.
 
-If managing Windows there is a soft dependency on the [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.0 < 5.0.0`).
+If managing Windows there is a soft dependency on the [puppetlabs/chocolatey](https://forge.puppet.com/puppetlabs/chocolatey) module (`>= 3.0.0 < 5.0.0`).
+
+If managing Windows and defining `package_source`, there is a soft dependency on the [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.0 < 5.0.0`).
 
 For PostgreSQL datastore support there is a soft dependency on [puppetlabs/postgresql](https://forge.puppet.com/puppetlabs/postgresql) module (`>= 6.0.0 < 7.0.0`).
 
@@ -129,15 +131,25 @@ associated to `linux` and `apache-servers` subscriptions.
 
 ### Manage Windows Agent
 
-This module supports Windows Sensu Go agent starting with version 5.7.0.
+This module supports Windows Sensu Go agent via chocolatey beginning with version 5.12.0.
 
-The Windows package source must be specified as either a URL, a Puppet source or a filesystem path.
+```puppet
+class { 'sensu::agent':
+  backends    => ['sensu-backend.example.com:8081'],
+  config_hash => {
+    'subscriptions' => ['windows'],
+  },
+}
+```
+
+If you do not wish to install using chocolatey then you must define `package_source` as either a URL, a Puppet source or a filesystem path.
 
 Install sensu-go-agent on Windows from URL:
 
 ```puppet
 class { 'sensu::agent':
-  package_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-go-agent_5.7.0.2380_en-US.x64.msi',
+  package_name   => 'Sensu Agent',
+  package_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.13.1/sensu-go-agent_5.13.1.5957_en-US.x64.msi',
 }
 ```
 
@@ -145,6 +157,7 @@ Install sensu-go-agent on Windows from Puppet source:
 
 ```puppet
 class { 'sensu::agent':
+  package_name   => 'Sensu Agent',
   package_source => 'puppet:///modules/profile/sensu/sensu-go-agent.msi',
 }
 ```
@@ -153,6 +166,7 @@ If a system already has the necessary MSI present it can be installed without do
 
 ```puppet
 class { 'sensu::agent':
+  package_name   => 'Sensu Agent',
   package_source => 'C:\Temp\sensu-go-agent.msi',
 }
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
 - set PATH=C:\Program Files\Puppet Labs\Puppet\bin;%PATH%
 - puppet --version
 - puppet module install puppetlabs-stdlib
+- puppet module install puppetlabs-chocolatey
 - puppet module install puppet-archive
 - puppet config set --section main certname sensu_agent
 - facter -p --debug

--- a/data/os/windows.yaml
+++ b/data/os/windows.yaml
@@ -2,7 +2,7 @@
 sensu::manage_repo: false
 sensu::etc_dir: 'C:\ProgramData\Sensu\config'
 sensu::ssl_dir: 'C:\ProgramData\Sensu\config\ssl'
-sensu::agent::package_name: 'Sensu Agent'
+sensu::agent::package_name: 'sensu-agent'
 sensu::agent::package_download_path: 'C:\'
 sensu::agent::log_file: 'C:\ProgramData\sensu\log\sensu-agent.log'
 sensu::agent::service_name: SensuAgent

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -35,11 +35,12 @@ describe 'sensu::agent', :type => :class do
 
         it {
           should contain_package('sensu-go-agent').with({
-            'ensure'  => 'installed',
-            'name'    => platforms[facts[:osfamily]][:agent_package_name],
-            'source'  => nil,
-            'before'  => 'File[sensu_etc_dir]',
-            'require' => platforms[facts[:osfamily]][:package_require],
+            'ensure'   => 'installed',
+            'name'     => platforms[facts[:osfamily]][:agent_package_name],
+            'source'   => nil,
+            'provider' => platforms[facts[:osfamily]][:package_provider],
+            'before'   => 'File[sensu_etc_dir]',
+            'require'  => platforms[facts[:osfamily]][:package_require],
           })
         }
 
@@ -86,6 +87,7 @@ describe 'sensu::agent', :type => :class do
             })
           }
           it { should contain_package('sensu-go-agent').with_source('C:\\\\sensu-go-agent.msi') }
+          it { should contain_package('sensu-go-agent').without_provider }
         else
           it { should_not contain_archive('sensu-go-agent.msi') }
           it { should contain_package('sensu-go-agent').without_source }
@@ -104,6 +106,7 @@ describe 'sensu::agent', :type => :class do
             })
           }
           it { should contain_package('sensu-go-agent').with_source('C:\\\\sensu-go-agent.msi') }
+          it { should contain_package('sensu-go-agent').without_provider }
         else
           it { should_not contain_archive('sensu-go-agent.msi') }
           it { should contain_package('sensu-go-agent').without_source }
@@ -115,6 +118,7 @@ describe 'sensu::agent', :type => :class do
         it { should_not contain_archive('sensu-go-agent.msi') }
         if facts[:os]['family'] == 'windows'
           it { should contain_package('sensu-go-agent').with_source('C:\\sensu-go-agent.msi') }
+          it { should contain_package('sensu-go-agent').without_provider }
         else
           it { should contain_package('sensu-go-agent').without_source }
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,6 +47,8 @@ RSpec.configure do |config|
     :fqdn                      => 'testfqdn.example.com',
     :puppet_hostcert           => '/dne/cert.pem',
     :puppet_hostprivkey        => '/dne/key.pem',
+    :choco_install_path        => 'C:\ProgramData\chocolatey',
+    :chocolateyversion         => '1.0.0',
   }
   config.backtrace_exclusion_patterns = [
     %r{/\.bundle/},
@@ -80,6 +82,7 @@ def platforms
   {
     'Debian' => {
       :package_require => ['Class[Sensu::Repo]', 'Class[Apt::Update]'],
+      package_provider: nil,
       :plugins_package_require => ['Class[Sensu::Repo::Community]', 'Class[Apt::Update]'],
       :plugins_dependencies => ['make','gcc','g++','libssl-dev'],
       agent_package_name: 'sensu-go-agent',
@@ -98,6 +101,7 @@ def platforms
     },
     'RedHat' => {
       :package_require => ['Class[Sensu::Repo]'],
+      package_provider: nil,
       :plugins_package_require => ['Class[Sensu::Repo::Community]'],
       :plugins_dependencies => ['make','gcc','gcc-c++','openssl-devel'],
       agent_package_name: 'sensu-go-agent',
@@ -115,7 +119,8 @@ def platforms
       log_file: nil,
     },
     'windows' => {
-      agent_package_name: 'Sensu Agent',
+      agent_package_name: 'sensu-agent',
+      package_provider: 'chocolatey',
       :agent_config_path => 'C:\ProgramData\Sensu\config\agent.yml',
       agent_config_mode: nil,
       etc_dir: 'C:\\ProgramData\\Sensu\\config',

--- a/tests/provision_basic_win.ps1
+++ b/tests/provision_basic_win.ps1
@@ -40,7 +40,7 @@ $hiera_content | Out-File -FilePath "$hiera_file" -Encoding ascii
 # Puppet in the PATH.
 $env:PATH += ";C:\Program Files\Puppet Labs\Puppet\bin"
 iex "puppet module install puppetlabs-stdlib"
-iex "puppet module install puppet-archive"
+iex "puppet module install puppetlabs-chocolatey"
 New-Item -Path "C:\ProgramData\PuppetLabs\puppet\etc\ssl" -ItemType directory -Force | Out-Null
 Copy-Item -Path "C:\vagrant\tests\ssl\*" -Destination "C:\ProgramData\PuppetLabs\puppet\etc\ssl\" -Recurse -Force
 

--- a/tests/sensu-agent.pp
+++ b/tests/sensu-agent.pp
@@ -1,10 +1,3 @@
-if $facts['os']['family'] == 'windows' {
-  $package_source = 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.7.0/sensu-go-agent_5.7.0.2380_en-US.x64.msi'
-} else {
-  $package_source = undef
-}
-
 class { '::sensu::agent':
-  backends       => ['sensu-backend.example.com:8081'],
-  package_source => $package_source,
+  backends => ['sensu-backend.example.com:8081'],
 }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Default to installing Windows Sensu Go agent via Chocolatey. The previous behavior of installing via a source path is still allowed in case a site doesn't want to use Chocolatey.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1151 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu has a Chocolatey package available since version 5.12.0.