### PR TITLE
Add sensu_gem package provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ Set `dependencies` to an empty Array to disable the `sensu::plugins` dependency 
   }
 ```
 
+If gems are required and not pulled in as gem dependencies they can also be installed.
+
+```puppet
+class { 'sensu::plugins':
+  plugins          => ['memory-checks'],
+  gem_dependencies => ['vmstat'],
+}
+```
+
 You can uninstall plugins by passing `ensure` as `absent`.
 
 ```puppet

--- a/lib/puppet/provider/package/sensu_gem.rb
+++ b/lib/puppet/provider/package/sensu_gem.rb
@@ -1,0 +1,20 @@
+require 'puppet/provider/package'
+
+# Sensu Embedded Ruby gems support.
+Puppet::Type.type(:package).provide :sensu_gem, :parent => :gem do
+  desc "Sensu Embedded Ruby Gem support. If a URL is passed via `source`, then that URL is
+    appended to the list of remote gem repositories; to ensure that only the
+    specified source is used, also pass `--clear-sources` via `install_options`.
+    If source is present but is not a valid URL, it will be interpreted as the
+    path to a local gem file. If source is not present, the gem will be
+    installed from the default gem repositories. Note that to modify this for Windows, it has to be a valid URL.
+    This provider supports the `install_options` and `uninstall_options` attributes,
+    which allow command-line flags to be passed to the gem command.
+    These options should be specified as an array where each element is either a 
+    string or a hash."
+
+
+  has_feature :versionable, :install_options, :uninstall_options, :targetable
+
+  commands :gemcmd => "/opt/sensu-plugins-ruby/embedded/bin/gem"
+end

--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -28,6 +28,8 @@
 # @param dependencies
 #   Package dependencies needed to install plugins and extensions.
 #   Default is OS dependent.
+# @param gem_dependencies
+#   Gem dependencies.
 # @param plugins
 #   Plugins to install
 # @param extensions
@@ -38,6 +40,7 @@ class sensu::plugins (
   String $package_ensure = 'installed',
   String $package_name = 'sensu-plugins-ruby',
   Array $dependencies = [],
+  Array $gem_dependencies = [],
   Variant[Array, Hash] $plugins = [],
   Variant[Array, Hash] $extensions = [],
 ) {
@@ -67,6 +70,7 @@ class sensu::plugins (
   $dependencies.each |$package| {
     Package[$package] -> Sensu_plugin <| |> # lint:ignore:spaceship_operator_without_tag
   }
+  ensure_packages($gem_dependencies, {'provider' => 'sensu_gem', 'require' => [Package[$dependencies],Package['sensu-plugins-ruby']]})
 
   if $plugins =~ Array {
     $plugins.each |$plugin| {

--- a/spec/acceptance/sensu_plugin_spec.rb
+++ b/spec/acceptance/sensu_plugin_spec.rb
@@ -11,7 +11,9 @@ describe 'sensu_plugin', if: RSpec.configuration.sensu_full do
     it 'should work without errors' do
       pp = <<-EOS
       include ::sensu::agent
-      include ::sensu::plugins
+      class { '::sensu::plugins':
+        gem_dependencies => ['vmstat'],
+      }
       sensu_plugin { 'cpu-checks':
         ensure  => 'present',
         version => '2.0.0',
@@ -34,6 +36,12 @@ describe 'sensu_plugin', if: RSpec.configuration.sensu_full do
     it 'should have plugin installed' do
       on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
         expect(stdout).to match(/^sensu-plugins-cpu-checks \(2.0.0\)/)
+      end
+    end
+
+    it 'should have gem installed' do
+      on agent, '/opt/sensu-plugins-ruby/embedded/bin/gem list --local' do
+        expect(stdout).to match(/^vmstat \(/)
       end
     end
   end

--- a/spec/classes/plugins_spec.rb
+++ b/spec/classes/plugins_spec.rb
@@ -93,6 +93,15 @@ describe 'sensu::plugins', :type => :class do
         it { should_not contain_class('sensu::repo::community') }
         it { should contain_package('sensu-plugins-ruby').without_require }
       end
+
+      context 'with gem_dependencies' do
+        let(:params) {{ :gem_dependencies => ['test'] }}
+        it { should contain_package('test').with_provider('sensu_gem') }
+        it { should contain_package('test').that_requires('Package[sensu-plugins-ruby]') }
+        platforms[facts[:osfamily]][:plugins_dependencies].each do |package|
+          it { should contain_package('test').that_requires("Package[#{package}]") }
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `sensu_gem` package provider and add `gem_dependencies` parameter to `sensu::plugins`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1155 .

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allow Sensu plugins gem dependencies to be managed