### PR TITLE
Support defining agent and backend service environment variables

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -26,5 +26,7 @@ fixtures:
       repo: git://github.com/puppetlabs/puppetlabs-postgresql.git
     archive:
       repo: git://github.com/voxpupuli/puppet-archive.git
+    windows_env:
+      repo: git://github.com/voxpupuli/puppet-windows_env.git
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -36,5 +36,8 @@ fixtures:
     archive:
       repo: git://github.com/voxpupuli/puppet-archive.git
       ref: 'v3.0.0'
+    windows_env:
+      repo: git://github.com/voxpupuli/puppet-windows_env.git
+      ref: 'v3.0.0'
   symlinks:
     sensu: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ If managing Windows there is a soft dependency on the [puppetlabs/chocolatey](ht
 
 If managing Windows and defining `package_source`, there is a soft dependency on the [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.0 < 5.0.0`).
 
+If managing Windows and defining `service_env_vars` there is a soft depedency on [puppet/windows_env](https://forge.puppet.com/puppet/windows_env) module (`>= 3.0.0 < 4.0.0`)
+
 For PostgreSQL datastore support there is a soft dependency on [puppetlabs/postgresql](https://forge.puppet.com/puppetlabs/postgresql) module (`>= 6.0.0 < 7.0.0`).
 
 ### Beginning with sensu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ install:
 - puppet module install puppetlabs-stdlib
 - puppet module install puppetlabs-chocolatey
 - puppet module install puppet-archive
+- puppet module install puppet-windows_env
 - puppet config set --section main certname sensu_agent
 - facter -p --debug
 - ruby -v

--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,4 +1,6 @@
 ---
+sensu::agent::service_env_vars_file: /etc/default/sensu-agent
+sensu::backend::service_env_vars_file: /etc/default/sensu-backend
 sensu::plugins::dependencies:
   - make
   - gcc

--- a/data/os/RedHat.yaml
+++ b/data/os/RedHat.yaml
@@ -1,4 +1,6 @@
 ---
+sensu::agent::service_env_vars_file: /etc/sysconfig/sensu-agent
+sensu::backend::service_env_vars_file: /etc/sysconfig/sensu-backend
 sensu::plugins::dependencies:
   - make
   - gcc

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -95,7 +95,7 @@ class sensu::agent (
   $_service_env_vars = $service_env_vars.map |$key,$value| {
     "${key}=\"${value}\""
   }
-  $_service_env_vars_content = ['# File managed by Puppet'] + $_service_env_vars
+  $_service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'] + $_service_env_vars
 
   if $facts['os']['family'] == 'windows' {
     $sensu_agent_exe = "C:\\Program Files\\sensu\\sensu-agent\\bin\\sensu-agent.exe"
@@ -176,6 +176,7 @@ class sensu::agent (
       notify    => Service['sensu-agent'],
     }
   }
+  # No built in way to read environment variables from a file for Windows
   if $facts['os']['family'] == 'windows' {
     $service_env_vars.each |$key,$value| {
       windows_env { $key:

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -95,7 +95,7 @@ class sensu::agent (
   $_service_env_vars = $service_env_vars.map |$key,$value| {
     "${key}=\"${value}\""
   }
-  $_service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'] + $_service_env_vars
+  $_service_env_vars_lines = ['# This file is being maintained by Puppet.','# DO NOT EDIT'] + $_service_env_vars
 
   if $facts['os']['family'] == 'windows' {
     $sensu_agent_exe = "C:\\Program Files\\sensu\\sensu-agent\\bin\\sensu-agent.exe"
@@ -164,10 +164,11 @@ class sensu::agent (
   }
 
   if $service_env_vars_file {
+    $_service_env_vars_content = join($_service_env_vars_lines, "\n")
     file { 'sensu-agent_env_vars':
       ensure    => 'file',
       path      => $service_env_vars_file,
-      content   => join($_service_env_vars_content, "\n"),
+      content   => "${_service_env_vars_content}\n",
       owner     => $::sensu::sensu_user,
       group     => $::sensu::sensu_group,
       mode      => $::sensu::file_mode,

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -240,7 +240,7 @@ class sensu::backend (
   $_service_env_vars = $service_env_vars.map |$key,$value| {
     "${key}=\"${value}\""
   }
-  $_service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'] + $_service_env_vars
+  $_service_env_vars_lines = ['# This file is being maintained by Puppet.','# DO NOT EDIT'] + $_service_env_vars
 
   if $include_default_resources {
     include ::sensu::backend::default_resources
@@ -354,10 +354,11 @@ class sensu::backend (
   }
 
   if $service_env_vars_file {
+    $_service_env_vars_content = join($_service_env_vars_lines, "\n")
     file { 'sensu-backend_env_vars':
       ensure    => 'file',
       path      => $service_env_vars_file,
-      content   => join($_service_env_vars_content, "\n"),
+      content   => "${_service_env_vars_content}\n",
       owner     => $::sensu::sensu_user,
       group     => $::sensu::sensu_group,
       mode      => '0640',

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -240,7 +240,7 @@ class sensu::backend (
   $_service_env_vars = $service_env_vars.map |$key,$value| {
     "${key}=\"${value}\""
   }
-  $_service_env_vars_content = ['# File managed by Puppet'] + $_service_env_vars
+  $_service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'] + $_service_env_vars
 
   if $include_default_resources {
     include ::sensu::backend::default_resources

--- a/spec/acceptance/01_agent_spec.rb
+++ b/spec/acceptance/01_agent_spec.rb
@@ -10,7 +10,8 @@ describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
         backends    => ['sensu_backend:8081'],
         config_hash => {
           'name' => 'sensu_agent',
-        }
+        },
+        service_env_vars => { 'SENSU_API_PORT' => '4041' },
       }
       EOS
 
@@ -30,6 +31,10 @@ describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
     describe service('sensu-agent'), :node => node do
       it { should be_enabled }
       it { should be_running }
+    end
+
+    describe port(4041), :node => node do
+      it { should be_listening }
     end
   end
 end

--- a/spec/acceptance/nodesets/centos-7.yml
+++ b/spec/acceptance/nodesets/centos-7.yml
@@ -11,7 +11,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - "sed -i -r '/^tsflags/d' /etc/yum.conf"
-      - 'yum install -y wget which'
+      - 'yum install -y wget which iproute'
     docker_container_name: 'sensu-agent-el7'
   sensu_backend:
     roles:
@@ -27,7 +27,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - "sed -i -r '/^tsflags/d' /etc/yum.conf"
-      - 'yum install -y wget which initscripts'
+      - 'yum install -y wget which initscripts iproute'
     docker_container_name: 'sensu-backend-el7'
 CONFIG:
   log_level: debug

--- a/spec/acceptance/nodesets/ubuntu-1804.yml
+++ b/spec/acceptance/nodesets/ubuntu-1804.yml
@@ -11,7 +11,7 @@ HOSTS:
     docker_image_commands:
       - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
       - 'apt-get update'
-      - 'apt-get install -y -q net-tools wget curl locales'
+      - 'apt-get install -y -q net-tools wget curl locales iproute2'
       - 'locale-gen en_US.UTF-8'
     docker_container_name: 'sensu-agent-ubuntu1804'
   sensu_backend:
@@ -26,7 +26,7 @@ HOSTS:
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
       - "rm -f /etc/dpkg/dpkg.cfg.d/excludes"
-      - 'apt-get install -y -q net-tools wget locales'
+      - 'apt-get install -y -q net-tools wget locales iproute2'
       - 'locale-gen en_US.UTF-8'
     docker_container_name: 'sensu-backend-ubuntu1804'
 CONFIG:

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -9,7 +9,8 @@ describe 'sensu::agent class', if: Gem.win_platform? do
       backends       => ['sensu_backend:8081'],
       config_hash    => {
         'name' => 'sensu_agent',
-      }
+      },
+      service_env_vars => { 'SENSU_API_PORT' => '4041' },
     }
     EOS
 
@@ -70,6 +71,9 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     describe service('SensuAgent') do
       it { should be_enabled }
       it { should be_running }
+    end
+    describe port(4041) do
+      it { should be_listening }
     end
     describe 'sensu_agent.version fact' do
       it 'has version fact' do

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -64,7 +64,12 @@ describe 'sensu::agent', :type => :class do
           })
         }
 
-        service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'].join("\n")
+        let(:service_env_vars_content) do
+          <<-END.gsub(/^\s+\|/, '')
+            |# This file is being maintained by Puppet.
+            |# DO NOT EDIT
+          END
+        end
 
         if platforms[facts[:osfamily]][:agent_service_env_vars_file]
           it {
@@ -191,11 +196,13 @@ describe 'sensu::agent', :type => :class do
 
       context 'with service_env_vars defined' do
         let(:params) {{ :service_env_vars => { 'SENSU_API_PORT' => '4041' } }}
-        service_env_vars_content = [
-          '# This file is being maintained by Puppet.',
-          '# DO NOT EDIT',
-          'SENSU_API_PORT="4041"',
-        ].join("\n")
+        let(:service_env_vars_content) do
+          <<-END.gsub(/^\s+\|/, '')
+            |# This file is being maintained by Puppet.
+            |# DO NOT EDIT
+            |SENSU_API_PORT="4041"
+          END
+        end
 
         if platforms[facts[:osfamily]][:agent_service_env_vars_file]
           it { should contain_file('sensu-agent_env_vars').with_content(service_env_vars_content) }

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -64,7 +64,7 @@ describe 'sensu::agent', :type => :class do
           })
         }
 
-        service_env_vars_content = ['# File managed by Puppet'].join("\n")
+        service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'].join("\n")
 
         if platforms[facts[:osfamily]][:agent_service_env_vars_file]
           it {
@@ -192,7 +192,8 @@ describe 'sensu::agent', :type => :class do
       context 'with service_env_vars defined' do
         let(:params) {{ :service_env_vars => { 'SENSU_API_PORT' => '4041' } }}
         service_env_vars_content = [
-          '# File managed by Puppet',
+          '# This file is being maintained by Puppet.',
+          '# DO NOT EDIT',
           'SENSU_API_PORT="4041"',
         ].join("\n")
 

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -64,6 +64,25 @@ describe 'sensu::agent', :type => :class do
           })
         }
 
+        service_env_vars_content = ['# File managed by Puppet'].join("\n")
+
+        if platforms[facts[:osfamily]][:agent_service_env_vars_file]
+          it {
+            should contain_file('sensu-agent_env_vars').with({
+              'ensure'  => 'file',
+              'path'    => platforms[facts[:osfamily]][:agent_service_env_vars_file],
+              'content' => service_env_vars_content,
+              'owner'   => platforms[facts[:osfamily]][:user],
+              'group'   => platforms[facts[:osfamily]][:group],
+              'mode'    => platforms[facts[:osfamily]][:agent_config_mode],
+              'require' => 'Package[sensu-go-agent]',
+              'notify'  => 'Service[sensu-agent]',
+            })
+          }
+        else
+          it { should_not contain_file('sensu-agent_env_vars') }
+        end
+
         it {
           should contain_service('sensu-agent').with({
             'ensure'    => 'running',
@@ -168,6 +187,30 @@ describe 'sensu::agent', :type => :class do
           it { should compile.with_all_deps }
         end
         it { should contain_package('sensu-go-agent').without_require }
+      end
+
+      context 'with service_env_vars defined' do
+        let(:params) {{ :service_env_vars => { 'SENSU_API_PORT' => '4041' } }}
+        service_env_vars_content = [
+          '# File managed by Puppet',
+          'SENSU_API_PORT="4041"',
+        ].join("\n")
+
+        if platforms[facts[:osfamily]][:agent_service_env_vars_file]
+          it { should contain_file('sensu-agent_env_vars').with_content(service_env_vars_content) }
+        end
+        if facts[:os]['family'] == 'windows'
+          it {
+            should contain_windows_env('SENSU_API_PORT').with({
+              :ensure     => 'present',
+              :value      => '4041',
+              :mergemode  => 'clobber',
+              :notify     => 'Service[sensu-agent]',
+            })
+          }
+        else
+          it { should_not contain_windows_env('sensu_api_host') }
+        end
       end
 
       # Test various backend values

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -131,7 +131,12 @@ describe 'sensu::backend', :type => :class do
           })
         }
 
-        service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'].join("\n")
+        let(:service_env_vars_content) do
+          <<-END.gsub(/^\s+\|/, '')
+            |# This file is being maintained by Puppet.
+            |# DO NOT EDIT
+          END
+        end
 
         if platforms[facts[:osfamily]][:backend_service_env_vars_file]
           it {
@@ -326,12 +331,13 @@ describe 'sensu::backend', :type => :class do
 
       context 'with service_env_vars defined' do
         let(:params) {{ :service_env_vars => { 'SENSU_BACKEND_AGENT_PORT' => '9081' } }}
-        service_env_vars_content = [
-          '# This file is being maintained by Puppet.',
-          '# DO NOT EDIT',
-          'SENSU_BACKEND_AGENT_PORT="9081"',
-        ].join("\n")
-
+        let(:service_env_vars_content) do
+          <<-END.gsub(/^\s+\|/, '')
+            |# This file is being maintained by Puppet.
+            |# DO NOT EDIT
+            |SENSU_BACKEND_AGENT_PORT="9081"
+          END
+        end
         if platforms[facts[:osfamily]][:backend_service_env_vars_file]
           it { should contain_file('sensu-backend_env_vars').with_content(service_env_vars_content) }
         end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -131,7 +131,7 @@ describe 'sensu::backend', :type => :class do
           })
         }
 
-        service_env_vars_content = ['# File managed by Puppet'].join("\n")
+        service_env_vars_content = ['# This file is being maintained by Puppet.','# DO NOT EDIT'].join("\n")
 
         if platforms[facts[:osfamily]][:backend_service_env_vars_file]
           it {
@@ -327,7 +327,8 @@ describe 'sensu::backend', :type => :class do
       context 'with service_env_vars defined' do
         let(:params) {{ :service_env_vars => { 'SENSU_BACKEND_AGENT_PORT' => '9081' } }}
         service_env_vars_content = [
-          '# File managed by Puppet',
+          '# This file is being maintained by Puppet.',
+          '# DO NOT EDIT',
           'SENSU_BACKEND_AGENT_PORT="9081"',
         ].join("\n")
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -98,6 +98,8 @@ def platforms
       ca_mode: '0644',
       agent_service_name: 'sensu-agent',
       log_file: nil,
+      agent_service_env_vars_file: '/etc/default/sensu-agent',
+      backend_service_env_vars_file: '/etc/default/sensu-backend',
     },
     'RedHat' => {
       :package_require => ['Class[Sensu::Repo]'],
@@ -117,6 +119,8 @@ def platforms
       ca_mode: '0644',
       agent_service_name: 'sensu-agent',
       log_file: nil,
+      agent_service_env_vars_file: '/etc/sysconfig/sensu-agent',
+      backend_service_env_vars_file: '/etc/sysconfig/sensu-backend',
     },
     'windows' => {
       agent_package_name: 'sensu-agent',
@@ -134,6 +138,8 @@ def platforms
       plugins_dependencies: [],
       agent_service_name: 'SensuAgent',
       log_file: 'C:\ProgramData\sensu\log\sensu-agent.log',
+      agent_service_env_vars_file: nil,
+      backend_service_env_vars_file: nil,
     }
   }
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Supporting setting environment variables that are loaded by agent and backend services.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The daemons for both agent and daemon load environment variables from `/etc/default/` or `/etc/sysconfig/` files and this adds support for defining those environment variables. Also added support for doing the same with Windows by setting Windows environment variables.