### PR TITLE
Add bolt tasks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -164,6 +164,20 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     agent.vm.provision :shell, :inline => 'iex "facter --custom-dir=C:\vagrant\lib\facter sensu_agent"'
   end
 
+  config.vm.define "win2012r2-agent-bolt", autostart: false do |agent|
+    agent.vm.box = "opentable/win-2012r2-standard-amd64-nocm"
+    agent.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--memory", "2048"]
+      vb.customize ["modifyvm", :id, "--cpus", "1"]
+    end
+    agent.vm.hostname = 'win2012r2-agent'
+    agent.vm.network  :private_network, ip: "192.168.52.29"
+    agent.vm.network "forwarded_port", host: 3389, guest: 3389, auto_correct: true
+    agent.vm.provision :shell, :path => "tests/provision_basic_win.ps1"
+    agent.vm.provision :shell, :path => "tests/test_bolt_win.ps1"
+    agent.vm.provision :shell, :inline => 'iex "facter --custom-dir=C:\vagrant\lib\facter sensu_agent"'
+  end
+
   config.vm.define "win2016-agent", autostart: false do |agent|
     agent.vm.box = "mwrock/Windows2016"
     agent.vm.provider :virtualbox do |vb|
@@ -176,6 +190,21 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     agent.vm.network "forwarded_port", host: 3391, guest: 3389, auto_correct: true
     agent.vm.provision :shell, :path => "tests/provision_basic_win.ps1"
     agent.vm.provision :shell, :inline => 'iex "puppet apply -v C:/vagrant/tests/sensu-agent.pp"'
+    agent.vm.provision :shell, :inline => 'iex "facter --custom-dir=C:\vagrant\lib\facter sensu_agent"'
+  end
+
+  config.vm.define "win2016-agent-bolt", autostart: false do |agent|
+    agent.vm.box = "mwrock/Windows2016"
+    agent.vm.provider :virtualbox do |vb|
+      vb.customize ["modifyvm", :id, "--memory", "2048"]
+      vb.customize ["modifyvm", :id, "--cpus", "1"]
+      vb.gui = false
+    end
+    agent.vm.hostname = 'win2016-agent-bolt'
+    agent.vm.network  :private_network, ip: "192.168.52.28"
+    agent.vm.network "forwarded_port", host: 3391, guest: 3389, auto_correct: true
+    agent.vm.provision :shell, :path => "tests/provision_basic_win.ps1"
+    agent.vm.provision :shell, :path => "tests/test_bolt_win.ps1"
     agent.vm.provision :shell, :inline => 'iex "facter --custom-dir=C:\vagrant\lib\facter sensu_agent"'
   end
 end

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,7 +44,7 @@ test_script:
 - ps: Copy-Item -Path $ENV:APPVEYOR_BUILD_FOLDER -Destination C:/ProgramData/PuppetLabs/code/environments/production/modules/sensu -Recurse
 - set BEAKER_skip_apply=yes
 - '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" task show'
-- '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" --debug task run sensu::install_agent backend=sensu_backend:8081 subscription=windows --nodes localhost'
+- '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" --debug task run sensu::install_agent backend=sensu_backend:8081 subscription=windows output=true --nodes localhost'
 - bundle exec rake acceptance:windows
 image:
   # Windows 2012 R2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,6 @@ branches:
   only:
     - master
     - /^v\d/
-cache:
-- C:\downloads
-- C:\vendor\bundle
 init:
 - ps: $env:GEM_SOURCE = "http://rubygems.org"
 install:
@@ -28,6 +25,7 @@ install:
 - ps: Copy-Item -Path $ENV:APPVEYOR_BUILD_FOLDER -Destination C:/ProgramData/PuppetLabs/code/environments/production/modules/sensu -Recurse
 - ps: Copy-Item -Path "${ENV:APPVEYOR_BUILD_FOLDER}/tests/ssl" -Destination C:/ProgramData/PuppetLabs/puppet/etc/ssl -Recurse
 - ps: Copy-Item -Path "${ENV:APPVEYOR_BUILD_FOLDER}/lib/facter" -Destination C:/ProgramData/PuppetLabs/puppet/cache/lib/facter -Recurse
+- choco install puppet-bolt
 - set PATH=C:\Program Files\Puppet Labs\Puppet\bin;%PATH%
 - puppet --version
 - puppet module install puppetlabs-stdlib
@@ -36,11 +34,17 @@ install:
 - puppet config set --section main certname sensu_agent
 - facter -p --debug
 - ruby -v
-- gem update --system 2.7.9
-- gem -v
 - bundle -v
 - bundle install --jobs 4 --retry 2 --path C:\vendor\bundle
 test_script:
+- bundle exec rake acceptance:windows
+- '"C:\\Program Files\\sensu\\sensu-agent\\bin\\sensu-agent.exe" service uninstall'
+- 'puppet resource package "Sensu Agent" ensure=absent'
+- rmdir C:\\ProgramData\\PuppetLabs\\code\\environments\\production\\modules /s /q
+- ps: Copy-Item -Path $ENV:APPVEYOR_BUILD_FOLDER -Destination C:/ProgramData/PuppetLabs/code/environments/production/modules/sensu -Recurse
+- set BEAKER_skip_apply=yes
+- '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" task show'
+- '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" --debug task run sensu::install_agent backend=sensu_backend:8081 subscription=windows --nodes localhost'
 - bundle exec rake acceptance:windows
 image:
   # Windows 2012 R2

--- a/spec/acceptance/sensu_bolt_tasks_spec.rb
+++ b/spec/acceptance/sensu_bolt_tasks_spec.rb
@@ -187,7 +187,7 @@ describe 'sensu check_execute task', if: RSpec.configuration.sensu_full do
   context 'check_execute' do
     it 'should work without errors' do
       on backend, 'bolt task run sensu::check_execute check=test subscription=entity:sensu_agent --nodes localhost'
-      sleep 5
+      sleep 30
     end
 
     it 'should have executed check' do

--- a/spec/acceptance/sensu_bolt_tasks_spec.rb
+++ b/spec/acceptance/sensu_bolt_tasks_spec.rb
@@ -144,7 +144,7 @@ describe 'sensu install_agent task', if: RSpec.configuration.sensu_full do
   end
   context 'install_agent' do
     it 'should work without errors' do
-      on backend, 'bolt task run sensu::install_agent backend=sensu_backend:8081 subscription=linux --nodes sensu_agent'
+      on backend, 'bolt task run sensu::install_agent backend=sensu_backend:8081 subscription=linux output=true --nodes sensu_agent'
       sleep 5
     end
 

--- a/spec/acceptance/sensu_bolt_tasks_spec.rb
+++ b/spec/acceptance/sensu_bolt_tasks_spec.rb
@@ -1,0 +1,116 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu event task', if: RSpec.configuration.sensu_full do
+  node = hosts_as('sensu_backend')[0]
+  agent = hosts_as('sensu_agent')[0]
+  context 'setup agent' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      class { '::sensu': }
+      class { '::sensu::agent':
+        backends    => ['sensu_backend:8081'],
+        config_hash => {
+          'name' => 'sensu_agent',
+        }
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        agent_site_pp = "node 'sensu_agent' { #{pp} }\nnode 'sensu_backend' { include ::sensu::backend }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on agent, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on agent, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(agent, pp, :catch_failures => true)
+        apply_manifest_on(agent, pp, :catch_changes  => true)
+        apply_manifest_on(node, 'include ::sensu::backend', :catch_failures => true)
+        apply_manifest_on(node, 'include ::sensu::backend', :catch_changes  => true)
+      end
+    end
+  end
+
+  context 'resolve' do
+    it 'should work without errors' do
+      check_pp = <<-EOS
+      include ::sensu::backend
+      sensu_check { 'test':
+        command       => 'exit 1',
+        subscriptions => ['entity:sensu_agent'],
+        interval      => 3600,
+      }
+      EOS
+
+      apply_manifest_on(node, check_pp, :catch_failures => true)
+      on node, 'sensuctl check execute test'
+      sleep 20
+      on node, 'bolt task run sensu::event action=resolve entity=sensu_agent check=test --nodes sensu_backend'
+    end
+
+    it 'should have resolved check' do
+      on node, 'sensuctl event info sensu_agent test --format json' do
+        data = JSON.parse(stdout)
+        expect(data['check']['status']).to eq(0)
+      end
+    end
+  end
+
+  context 'delete' do
+    it 'should remove without errors' do
+      # Stop sensu-agent on agent node to avoid re-creating event
+      apply_manifest_on(agent,
+        "service { 'sensu-agent': ensure => 'stopped' }")
+      sleep 20
+      on node, 'bolt task run sensu::event action=delete entity=sensu_agent check=test --nodes sensu_backend'
+    end
+
+    describe command('sensuctl event info sensu_agent test'), :node => node do
+      its(:exit_status) { should_not eq 0 }
+    end
+  end
+end
+
+describe 'sensu silenced task', if: RSpec.configuration.sensu_full do
+  node = hosts_as('sensu_backend')[0]
+  context 'create' do
+    it 'should work without errors' do
+      on node, 'bolt task run sensu::silenced action=create subscription=entity:sensu_agent --nodes sensu_backend'
+    end
+
+    it 'should have a valid silenced' do
+      on node, 'sensuctl silenced info entity:sensu_agent:* --format json' do
+        data = JSON.parse(stdout)
+        expect(data['subscription']).to eq('entity:sensu_agent')
+        expect(data['expire']).to eq(-1)
+        expect(data['expire_on_resolve']).to eq(false)
+      end
+    end
+  end
+
+  context 'update' do
+    it 'should work without errors' do
+      on node, 'bolt task run sensu::silenced action=create subscription=entity:sensu_agent expire_on_resolve=true --nodes sensu_backend'
+    end
+
+    it 'should have a valid silenced with updated propery' do
+      on node, 'sensuctl silenced info entity:sensu_agent:* --format json' do
+        data = JSON.parse(stdout)
+        expect(data['expire_on_resolve']).to eq(true)
+      end
+    end
+  end
+
+  context 'delete' do
+    it 'should remove without errors' do
+      on node, 'bolt task run sensu::silenced action=delete subscription=entity:sensu_agent --nodes sensu_backend'
+    end
+
+    describe command('sensuctl silenced info entity:sensu_agent:*'), :node => node do
+      its(:exit_status) { should_not eq 0 }
+    end
+  end
+end
+

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -13,14 +13,16 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     }
     EOS
 
-    it 'creates manifest' do
-      File.open('C:\manifest-agent.pp', 'w') { |f| f.write(pp) }
-      puts "C:\manifest-agent.pp"
-      puts File.read('C:\manifest-agent.pp')
-    end
+    unless RSpec.configuration.skip_apply
+      it 'creates manifest' do
+        File.open('C:\manifest-agent.pp', 'w') { |f| f.write(pp) }
+        puts "C:\manifest-agent.pp"
+        puts File.read('C:\manifest-agent.pp')
+      end
 
-    describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp') do
-      its(:exit_status) { is_expected.to eq 256 }
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp') do
+        its(:exit_status) { is_expected.to eq 256 }
+      end
     end
 
     describe service('SensuAgent') do
@@ -49,18 +51,20 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     }
     EOS
 
-    it 'creates manifest' do
-      File.open('C:\manifest-agent.pp', 'w') { |f| f.write(pp) }
-      puts "C:\manifest-agent.pp"
-      puts File.read('C:\manifest-agent.pp')
-    end
+    unless RSpec.configuration.skip_apply
+      it 'creates manifest' do
+        File.open('C:\manifest-agent.pp', 'w') { |f| f.write(pp) }
+        puts "C:\manifest-agent.pp"
+        puts File.read('C:\manifest-agent.pp')
+      end
 
-    describe command('puppet resource package sensu-agent ensure=absent provider=chocolatey') do
-      its(:exit_status) { is_expected.to eq 0 }
-    end
+      describe command('puppet resource package sensu-agent ensure=absent provider=chocolatey') do
+        its(:exit_status) { is_expected.to eq 0 }
+      end
 
-    describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp') do
-      its(:exit_status) { is_expected.to eq 256 }
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp') do
+        its(:exit_status) { is_expected.to eq 256 }
+      end
     end
 
     describe service('SensuAgent') do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -110,6 +110,7 @@ EOS
       on puppetserver, "chmod 0644 /etc/puppetlabs/code/environments/production/manifests/site.pp"
     end
 
+    # Setup Puppet Bolt
     on setup_nodes, puppet("resource package puppet-bolt ensure=installed")
     bolt_cfg = <<-EOS
 modulepath: "/etc/puppetlabs/code/modules:/etc/puppetlabs/code/environments/production/modules"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -16,6 +16,7 @@ RSpec.configure do |c|
   c.add_setting :sensu_test_enterprise, default: false
   c.add_setting :sensu_manage_repo, default: true
   c.add_setting :sensu_use_agent, default: false
+  c.add_setting :skip_apply, default: false
   c.sensu_full = (ENV['BEAKER_sensu_full'] == 'yes' || ENV['BEAKER_sensu_full'] == 'true')
   c.sensu_cluster = (ENV['BEAKER_sensu_cluster'] == 'yes' || ENV['BEAKER_sensu_cluster'] == 'true')
   c.sensu_use_agent = (ENV['BEAKER_sensu_use_agent'] == 'yes' || ENV['BEAKER_sensu_use_agent'] == 'true')

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -108,5 +108,16 @@ EOS
       create_remote_file(puppetserver, '/etc/puppetlabs/code/environments/production/manifests/site.pp', '')
       on puppetserver, "chmod 0644 /etc/puppetlabs/code/environments/production/manifests/site.pp"
     end
+
+    on setup_nodes, puppet("resource package puppet-bolt ensure=installed")
+    bolt_cfg = <<-EOS
+modulepath: "/etc/puppetlabs/code/modules:/etc/puppetlabs/code/environments/production/modules"
+ssh:
+  host-key-check: false
+  user: root
+  password: root
+EOS
+    on setup_nodes, 'mkdir -p -m 0755 /root/.puppetlabs/bolt'
+    create_remote_file(setup_nodes, '/root/.puppetlabs/bolt/bolt.yaml', bolt_cfg)
   end
 end

--- a/spec/spec_helper_acceptance_windows.rb
+++ b/spec/spec_helper_acceptance_windows.rb
@@ -5,4 +5,15 @@ set :backend, :cmd
 RSpec.configure do |c|
   # Readable test descriptions
   c.formatter = :documentation
+  c.add_setting :skip_apply, default: false
+  c.skip_apply = (ENV['BEAKER_skip_apply'] == 'yes' || ENV['BEAKER_skip_apply'] == 'true')
+  c.before :suite do
+    bolt_cfg = <<-EOS
+modulepath: "C:/ProgramData/PuppetLabs/code/environments/production/modules"
+EOS
+    require 'fileutils'
+    home = File.expand_path('~')
+    FileUtils.mkdir_p(File.join(home, '.puppetlabs\bolt'))
+    File.open(File.join(home, '.puppetlabs\bolt\bolt.yaml'), 'w') { |f| f.write(bolt_cfg) }
+  end
 end

--- a/tasks/agent_event.json
+++ b/tasks/agent_event.json
@@ -1,0 +1,26 @@
+{
+  "description": "Create a Sensu Go agent event via the agent API",
+  "input_method": "stdin",
+  "parameters": {
+    "name": {
+      "description": "The name of the event",
+      "type": "String[1]"
+    },
+    "status": {
+      "description": "The event status",
+      "type": "Integer"
+    },
+    "output": {
+      "description": "The event output",
+      "type": "String[1]"
+    },
+    "ttl": {
+      "description": "The event TTL",
+      "type": "Optional[Integer]"
+    },
+    "port": {
+      "description": "The agent API port, defaults to 3031",
+      "type": "Optional[Integer]"
+    }
+  }
+}

--- a/tasks/agent_event.rb
+++ b/tasks/agent_event.rb
@@ -1,0 +1,37 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'net/http'
+
+begin
+  params = JSON.parse(STDIN.read)
+  name = params['name']
+  status = params['status']
+  output = params['output']
+  ttl = params['ttl']
+  port = params['port'] || 3031
+
+  data = {
+    "check": {
+      "metadata": {
+        "name": name,
+      },
+      "status": status,
+      "output": output,
+    }
+  }
+  data['ttl'] = ttl unless ttl.nil?
+
+  http = Net::HTTP.new('localhost', port)
+  request = Net::HTTP::Post.new('/events', "Content-Type" => "application/json")
+  request.body = data.to_json
+  response = http.request(request)
+  if response.kind_of?(Net::HTTPSuccess)
+    puts({ status: "agent event successful" }.to_json)
+  else
+    puts({ status: "agent event failure: #{response.code}"}.to_json)
+  end
+rescue Exception => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end
+exit 0

--- a/tasks/check_execute.json
+++ b/tasks/check_execute.json
@@ -1,0 +1,22 @@
+{
+  "description": "Execute a Sensu Go check",
+  "input_method": "stdin",
+  "parameters": {
+    "check": {
+      "description": "The name of the check to execute",
+      "type": "String[1]"
+    },
+    "subscription": {
+      "description": "The subscription",
+      "type": "Optional[String[1]]"
+    },
+    "namespace": {
+      "description": "The namespace, defaults to `default`",
+      "type": "Optional[String[1]]"
+    },
+    "reason": {
+      "description": "Explanation for the creation of this entry.",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/tasks/check_execute.rb
+++ b/tasks/check_execute.rb
@@ -1,0 +1,32 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'open3'
+require 'tempfile'
+
+begin
+  params = JSON.parse(STDIN.read)
+  check = params['check']
+  subscription = params['subscription']
+  namespace = params['namespace'] || 'default'
+  reason = params['reason']
+
+  cmd = ['sensuctl','check','execute',check,'--namespace',namespace]
+  if subscription
+    cmd << '--subscriptions'
+    cmd << subscription
+  end
+  if reason
+    cmd << '--reason'
+    cmd << reason
+  end
+  stdout, stderr, status = Open3.capture3(cmd.join(' '))
+  if status != 0
+    raise Exception, "Failed to execute #{cmd.join(' ')}: #{stdout + stderr}"
+  end
+
+  puts({ status: "check execute successful" }.to_json)
+rescue Exception => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end
+exit 0

--- a/tasks/event.json
+++ b/tasks/event.json
@@ -1,0 +1,22 @@
+{
+  "description": "Manage Sensu Go events",
+  "input_method": "stdin",
+  "parameters": {
+    "action": {
+      "description": "The action to perform",
+      "type": "Enum[resolve,delete]"
+    },
+    "entity": {
+      "description": "The entity for event",
+      "type": "String[1]"
+    },
+    "check": {
+      "description": "The check for event",
+      "type": "String[1]"
+    },
+    "namespace": {
+      "description": "The namespace for event",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/tasks/event.rb
+++ b/tasks/event.rb
@@ -34,4 +34,3 @@ rescue Puppet::Error => e
   puts({ status: 'failure', error: e.message }.to_json)
   exit 1
 end
-

--- a/tasks/event.rb
+++ b/tasks/event.rb
@@ -1,0 +1,37 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'open3'
+require 'puppet'
+
+def resolve(entity, check, namespace)
+  _stdout, stderr, status = Open3.capture3('sensuctl', 'event', 'resolve', entity, check, '--namespace', namespace)
+  raise Puppet::Error, stderr if status != 0
+  { status: "resolve successful" }
+end
+
+def delete(entity, check, namespace)
+  _stdout, stderr, status = Open3.capture3('sensuctl', 'event', 'delete', entity, check, '--skip-confirm', '--namespace', namespace)
+  raise Puppet::Error, stderr if status != 0
+  { status: "delete successful" }
+end
+
+begin
+  params = JSON.parse(STDIN.read)
+  action = params['action']
+  entity = params['entity']
+  check = params['check']
+  namespace = params['namespace'] || 'default'
+
+  case action
+  when 'resolve'
+    result = resolve(entity, check, namespace)
+  when 'delete'
+    result = delete(entity, check, namespace)
+  end
+  puts result.to_json
+  exit 0
+rescue Puppet::Error => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end
+

--- a/tasks/install_agent.json
+++ b/tasks/install_agent.json
@@ -4,11 +4,11 @@
   "parameters": {
     "backend": {
       "description": "The backend(s) to connect agent to",
-      "type": "Variant[Array, String]"
+      "type": "String[1]"
     },
     "subscription": {
       "description": "The subscription(s) for the agent",
-      "type": "Variant[Array, String]"
+      "type": "String[1]"
     },
     "namespace": {
       "description": "The namespace for the agent, default is 'default'",

--- a/tasks/install_agent.json
+++ b/tasks/install_agent.json
@@ -16,6 +16,7 @@
     }
   },
   "implementations": [
-    {"name": "install_agent_linux.rb", "requirements": ["shell"]}
+    {"name": "install_agent_linux.rb", "requirements": ["shell"]},
+    {"name": "install_agent_windows.ps1", "requirements": ["powershell"], "input_method": "powershell"}
   ]
 }

--- a/tasks/install_agent.json
+++ b/tasks/install_agent.json
@@ -13,6 +13,10 @@
     "namespace": {
       "description": "The namespace for the agent, default is 'default'",
       "type": "Optional[String[1]]"
+    },
+    "output": {
+      "description": "Return output from commands",
+      "type": "Optional[Boolean]"
     }
   },
   "implementations": [

--- a/tasks/install_agent.json
+++ b/tasks/install_agent.json
@@ -1,0 +1,21 @@
+{
+  "description": "Install Sensu Go agent",
+  "input_method": "stdin",
+  "parameters": {
+    "backend": {
+      "description": "The backend(s) to connect agent to",
+      "type": "Variant[Array, String]"
+    },
+    "subscription": {
+      "description": "The subscription(s) for the agent",
+      "type": "Variant[Array, String]"
+    },
+    "namespace": {
+      "description": "The namespace for the agent, default is 'default'",
+      "type": "Optional[String[1]]"
+    }
+  },
+  "implementations": [
+    {"name": "install_agent_linux.rb", "requirements": ["shell"]}
+  ]
+}

--- a/tasks/install_agent_linux.json
+++ b/tasks/install_agent_linux.json
@@ -1,0 +1,5 @@
+{
+  "name": "Install Agent Linux",
+  "description": "Install Sensu Go agent on Linux",
+  "private": true
+}

--- a/tasks/install_agent_linux.json
+++ b/tasks/install_agent_linux.json
@@ -1,5 +1,6 @@
 {
   "name": "Install Agent Linux",
   "description": "Install Sensu Go agent on Linux",
-  "private": true
+  "private": true,
+  "parameters": []
 }

--- a/tasks/install_agent_linux.rb
+++ b/tasks/install_agent_linux.rb
@@ -58,4 +58,3 @@ rescue Puppet::Error => e
   puts({ status: 'failure', error: e.message }.to_json)
   exit 1
 end
-

--- a/tasks/install_agent_linux.rb
+++ b/tasks/install_agent_linux.rb
@@ -1,0 +1,60 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'open3'
+require 'puppet'
+require 'tempfile'
+
+begin
+  params = JSON.parse(STDIN.read)
+  backend = params['backend']
+  if backend.is_a?(String)
+    backend = [backend]
+  end
+  subscription = params['subscription']
+  if subscription.is_a?(String)
+    subscription = [subscription]
+  end
+  namespace = params['namespace'] || 'default'
+  backends_param = backend.map { |b| "'#{b}'" }.join(',')
+  subscriptions_param = subscription.map { |b| "'#{b}'" }.join(',')
+
+  puppet = '/opt/puppetlabs/bin/puppet'
+  _stdout, stderr, status = Open3.capture3(puppet,'module','install','sensu-sensu')
+  if status != 0
+    raise Puppet::Error, "Failed to execute install sensu-sensu: #{_stdout + _stderr}"
+  end
+
+  `which apt 2>/dev/null 1>/dev/null`
+  if $?.success?
+    _stdout, stderr, status = Open3.capture3(puppet,'module','install','puppetlabs-apt')
+    if status != 0
+      raise Puppet::Error, "Failed to execute install puppetlabs-apt: #{_stdout + _stderr}"
+    end
+  end
+  f = Tempfile.new('manifest')
+  manifest = <<-EOS
+class { '::sensu':
+  use_ssl => false,
+}
+class { '::sensu::agent':
+  backends    => [#{backends_param}],
+  config_hash => {
+    'subscriptions' => [#{subscriptions_param}],
+    'namespace'     => '#{namespace}',
+  },
+}
+EOS
+  f.write(manifest)
+  f.close
+  _stdout, stderr, status = Open3.capture3(puppet,'apply',f.path)
+  if status != 0
+    raise Puppet::Error, "Failed to execute install sensu-sensu: #{_stdout + _stderr}"
+  end
+
+  puts({ status: "install agent successful" }.to_json)
+  exit 0
+rescue Puppet::Error => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end
+

--- a/tasks/install_agent_linux.rb
+++ b/tasks/install_agent_linux.rb
@@ -7,16 +7,8 @@ require 'tempfile'
 begin
   params = JSON.parse(STDIN.read)
   backend = params['backend']
-  if backend.is_a?(String)
-    backend = [backend]
-  end
   subscription = params['subscription']
-  if subscription.is_a?(String)
-    subscription = [subscription]
-  end
   namespace = params['namespace'] || 'default'
-  backends_param = backend.map { |b| "'#{b}'" }.join(',')
-  subscriptions_param = subscription.map { |b| "'#{b}'" }.join(',')
 
   puppet = '/opt/puppetlabs/bin/puppet'
   _stdout, stderr, status = Open3.capture3(puppet,'module','install','sensu-sensu')
@@ -37,9 +29,9 @@ class { '::sensu':
   use_ssl => false,
 }
 class { '::sensu::agent':
-  backends    => [#{backends_param}],
+  backends    => ['#{backend}'],
   config_hash => {
-    'subscriptions' => [#{subscriptions_param}],
+    'subscriptions' => ['#{subscription}'],
     'namespace'     => '#{namespace}',
   },
 }

--- a/tasks/install_agent_linux.rb
+++ b/tasks/install_agent_linux.rb
@@ -13,12 +13,14 @@ begin
 
   return_output = {}
   puppet = '/opt/puppetlabs/bin/puppet'
+  # Install sensu module
   _stdout, _stderr, status = Open3.capture3(puppet,'module','install','sensu-sensu','--color','false')
   return_output['module-install'] = _stdout + _stderr
   if status != 0
     raise Puppet::Error, "Failed to execute install sensu-sensu: #{_stdout + _stderr}"
   end
 
+  # Install apt module for apt systems
   `which apt 2>/dev/null 1>/dev/null`
   if $?.success?
     _stdout, _stderr, status = Open3.capture3(puppet,'module','install','puppetlabs-apt','--color','false')
@@ -28,6 +30,8 @@ begin
     end
   end
   return_output['module-install'] = return_output['module-install'].split(/\n/)
+
+  # Apply sensu and sensu::agent classes to actually install Sensu Go Agent
   f = Tempfile.new('manifest')
   manifest = <<-EOS
 class { '::sensu':

--- a/tasks/install_agent_windows.json
+++ b/tasks/install_agent_windows.json
@@ -1,0 +1,6 @@
+{
+  "name": "Install Agent Windows",
+  "description": "Install Sensu Go agent on Windows",
+  "input_method": "powershell",
+  "private": true
+}

--- a/tasks/install_agent_windows.json
+++ b/tasks/install_agent_windows.json
@@ -2,5 +2,6 @@
   "name": "Install Agent Windows",
   "description": "Install Sensu Go agent on Windows",
   "input_method": "powershell",
-  "private": true
+  "private": true,
+  "parameters": []
 }

--- a/tasks/install_agent_windows.ps1
+++ b/tasks/install_agent_windows.ps1
@@ -1,0 +1,37 @@
+[CmdletBinding()]
+Param(
+  [Parameter(Mandatory = $True)] [String] $Backend,
+  [Parameter(Mandatory = $True)] [String] $Subscription,
+  [Parameter(Mandatory = $False)] [String] $Namespace = "default"
+)
+
+$Package_source = "https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.13.1/sensu-go-agent_5.13.1.5957_en-US.x64.msi"
+
+$env:PATH += ";C:\Program Files\Puppet Labs\Puppet\bin"
+
+$output = iex "puppet module install sensu-sensu"
+$output = iex "puppet module install puppet-archive"
+
+$MANIFEST = [System.IO.Path]::GetTempFileName()
+$manifest_content = @"
+class { '::sensu':
+  use_ssl => false,
+}
+class { '::sensu::agent':
+  package_source => '$Package_source',
+  backends       => ['$Backend'],
+  config_hash    => {
+    'subscriptions' => ['$Subscription'],
+    'namespace'     => '$Namespace',
+  },
+}
+"@
+
+$manifest_content | Out-File -FilePath $MANIFEST -Encoding ascii
+
+$output = iex "puppet apply $MANIFEST"
+
+Remove-Item -Path $MANIFEST
+
+ConvertTo-Json -InputObject @{"status" = "install agent successful"} -Compress
+

--- a/tasks/install_agent_windows.ps1
+++ b/tasks/install_agent_windows.ps1
@@ -11,11 +11,14 @@ $Package_source = "https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.13.1/s
 $env:PATH += ";C:\Program Files\Puppet Labs\Puppet\bin"
 
 $return_output = @{}
+
+# Install modules
 $module_output1 = iex "puppet module install sensu-sensu --color false"
 $module_output2 = iex "puppet module install puppet-archive --color false"
 $module_install_output = $module_output1 + $module_output2
 $return_output.Add("module-install", $($module_install_output -Split "`n").TrimEnd("`r"))
 
+# Create Puppet manifest in Temp space
 $MANIFEST = [System.IO.Path]::GetTempFileName()
 $manifest_content = @"
 class { '::sensu':
@@ -35,6 +38,7 @@ $return_output.Add("manifest", $($manifest_content -Split "`n").TrimEnd("`r"))
 $manifest_content | Out-File -FilePath $MANIFEST -Encoding ascii
 $manifest_content = Get-Content -Path $MANIFEST
 
+# Apply manifest that installs Sensu Go Agent
 $output_apply = iex "puppet apply $MANIFEST --color false 2>&1"
 $return_output.Add("apply", $($output_apply -Split "`n").TrimEnd("`r"))
 

--- a/tasks/install_agent_windows.ps1
+++ b/tasks/install_agent_windows.ps1
@@ -10,9 +10,13 @@ $Package_source = "https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.13.1/s
 $env:PATH += ";C:\Program Files\Puppet Labs\Puppet\bin"
 
 $output = iex "puppet module install sensu-sensu"
+Write-Output $output
 $output = iex "puppet module install puppet-archive"
+Write-Output $output
 
-$MANIFEST = [System.IO.Path]::GetTempFileName()
+#$MANIFEST = [System.IO.Path]::GetTempFileName()
+$MANIFEST = "C:/manifest.pp"
+Write-Output $MANIFEST
 $manifest_content = @"
 class { '::sensu':
   use_ssl => false,
@@ -28,10 +32,18 @@ class { '::sensu::agent':
 "@
 
 $manifest_content | Out-File -FilePath $MANIFEST -Encoding ascii
+$manifest_content = Get-Content -Path $MANIFEST
+Write-Output $manifest_content
 
-$output = iex "puppet apply $MANIFEST"
+Write-Output "Execute: puppet apply $MANIFEST"
+$output = iex "puppet apply -v --debug --trace $MANIFEST 2>&1"
+$output | Out-File -FilePath C:\output
+Write-Output $output
 
 Remove-Item -Path $MANIFEST
 
-ConvertTo-Json -InputObject @{"status" = "install agent successful"} -Compress
+$return = @{
+status = "install agent successful"
+}
+ConvertTo-Json -InputObject $return -Compress
 

--- a/tasks/install_agent_windows.ps1
+++ b/tasks/install_agent_windows.ps1
@@ -45,4 +45,3 @@ status = "install agent successful"
 }
 if ($Output -eq $True) { $return.Add("output", $return_output) }
 ConvertTo-Json -InputObject $return -Compress
-

--- a/tasks/silenced.json
+++ b/tasks/silenced.json
@@ -1,0 +1,42 @@
+{
+  "description": "Manage Sensu Go silencings",
+  "input_method": "stdin",
+  "parameters": {
+    "action": {
+      "description": "The action to perform",
+      "type": "Enum[create,update,delete]"
+    },
+    "subscription": {
+      "description": "The subscription to silence",
+      "type": "Optional[String[1]]"
+    },
+    "check": {
+      "description": "The check to silence",
+      "type": "Optional[String[1]]"
+    },
+    "namespace": {
+      "description": "The namespace for silenced resources",
+      "type": "Optional[String[1]]"
+    },
+    "begin": {
+      "description": "Time at which silence entry goes into effect, in epoch.",
+      "type": "Optional[Integer]"
+    },
+    "expire": {
+      "description": "Number of seconds until this entry should be deleted.",
+      "type": "Optional[Integer]"
+    },
+    "expire_on_resolve": {
+      "description": "If the entry should be deleted when a check begins return OK status (resolves).",
+      "type": "Optional[Boolean]"
+    },
+    "creator": {
+      "description": "Person/application/entity responsible for creating the entry.",
+      "type": "Optional[String]"
+    },
+    "reason": {
+      "description": "Explanation for the creation of this entry.",
+      "type": "Optional[String]"
+    }
+  }
+}

--- a/tasks/silenced.rb
+++ b/tasks/silenced.rb
@@ -1,0 +1,66 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'open3'
+require 'puppet'
+require 'tempfile'
+
+def sensuctl_create(name, spec, namespace)
+  data = {
+    type: "Silenced",
+    api_version: "core/v2",
+    metadata: { name: name, namespace: namespace },
+    spec: spec
+  }
+  f = Tempfile.new('sensuctl')
+  f.write(JSON.pretty_generate(data))
+  f.close
+  _stdout, stderr, status = Open3.capture3('sensuctl', 'create', '-f', f.path)
+  raise Puppet::Error, stderr if status != 0
+  { status: "sensuctl create successful" }
+end
+
+def delete(name, namespace)
+  _stdout, stderr, status = Open3.capture3('sensuctl', 'silenced', 'delete', name, '--skip-confirm', '--namespace', namespace)
+  raise Puppet::Error, stderr if status != 0
+  { status: "delete successful" }
+end
+
+begin
+  params = JSON.parse(STDIN.read)
+  action = params['action']
+  subscription = params['subscription']
+  check = params['check']
+  namespace = params['namespace'] || 'default'
+
+  if subscription && check
+    name = "#{subscription}:#{check}"
+  elsif check
+    name = "*:#{check}"
+  elsif subscription
+    name = "#{subscription}:*"
+  else
+    raise Puppet::Error, "must provide subscription and/or check"
+  end
+
+  case action
+  when 'delete'
+    result = delete(name, namespace)
+  else
+    spec = {
+      check: check,
+      subscription: subscription,
+      begin: params['begin'],
+      expire: params['expire'].nil? ? -1 : params['expire'],
+      expire_on_resolve: params['expire_on_resolve'].nil? ? false : params['expire_on_resolve'],
+      creator: params['creator'],
+      reason: params['reason'],
+    }
+    result = sensuctl_create(name, spec, namespace)
+  end
+  puts result.to_json
+  exit 0
+rescue Puppet::Error => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end
+

--- a/tasks/silenced.rb
+++ b/tasks/silenced.rb
@@ -63,4 +63,3 @@ rescue Puppet::Error => e
   puts({ status: 'failure', error: e.message }.to_json)
   exit 1
 end
-

--- a/tests/test_bolt_win.ps1
+++ b/tests/test_bolt_win.ps1
@@ -1,0 +1,10 @@
+#$env:PATH += ";C:\Program Files\sensu\sensu-agent\bin"
+$env:PATH += ";C:\Program Files\Puppet Labs\Puppet\bin"
+#iex 'sensu-agent.exe service uninstall'
+#iex 'puppet resource package "Sensu Agent" ensure=absent'
+iex "puppet module install puppetlabs-chocolatey"
+iex "puppet apply -e 'include ::chocolatey'"
+$env:PATH += ";C:\ProgramData\chocolatey\bin"
+iex "choco install -y puppet-bolt"
+$env:PATH += ";C:\Program Files\Puppet Labs\Bolt\bin"
+iex 'bolt task run sensu::install_agent backend=sensu-backend.example.com:8081 subscription=windows --nodes localhost --modulepath C:/ProgramData/PuppetLabs/code/environments/production/modules'

--- a/tests/test_bolt_win.ps1
+++ b/tests/test_bolt_win.ps1
@@ -1,7 +1,4 @@
-#$env:PATH += ";C:\Program Files\sensu\sensu-agent\bin"
 $env:PATH += ";C:\Program Files\Puppet Labs\Puppet\bin"
-#iex 'sensu-agent.exe service uninstall'
-#iex 'puppet resource package "Sensu Agent" ensure=absent'
 iex "puppet module install puppetlabs-chocolatey"
 iex "puppet apply -e 'include ::chocolatey'"
 $env:PATH += ";C:\ProgramData\chocolatey\bin"


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add bolt tasks to manage sensuctl events and silencings. These will replace sensu_event and sensu_silenced types removed in #1141 

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Part of #1147 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Events and silencings are ad-hoc tasks so best to move into bolt tasks.