### PR TITLE
Support Windows 2019

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,10 @@ Linux.
 * Ubuntu 18.04 LTS
 * Amazon 2018.03
 * Amazon 2
+* Windows Server 2008 R2
+* Windows Server 2012 R2
+* Windows Server 2016
+* Windows Server 2019
 
 ## Development
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -51,6 +51,8 @@ image:
   - Visual Studio 2015
   # Windows 2016
   - Visual Studio 2017
+  # Windows 2019
+  - Visual Studio 2019
 environment:
   matrix:
     - PUPPET_GEM_VERSION: '~>5.x'

--- a/metadata.json
+++ b/metadata.json
@@ -53,7 +53,8 @@
       "operatingsystemrelease": [
         "Server 2008 R2",
         "Server 2012 R2",
-        "Server 2016"
+        "Server 2016",
+        "Server 2019"
       ]
     }
   ],


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add Support for Windows 2019

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go says "2008 R2 and later" and now Appveyor has Windows 2019 images.
