### PR TITLE
Add sensu_resources type that will handle resource purging

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,8 +437,17 @@ sensu::backend::checks:
 ### Resource purging
 
 All the types provided by this module support purging except `sensu_config`.
-At this time `sensu_asset` can not be purged, see [Limitations](#limitations).
 This example will remove all unmanaged Sensu checks:
+
+```puppet
+sensu_resources { 'sensu_check':
+  purge => true,
+}
+```
+
+**NOTE**: The Puppet built-in `resources` can also be used for purging but you must ensure that resources that support namespaces are defined using composite names in the form of `$name in $namespace`. See [Composite Names for Namespaces](#composite-names-for-namespaces) for details on composite names.
+
+Using the Puppet built-in `resources` would look like this:
 
 ```puppet
 resources { 'sensu_check':
@@ -595,8 +604,6 @@ facter -p sensuctl
 
 The Sensu v2 support is designed so that all resources managed by `sensuctl` are defined on the `sensu-backend` host.
 This module does not support adding `sensuctl` resources on a host other than the `sensu-backend` host.
-
-The type `sensu_asset` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#988](https://github.com/sensu/sensu-go/issues/988).
 
 The type `sensu_user` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#2540](https://github.com/sensu/sensu-go/issues/2540).
 

--- a/lib/puppet/type/sensu_resources.rb
+++ b/lib/puppet/type/sensu_resources.rb
@@ -1,0 +1,101 @@
+require 'puppet'
+require 'puppet/parameter/boolean'
+
+Puppet::Type.newtype(:sensu_resources) do
+  desc <<-DESC
+    @summary Metatype for sensu resources
+
+    @example Purge unmanaged sensu_check resources
+      sensu_resources { 'sensu_check':
+        purge => true,
+      }
+  DESC
+
+  newparam(:name) do
+    desc "The name of the type to be managed."
+
+    validate do |name|
+      raise ArgumentError, _("Only supported with sensu module types") unless name =~ /^sensu_/
+      raise ArgumentError, _("Could not find resource type '%{name}'") % { name: name } unless Puppet::Type.type(name)
+    end
+
+    munge { |v| v.to_s }
+  end
+
+  newparam(:purge, :boolean => true, :parent => Puppet::Parameter::Boolean) do
+    desc "Whether to purge unmanaged sensu resources.  When set to `true`, this will
+      delete any resource that is not specified in your configuration and is not
+      autorequired by any managed resources."
+
+    defaultto :false
+    newvalues(:true, :false)
+
+    validate do |value|
+      if munge(value)
+        unless @resource.resource_type.respond_to?(:instances)
+          raise ArgumentError, _("Purging resources of type %{res_type} is not supported, since they cannot be queried from the system") % { res_type: @resource[:name] }
+        end
+        raise ArgumentError, _("Purging is only supported on types that accept 'ensure'") unless @resource.resource_type.validproperty?(:ensure)
+      end
+    end
+  end
+
+  def able_to_ensure_absent?(resource)
+      resource[:ensure] = :absent
+  rescue ArgumentError, Puppet::Error
+      err _("The 'ensure' attribute on %{name} resources does not accept 'absent' as a value") % { name: self[:name] }
+      false
+  end
+
+  # Generate any new resources we need to manage.  This is pretty hackish
+  # right now, because it only supports purging.
+  def generate
+    return [] unless self.purge?
+    resource_type.instances.
+      reject { |r| catalog.resource_refs.include? r.ref }.
+      select { |r| check(r) }.
+      select { |r| r.class.validproperty?(:ensure) }.
+      select { |r| able_to_ensure_absent?(r) }.
+      each { |resource|
+        @parameters.each do |name, param|
+          resource[name] = param.value if param.metaparam?
+        end
+
+        # Mark that we're purging, so transactions can handle relationships
+        # correctly
+        resource.purging
+      }
+  end
+
+  def resource_type
+    unless defined?(@resource_type)
+      type = Puppet::Type.type(self[:name])
+      unless type
+        raise Puppet::DevError, _("Could not find resource type")
+      end
+      @resource_type = type
+    end
+    @resource_type
+  end
+
+  # Check if name + namespace combination exists in catalog
+  def check(resource)
+    if ! resource.class.validproperty?(:namespace)
+      return true
+    end
+    namespace = resource[:namespace]
+    name = resource[:resource_name] || resource[:name]
+    Puppet.debug("sensu_resources check: #{name} in #{namespace}")
+    catalog.resources.each do |res|
+      if res.class == resource.class
+        res_name = res[:resource_name] || resource[:name]
+        res_namespace = res[:namespace]
+        if res_name == name && res_namespace == namespace
+          return false
+        end
+      end
+    end
+    return true
+  end
+
+end

--- a/spec/unit/sensu_resources_spec.rb
+++ b/spec/unit/sensu_resources_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+require 'puppet/type/sensu_resources'
+
+describe Puppet::Type.type(:sensu_resources) do
+  let(:default_config) do
+    {
+      name: 'sensu_check',
+      purge: true,
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:resource) do
+    described_class.new(config)
+  end
+
+  it 'should add to catalog without raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource resource
+    }.to_not raise_error
+  end
+
+  it 'should require a name' do
+    expect {
+      described_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should not work with other module types' do
+    config[:name] = 'sensuclassic_check'
+    expect { resource }.to raise_error(Puppet::Error, /Only supported with sensu module types/)
+  end
+
+  # Boolean properties
+  [
+    :purge,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = true
+      expect(resource[property]).to eq(true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = false
+      expect(resource[property]).to eq(false)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'true'
+      expect(resource[property]).to eq(true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'false'
+      expect(resource[property]).to eq(false)
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { resource }.to raise_error(Puppet::Error, /expected a boolean value/)
+    end
+  end
+
+  it 'should not purge sensu_check defined' do
+    config[:name] = 'sensu_check'
+    check = Puppet::Type.type(:sensu_check).new(:name => 'test', :command => 'test', :subscriptions => ['test'], :handlers => ['test'], :interval => 60)
+    instance_check = Puppet::Type.type(:sensu_check).new(:name => 'test in default', :command => 'test', :subscriptions => ['test'], :handlers => ['test'], :interval => 60)
+    allow(check.class).to receive(:instances).and_return([instance_check])
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource resource
+    catalog.add_resource check
+    resource.generate
+    expect(catalog.resources.size).to eq(2)
+  end
+
+  it 'should purge sensu_check not defined' do
+    config[:name] = 'sensu_check'
+    instance_check = Puppet::Type.type(:sensu_check).new(:name => 'test in default', :command => 'test', :subscriptions => ['test'], :handlers => ['test'], :interval => 60)
+    allow(instance_check.class).to receive(:instances).and_return([instance_check])
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource resource
+    resource.generate
+    expect(catalog.resources.size).to eq(1)
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add `sensu_resources` type that behaves just like Puppet's built-in `resources` type that will handle purging unmanaged sensu types.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1157 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The resources collected for sensuctl types take the name of `$name in $namespace` to support resources with the same name in different name spaces. However it's not required to name resources that way and this causes issues with the Puppet built-in `resources` type which just looks at the name and nothing else. This new type looks at `name` plus `namespace` to determine if a resource exists in the catalog. The prefetching in providers that links catalog items to sensuctl items is already matching on name + namespace.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added acceptance tests for a type that supports namespaces and for a type that does not support namespaces to show the new `sensu_resources` type will work for both.
