### PR TITLE
BREAKING: Update type properties to map to Sensu Go specifications

### DIFF
--- a/lib/puppet/provider/sensu_check/sensuctl.rb
+++ b/lib/puppet/provider/sensu_check/sensuctl.rb
@@ -19,7 +19,6 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
       check[:labels] = d['metadata']['labels']
       check[:annotations] = d['metadata']['annotations']
       d.each_pair do |key,value|
-        next if key == 'proxy_requests'
         next if key == 'metadata'
         if !!value == value
           value = value.to_s.to_sym
@@ -28,15 +27,6 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
           check[key.to_sym] = value
         else
           next
-        end
-      end
-      if d['proxy_requests']
-        check[:proxy_requests] = :present
-        d['proxy_requests'].each_pair do |k,v|
-          property = "proxy_requests_#{k}".to_sym
-          if type_properties.include?(property)
-            check[property] = v
-          end
         end
       end
       checks << new(check)
@@ -76,7 +66,6 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
       value = resource[property]
       next if value.nil?
       next if value == :absent || value == [:absent]
-      next if property.to_s =~ /^proxy_requests/
       if [:true, :false].include?(value)
         value = convert_boolean_property_value(value)
       end
@@ -89,12 +78,6 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
       else
         spec[property] = value
       end
-    end
-    if resource[:proxy_requests_entity_attributes] ||  resource[:proxy_requests_splay] || resource[:proxy_requests_splay_coverage]
-      spec[:proxy_requests] = {}
-      spec[:proxy_requests][:entity_attributes] = resource[:proxy_requests_entity_attributes] if resource[:proxy_requests_entity_attributes]
-      spec[:proxy_requests][:splay] = convert_boolean_property_value(resource[:proxy_requests_splay]) if resource[:proxy_requests_splay]
-      spec[:proxy_requests][:splay_coverage] = resource[:proxy_requests_splay_coverage] if resource[:proxy_requests_splay_coverage]
     end
     begin
       sensuctl_create('CheckConfig', metadata, spec)
@@ -116,7 +99,6 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
           value = resource[property]
         end
         next if value.nil?
-        next if property.to_s =~ /^proxy_requests/
         if [:true, :false].include?(value)
           value = convert_boolean_property_value(value)
         elsif value == :absent
@@ -131,19 +113,6 @@ Puppet::Type.type(:sensu_check).provide(:sensuctl, :parent => Puppet::Provider::
         else
           spec[property] = value
         end
-      end
-      # Use values from existing resource then overwrite with new values if they exist
-      if resource[:proxy_requests_entity_attributes] || resource[:proxy_requests_splay] || resource[:proxy_requests_splay_coverage]
-        spec[:proxy_requests] = {}
-        spec[:proxy_requests][:entity_attributes] = resource[:proxy_requests_entity_attributes] if resource[:proxy_requests_entity_attributes]
-        spec[:proxy_requests][:splay] = convert_boolean_property_value(resource[:proxy_requests_splay]) if resource[:proxy_requests_splay]
-        spec[:proxy_requests][:splay_coverage] = resource[:proxy_requests_splay_coverage] if resource[:proxy_requests_splay_coverage]
-      end
-      if @property_flush[:proxy_requests_entity_attributes] || @property_flush[:proxy_requests_splay] || @property_flush[:proxy_requests_splay_coverage]
-        spec[:proxy_requests] = {} unless spec[:proxy_requests]
-        spec[:proxy_requests][:entity_attributes] = @property_flush[:proxy_requests_entity_attributes] if @property_flush[:proxy_requests_entity_attributes]
-        spec[:proxy_requests][:splay] = convert_boolean_property_value(@property_flush[:proxy_requests_splay]) if @property_flush[:proxy_requests_splay]
-        spec[:proxy_requests][:splay_coverage] = @property_flush[:proxy_requests_splay_coverage] if @property_flush[:proxy_requests_splay_coverage]
       end
       begin
         sensuctl_create('CheckConfig', metadata, spec)

--- a/lib/puppet/provider/sensu_entity/sensuctl.rb
+++ b/lib/puppet/provider/sensu_entity/sensuctl.rb
@@ -23,9 +23,7 @@ Puppet::Type.type(:sensu_entity).provide(:sensuctl, :parent => Puppet::Provider:
         if !!value == value
           value = value.to_s.to_sym
         end
-        if key == 'deregistration'
-          entity[:deregistration_handler] = value['handler']
-        elsif type_properties.include?(key.to_sym)
+        if type_properties.include?(key.to_sym)
           entity[key.to_sym] = value
         else
           next
@@ -73,9 +71,7 @@ Puppet::Type.type(:sensu_entity).provide(:sensuctl, :parent => Puppet::Provider:
       if [:true, :false].include?(value)
         value = convert_boolean_property_value(value)
       end
-      if property == :deregistration_handler
-        spec[:deregistration] = {handler: value}
-      elsif property == :namespace
+      if property == :namespace
         metadata[:namespace] = value
       elsif property == :labels
         metadata[:labels] = value
@@ -117,9 +113,7 @@ Puppet::Type.type(:sensu_entity).provide(:sensuctl, :parent => Puppet::Provider:
         elsif value == :absent
           value = nil
         end
-        if property == :deregistration_handler
-          spec[:deregistration] = {handler: value}
-        elsif property == :namespace
+        if property == :namespace
           metadata[:namespace] = value
         elsif property == :labels
           metadata[:labels] = value

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -178,17 +178,42 @@ DESC
     newvalues(:true, :false)
   end
 
-  newproperty(:proxy_requests_entity_attributes, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
-    desc "Sensu entity attributes to match entities in the registry, using Sensu Query Expressions"
-  end
+  newproperty(:proxy_requests, :parent => PuppetX::Sensu::HashProperty) do
+    desc <<-EOS
+    Proxy requests attributes
 
-  newproperty(:proxy_requests_splay, :boolean => true) do
-    desc "If proxy check requests should be splayed"
-    newvalues(:true, :false)
-  end
-
-  newproperty(:proxy_requests_splay_coverage, :parent => PuppetX::Sensu::IntegerProperty) do
-    desc "The splay coverage percentage use for proxy check request splay calculation."
+    Valid keys:
+    * entity_attributes - Optional Array
+    * splay - Optional Boolean (default: false)
+    * splay_coverage - Optional Integer (default: 0)
+    EOS
+    validate do |value|
+      super(value)
+      valid_keys = ['entity_attributes','splay','splay_coverage']
+      value.keys.each do |key|
+        if ! valid_keys.include?(key)
+          raise ArgumentError, "#{key} is not a valid key for proxy_requests"
+        end
+      end
+      if value.key?('entity_attributes') && ! value['entity_attributes'].is_a?(Array)
+        raise ArgumentError, "proxy_requests.entity_attributes must be an Array"
+      end
+      if value.key?('splay') && !!value['splay'] != value['splay']
+        raise ArgumentError, "proxy_requests.splay must be a Boolean"
+      end
+      if value.key?('splay_coverage') && ! value['splay_coverage'].is_a?(Integer)
+        raise ArgumentError, "proxy_requests.splay_coverage must be an Integer"
+      end
+    end
+    munge do |v|
+      if ! v.key?('splay')
+        v['splay'] = false
+      end
+      if ! v.key?('splay_coverage')
+        v['splay_coverage'] = 0
+      end
+      v
+    end
   end
 
   newproperty(:silenced, :boolean => true) do

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -16,7 +16,9 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
           { 1          => ['test.sh'] },
           { 'critical' => ['httpd-restart'] },
         ],
-        proxy_requests_entity_attributes => ["entity.Class == 'proxy'"],
+        proxy_requests                   => {
+          'entity_attributes' => ["entity.Class == 'proxy'"],
+        },
         output_metric_format             => 'nagios_perfdata',
         labels                           => { 'foo' => 'baz' }
       }
@@ -116,7 +118,9 @@ describe 'sensu_check', if: RSpec.configuration.sensu_full do
           { 'critical' => ['httpd-restart'] },
           { 'warning'  => ['httpd-restart'] },
         ],
-        proxy_requests_entity_attributes => ['System.OS==linux'],
+        proxy_requests                   => {
+          'entity_attributes' => ['System.OS==linux'],
+        },
         output_metric_format             => 'graphite_plaintext',
         labels                           => { 'foo' => 'bar' }
       }

--- a/spec/acceptance/sensu_entity_spec.rb
+++ b/spec/acceptance/sensu_entity_spec.rb
@@ -8,7 +8,7 @@ describe 'sensu_entity', if: RSpec.configuration.sensu_full do
       include ::sensu::backend
       sensu_entity { 'test':
         entity_class           => 'proxy',
-        deregistration_handler => 'slack-handler',
+        deregistration         => {'handler' => 'slack-handler'},
       }
       EOS
 
@@ -41,7 +41,7 @@ describe 'sensu_entity', if: RSpec.configuration.sensu_full do
       include ::sensu::backend
       sensu_entity { 'test':
         entity_class           => 'proxy',
-        deregistration_handler => 'email-handler',
+        deregistration         => {'handler' => 'email-handler'},
         labels                 => { 'foo' => 'bar' }
       }
       EOS

--- a/spec/acceptance/sensu_handler_spec.rb
+++ b/spec/acceptance/sensu_handler_spec.rb
@@ -14,8 +14,7 @@ describe 'sensu_handler', if: RSpec.configuration.sensu_full do
       }
       sensu_handler { 'test2':
         type           => 'tcp',
-        socket_host    => '127.0.0.1',
-        socket_port    => 1234,
+        socket         => {'host' => '127.0.0.1', 'port' => 1234},
         labels         => { 'foo' => 'bar' },
       }
       EOS
@@ -67,8 +66,7 @@ describe 'sensu_handler', if: RSpec.configuration.sensu_full do
       }
       sensu_handler { 'test2':
         type           => 'tcp',
-        socket_host    => 'localhost',
-        socket_port    => 5678,
+        socket         => {'host' => 'localhost', 'port' => 5678},
         labels         => { 'foo' => 'bar' },
       }
       EOS

--- a/spec/classes/backend_resources_spec.rb
+++ b/spec/classes/backend_resources_spec.rb
@@ -172,8 +172,7 @@ describe 'sensu::backend::resources', :type => :class do
               'test' => {
                 'type'        => 'pipe',
                 'command'     => 'test',
-                'socket_host' => '127.0.0.1',
-                'socket_port' => 9000,
+                'socket'      => {'host' => '127.0.0.1', 'port' => 9000},
               }
             }
           }

--- a/spec/unit/provider/sensu_check/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_check/sensuctl_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
       resource[:handlers] = ['email', 'slack']
       resource[:stdin] = true
       resource[:publish] = false
-      resource[:proxy_requests_entity_attributes] = ["entity.Class == 'proxy'"]
+      resource[:proxy_requests] = {'entity_attributes' => ["entity.Class == 'proxy'"]}
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -44,7 +44,7 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
         :interval => 60,
         :stdin => true,
         :publish => false,
-        :proxy_requests => { :entity_attributes => ["entity.Class == 'proxy'"] }
+        :proxy_requests => { "entity_attributes" => ["entity.Class == 'proxy'"], "splay" => false, "splay_coverage" => 0 }
       }
       expect(resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
       resource.provider.create
@@ -55,7 +55,6 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
 
   describe 'flush' do
     it 'should update a check proxy_requests' do
-      resource[:proxy_requests_splay] = true
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -67,10 +66,10 @@ describe Puppet::Type.type(:sensu_check).provider(:sensuctl) do
         :publish => true,
         :stdin => false,
         :handlers => ['slack'],
-        :proxy_requests => { :splay => true, :entity_attributes => ["entity.Class == 'proxy'"] }
+        :proxy_requests => { "splay" => true, "entity_attributes" => ["entity.Class == 'proxy'"] }
       }
       expect(resource.provider).to receive(:sensuctl_create).with('CheckConfig', expected_metadata, expected_spec)
-      resource.provider.proxy_requests_entity_attributes = ["entity.Class == 'proxy'"]
+      resource.provider.proxy_requests = {'entity_attributes' => ["entity.Class == 'proxy'"], 'splay' => true}
       resource.provider.flush
     end
     it 'should update a check' do

--- a/spec/unit/provider/sensu_handler/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_handler/sensuctl_spec.rb
@@ -27,8 +27,7 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
   describe 'create' do
     it 'should create a handler' do
       resource[:filters] = ["recurrence", "production"]
-      resource[:socket_host] = "localhost"
-      resource[:socket_port] = 9000
+      resource[:socket] = {'host' => "localhost", 'port' => 9000}
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -37,7 +36,7 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
         :type => :pipe,
         :command => 'test',
         :filters => ["recurrence", "production"],
-        :socket => {:host => "localhost", :port => 9000}
+        :socket => {"host" => "localhost", "port" => 9000}
       }
       expect(resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
       resource.provider.create
@@ -49,8 +48,6 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
   describe 'flush' do
     it 'should update a handler socket' do
       resource[:type] = 'tcp'
-      resource[:socket_host] = "localhost"
-      resource[:socket_port] = 9000
       expected_metadata = {
         :name => 'test',
         :namespace => 'default',
@@ -58,10 +55,10 @@ describe Puppet::Type.type(:sensu_handler).provider(:sensuctl) do
       expected_spec = {
         :type => :tcp,
         :command => 'test',
-        :socket => { :host => 'localhost', :port => 9001 }
+        :socket => { 'host' => 'localhost', 'port' => 9001 }
       }
       expect(resource.provider).to receive(:sensuctl_create).with('Handler', expected_metadata, expected_spec)
-      resource.provider.socket_port = 9001
+      resource.provider.socket = {'host' => 'localhost', 'port' => 9001}
       resource.provider.flush
     end
     it 'should remove timeout' do

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -102,7 +102,6 @@ describe Puppet::Type.type(:sensu_check) do
     :subscriptions,
     :handlers,
     :runtime_assets,
-    :proxy_requests_entity_attributes,
     :output_metric_handlers,
     :env_vars
   ].each do |property|
@@ -127,7 +126,6 @@ describe Puppet::Type.type(:sensu_check) do
     :timeout,
     :low_flap_threshold,
     :high_flap_threshold,
-    :proxy_requests_splay_coverage,
     :max_output_size,
   ].each do |property|
     it "should accept valid #{property}" do
@@ -158,7 +156,6 @@ describe Puppet::Type.type(:sensu_check) do
     :publish,
     :stdin,
     :round_robin,
-    :proxy_requests_splay,
     :silenced,
     :discard_output,
   ].each do |property|
@@ -332,6 +329,33 @@ describe Puppet::Type.type(:sensu_check) do
     it 'should not accept invalid values' do
       config[:output_metric_format] = 'foo'
       expect { check }.to raise_error(Puppet::Error, /Invalid value "foo". Valid values are nagios_perfdata, graphite_plaintext, influxdb_line, opentsdb_line, absent/)
+    end
+  end
+
+  describe 'proxy_requests' do
+    it 'accepts valid value' do
+      config[:proxy_requests] = {'entity_attributes' => ['foo==bar'],'splay' => true, 'splay_coverage' => 60}
+      expect(check[:proxy_requests]).to eq({'entity_attributes' => ['foo==bar'],'splay' => true, 'splay_coverage' => 60})
+    end
+    it 'requires a hash' do
+      config[:proxy_requests] = 'foo'
+      expect { check }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+    it 'does not accept invalid key' do
+      config[:proxy_requests] = {'foo' => 'bar'}
+      expect { check }.to raise_error(Puppet::Error, /foo is not a valid key for proxy_requests/)
+    end
+    it 'requires array for entity_attributes' do
+      config[:proxy_requests] = {'entity_attributes' => 'foo==bar','splay' => true, 'splay_coverage' => 60}
+      expect { check }.to raise_error(Puppet::Error, /must be an Array/)
+    end
+    it 'requires boolean for splay' do
+      config[:proxy_requests] = {'entity_attributes' => ['foo==bar'],'splay' => 'foo', 'splay_coverage' => 60}
+      expect { check }.to raise_error(Puppet::Error, /must be a Boolean/)
+    end
+    it 'requires integer for splay_coverage' do
+      config[:proxy_requests] = {'entity_attributes' => ['foo==bar'],'splay' => true, 'splay_coverage' => 'foo'}
+      expect { check }.to raise_error(Puppet::Error, /must be an Integer/)
     end
   end
 

--- a/spec/unit/sensu_entity_spec.rb
+++ b/spec/unit/sensu_entity_spec.rb
@@ -73,7 +73,6 @@ describe Puppet::Type.type(:sensu_entity) do
 
   # String properties
   [
-    :deregistration_handler,
     :namespace,
   ].each do |property|
     it "should accept valid #{property}" do
@@ -207,6 +206,25 @@ describe Puppet::Type.type(:sensu_entity) do
     end
   end
 
+  describe 'deregistration' do
+    it 'accepts valid value' do
+      config[:deregistration] = {'handler' => 'test'}
+      expect(entity[:deregistration]).to eq({'handler' => 'test'})
+    end
+    it 'requires a hash' do
+      config[:deregistration] = 'foo'
+      expect { entity }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+    it 'does not accept invalid key' do
+      config[:deregistration] = {'foo' => 'bar'}
+      expect { entity }.to raise_error(Puppet::Error, /foo is not a valid key for deregistration/)
+    end
+    it 'requires string for handler' do
+      config[:deregistration] = {'handler' => ['test']}
+      expect { entity }.to raise_error(Puppet::Error, /must be a String/)
+    end
+  end
+
   include_examples 'autorequires' do
     let(:res) { entity }
   end
@@ -214,7 +232,7 @@ describe Puppet::Type.type(:sensu_entity) do
   it 'should autorequire sensu_handler' do
     handler = Puppet::Type.type(:sensu_handler).new(:name => 'test', :type => 'pipe', :command => 'test')
     catalog = Puppet::Resource::Catalog.new
-    config[:deregistration_handler] = ['test']
+    config[:deregistration] = {'handler' => 'test'}
     catalog.add_resource entity
     catalog.add_resource handler
     rel = entity.autorequire[0]

--- a/spec/unit/sensu_handler_spec.rb
+++ b/spec/unit/sensu_handler_spec.rb
@@ -7,8 +7,7 @@ describe Puppet::Type.type(:sensu_handler) do
       name: 'test',
       type: 'pipe',
       command: 'test',
-      socket_host: '127.0.0.1',
-      socket_port: 9000,
+      socket: {'host' => '127.0.0.1', 'port' => 9000},
     }
   end
   let(:config) do
@@ -78,7 +77,6 @@ describe Puppet::Type.type(:sensu_handler) do
     :mutator,
     :command,
     :namespace,
-    :socket_host,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = 'foo'
@@ -130,7 +128,6 @@ describe Puppet::Type.type(:sensu_handler) do
   # Integer properties
   [
     :timeout,
-    :socket_port,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = 30
@@ -225,6 +222,32 @@ describe Puppet::Type.type(:sensu_handler) do
     end
   end
 
+  describe 'socket' do
+    it 'accepts valid value' do
+      expect(handler[:socket]).to eq({'host' => '127.0.0.1', 'port' => 9000})
+    end
+    it 'requires a hash' do
+      config[:socket] = 'foo'
+      expect { handler }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+    it 'does not accept invalid key' do
+      config[:socket] = {'host' => '127.0.0.1', 'port' => 9000, 'foo' => 'bar'}
+      expect { handler }.to raise_error(Puppet::Error, /foo is not a valid key for socket/)
+    end
+    it 'requires host' do
+      config[:socket] = {'port' => 9000}
+      expect { handler }.to raise_error(Puppet::Error, /is required for socket/)
+    end
+    it 'requires port' do
+      config[:socket] = {'host' => '127.0.0.1'}
+      expect { handler }.to raise_error(Puppet::Error, /is required for socket/)
+    end
+    it 'requires integer for port' do
+      config[:socket] = {'host' => '127.0.0.1', 'port' => '9000'}
+      expect { handler }.to raise_error(Puppet::Error, /must be an Integer/)
+    end
+  end
+
   include_examples 'autorequires' do
     let(:res) { handler }
   end
@@ -288,25 +311,15 @@ describe Puppet::Type.type(:sensu_handler) do
     expect { handler.pre_run_check }.to raise_error(Puppet::Error, /command must be defined for type pipe/)
   end
 
-  it 'should require socket_host and socket_port' do
-    config.delete(:socket_port)
-    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_port is required if socket_host is set/)
-  end
-  it 'should require socket_host and socket_port' do
-    config.delete(:socket_host)
-    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_host is required if socket_port is set/)
-  end
-  it 'should require socket properties for tcp type' do
-    config.delete(:socket_host)
-    config.delete(:socket_port)
+  it 'should require socket for tcp type' do
+    config.delete(:socket)
     config[:type] = :tcp
-    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_host and socket_port are required for type tcp or type udp/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket is required for type tcp or type udp/)
   end
-  it 'should require socket properties for udp type' do
-    config.delete(:socket_host)
-    config.delete(:socket_port)
+  it 'should require socket for udp type' do
+    config.delete(:socket)
     config[:type] = :udp
-    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket_host and socket_port are required for type tcp or type udp/)
+    expect { handler.pre_run_check }.to raise_error(Puppet::Error, /socket is required for type tcp or type udp/)
   end
   it 'should require handlers for type set' do
     config[:type] = 'set'


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Replace sensu_check proxy_requests* properties with proxy_requests
Replace sensu_entity deregistration_handler with deregistration
Replace sensu_handler socket_* properties with socket

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1144

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This maps Sensu Go specification properties for resources to the Puppet type properties. The only exception is items put into `metadata` in Sensu Go spec.