### PR TITLE
Add bolt task to manage API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,12 @@ The following Bolt tasks are provided by this Module:
 
 Example: `bolt task run sensu::agent_event name=bolttest status=1 output=test --nodes sensu_agent`
 
+**sensu::apikey**: Manage Sensu Go API keys
+
+Example: `bolt task run sensu::apikey action=create username=foobar --nodes sensu_backend`
+Example: `bolt task run sensu::apikey action=list --nodes sensu_backend`
+Example: `bolt task run sensu::apikey action=delete key=replace-with-uuid-key --nodes sensu_backend`
+
 **sensu::assets\_outdated**: Retreive outdated Sensu Go assets
 
 Example: `bolt task run sensu::assets_outdated --nodes sensu_backend`

--- a/tasks/apikey.json
+++ b/tasks/apikey.json
@@ -1,0 +1,18 @@
+{
+  "description": "Manage Sensu Go API keys",
+  "input_method": "stdin",
+  "parameters": {
+    "action": {
+      "description": "The action to perform",
+      "type": "Enum[create,list,delete]"
+    },
+    "username": {
+      "description": "The username for the API key. Required for action=create",
+      "type": "Optional[String[1]]"
+    },
+    "key": {
+      "description": "The API key. Required for action=delete",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/tasks/apikey.rb
+++ b/tasks/apikey.rb
@@ -1,0 +1,46 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'json'
+require 'open3'
+require 'puppet'
+
+def create(username)
+  stdout, stderr, status = Open3.capture3('sensuctl', 'api-key', 'grant', username)
+  raise Puppet::Error, stderr if status != 0
+  key = stdout.split('/')[-1]
+  { status: "successful", key: key }
+end
+
+def list()
+  stdout, stderr, status = Open3.capture3('sensuctl', 'api-key', 'list', '--format', 'json')
+  raise Puppet::Error, stderr if status != 0
+  { status: "success", keys: JSON.parse(stdout) }
+end
+
+def delete(key)
+  stdout, stderr, status = Open3.capture3('sensuctl', 'api-key', 'revoke', key, '--skip-confirm')
+  raise Puppet::Error, stderr if status != 0
+  { status: "delete successful" }
+end
+
+begin
+  params = JSON.parse(STDIN.read)
+  action = params['action']
+  username = params['username']
+  key = params['key']
+
+  case action
+  when 'create'
+    raise Puppet::Error, "username is required for action=create" if username.nil?
+    result = create(username)
+  when 'list'
+    result = list()
+  when 'delete'
+    raise Puppet::Error, "key is required for action=delete" if key.nil?
+    result = delete(key)
+  end
+  puts result.to_json
+  exit 0
+rescue Puppet::Error => e
+  puts({ status: 'failure', error: e.message }.to_json)
+  exit 1
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add bolt task to create, list and delete API keys for Sensu Go.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.15 (not yet released) will have support for managing API keys. The way they are created and defined the key is generated at creation time thus can't be managed as a custom type/provider so must be handled via Bolt tasks where Bolt can return the key when created as part of the output.
