### PR TITLE
Improve name validations to match Sensu Go

### DIFF
--- a/lib/puppet/type/sensu_ad_auth.rb
+++ b/lib/puppet/type/sensu_ad_auth.rb
@@ -50,7 +50,7 @@ DESC
   newparam(:name, :namevar => true) do
     desc "The name of the AD auth."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_ad_auth name invalid"
       end
     end

--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -76,6 +76,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the asset."
     validate do |value|
+      # Must only contain lower case letters, numbers, underscores, periods, hyphens and colons
       unless value =~ %r{^[a-z0-9\/\_\.\-\:]+$}
         raise ArgumentError, "sensu_asset name invalid"
       end

--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -76,7 +76,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the asset."
     validate do |value|
-      unless value =~ /^[\w\.\-\/]+$/
+      unless value =~ %r{^[a-z0-9\/\_\.\-\:]+$}
         raise ArgumentError, "sensu_asset name invalid"
       end
     end

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -64,7 +64,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the check."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_check name invalid"
       end
     end

--- a/lib/puppet/type/sensu_cluster_role.rb
+++ b/lib/puppet/type/sensu_cluster_role.rb
@@ -27,6 +27,11 @@ DESC
 
   newparam(:name, :namevar => true) do
     desc "The name of the role."
+    validate do |value|
+      unless value =~ PuppetX::Sensu::Type.name_regex
+        raise ArgumentError, "sensu_cluster_role name invalid"
+      end
+    end
   end
 
   newproperty(:rules, :array_matching => :all, :parent => PuppetX::Sensu::ArrayOfHashesProperty) do

--- a/lib/puppet/type/sensu_cluster_role_binding.rb
+++ b/lib/puppet/type/sensu_cluster_role_binding.rb
@@ -41,6 +41,11 @@ DESC
 
   newparam(:name, :namevar => true) do
     desc "The name of the role binding."
+    validate do |value|
+      unless value =~ PuppetX::Sensu::Type.name_regex
+        raise ArgumentError, "sensu_cluster_role_binding name invalid"
+      end
+    end
   end
 
   newproperty(:role_ref, :parent => PuppetX::Sensu::HashProperty) do

--- a/lib/puppet/type/sensu_config.rb
+++ b/lib/puppet/type/sensu_config.rb
@@ -34,7 +34,7 @@ DESC
   newparam(:name, :namevar => true) do
     desc "The name of the config."
     validate do |value|
-      unless value =~ /^[\w\.\-\_]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_config name invalid"
       end
     end

--- a/lib/puppet/type/sensu_entity.rb
+++ b/lib/puppet/type/sensu_entity.rb
@@ -43,7 +43,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the entity."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_entity name invalid"
       end
     end

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -45,7 +45,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the filter."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_filter name invalid"
       end
     end

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -48,7 +48,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the handler."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_handler name invalid"
       end
     end

--- a/lib/puppet/type/sensu_hook.rb
+++ b/lib/puppet/type/sensu_hook.rb
@@ -43,7 +43,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the hook."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_hook name invalid"
       end
     end

--- a/lib/puppet/type/sensu_ldap_auth.rb
+++ b/lib/puppet/type/sensu_ldap_auth.rb
@@ -50,7 +50,7 @@ DESC
   newparam(:name, :namevar => true) do
     desc "The name of the LDAP auth."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_ldap_auth name invalid"
       end
     end

--- a/lib/puppet/type/sensu_mutator.rb
+++ b/lib/puppet/type/sensu_mutator.rb
@@ -43,7 +43,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the mutator."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_mutator name invalid"
       end
     end

--- a/lib/puppet/type/sensu_namespace.rb
+++ b/lib/puppet/type/sensu_namespace.rb
@@ -26,7 +26,7 @@ DESC
   newparam(:name, :namevar => true) do
     desc "The name of the namespace."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_namespace name invalid"
       end
     end

--- a/lib/puppet/type/sensu_oidc_auth.rb
+++ b/lib/puppet/type/sensu_oidc_auth.rb
@@ -37,7 +37,7 @@ DESC
   newparam(:name, :namevar => true) do
     desc "The name of the AD auth."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_ad_auth name invalid"
       end
     end

--- a/lib/puppet/type/sensu_role.rb
+++ b/lib/puppet/type/sensu_role.rb
@@ -43,7 +43,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the role."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_role name invalid"
       end
     end

--- a/lib/puppet/type/sensu_role_binding.rb
+++ b/lib/puppet/type/sensu_role_binding.rb
@@ -59,7 +59,7 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the role binding."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ PuppetX::Sensu::Type.name_regex
         raise ArgumentError, "sensu_role_binding name invalid"
       end
     end

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -44,6 +44,7 @@ DESC
   newparam(:name, :namevar => true) do
     desc "The name of the user."
     validate do |value|
+      # Match only upper case letters, lowercase letters, numbers, underscores, periods and hyphens
       unless value =~ %r{^[\w.\-]+$}
         raise ArgumentError, "sensu_user name invalid"
       end

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -44,7 +44,7 @@ DESC
   newparam(:name, :namevar => true) do
     desc "The name of the user."
     validate do |value|
-      unless value =~ /^[\w\.\-]+$/
+      unless value =~ %r{^[\w.\-]+$}
         raise ArgumentError, "sensu_user name invalid"
       end
     end

--- a/lib/puppet_x/sensu/type.rb
+++ b/lib/puppet_x/sensu/type.rb
@@ -2,6 +2,7 @@ module PuppetX
   module Sensu
     module Type
       def self.name_regex
+        # Match only upper case letters, lowercase letters, numbers, underscores, periods, hyphens, and colons
         %r{^[\w.\-:]+$}
       end
 

--- a/lib/puppet_x/sensu/type.rb
+++ b/lib/puppet_x/sensu/type.rb
@@ -1,6 +1,9 @@
 module PuppetX
   module Sensu
     module Type
+      def self.name_regex
+        %r{^[\w.\-:]+$}
+      end
 
       def add_autorequires(namespace=true, require_configure=true)
         autorequire(:package) do

--- a/spec/shared_examples/types.rb
+++ b/spec/shared_examples/types.rb
@@ -1,5 +1,34 @@
 require 'spec_helper'
 
+RSpec.shared_examples 'name_regex' do
+  let(:params) { default_params }
+  let(:resource) { described_class.new(params) }
+
+  invalid_names = [
+    'foo!'
+  ]
+  valid_names = [
+    'foo',
+    'foo:',
+    'foo-',
+    'foo_',
+    'foo.example.com',
+  ]
+
+  invalid_names.each do |name|
+    it "does not allow invalid name #{name}" do
+      params[:name] = name
+      expect { resource }.to raise_error(/name/)
+    end
+  end
+  valid_names.each do |name|
+    it "does allow valid name #{name}" do
+      params[:name] = name
+      expect { resource }.not_to raise_error
+    end
+  end
+end
+
 RSpec.shared_examples 'autorequires' do |namespace, configure|
   namespace = true if namespace.nil?
   configure = true if configure.nil?

--- a/spec/unit/sensu_ad_auth_spec.rb
+++ b/spec/unit/sensu_ad_auth_spec.rb
@@ -32,6 +32,10 @@ describe Puppet::Type.type(:sensu_ad_auth) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   defaults = {
   }
 

--- a/spec/unit/sensu_asset_spec.rb
+++ b/spec/unit/sensu_asset_spec.rb
@@ -31,6 +31,33 @@ describe Puppet::Type.type(:sensu_asset) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  valid_names = [
+    'foo',
+    'foo-bar',
+    'foo.bar',
+    'foo1',
+    'foo_bar',
+    'foo:bar',
+    'foo/bar',
+  ]
+  invalid_names = [
+    'foo!',
+    'Foo',
+    'fooBar',
+  ]
+  valid_names.each do |name|
+    it "allows valid name #{name}" do
+      config[:name] = name
+      expect { asset }.to_not raise_error
+    end
+  end
+  invalid_names.each do |name|
+    it "does not allow invalid name #{name}" do
+      config[:name] = name
+      expect { asset }.to raise_error(/name/)
+    end
+  end
+
   it 'allows bonsai name' do
     config[:name] = 'sensu/sensu-pagerduty-handler'
     expect(asset[:name]).to eq('sensu/sensu-pagerduty-handler')

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -31,6 +31,10 @@ describe Puppet::Type.type(:sensu_check) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_cluster_role_binding_spec.rb
+++ b/spec/unit/sensu_cluster_role_binding_spec.rb
@@ -29,6 +29,10 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   defaults = {
   }
 

--- a/spec/unit/sensu_cluster_role_spec.rb
+++ b/spec/unit/sensu_cluster_role_spec.rb
@@ -28,6 +28,10 @@ describe Puppet::Type.type(:sensu_cluster_role) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   defaults = {
   }
 

--- a/spec/unit/sensu_config_spec.rb
+++ b/spec/unit/sensu_config_spec.rb
@@ -33,6 +33,10 @@ describe Puppet::Type.type(:sensu_config) do
     expect { sensu_config[:ensure] = 'absent' }.to raise_error(Puppet::Error, /ensure does not support absent/)
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   defaults = {}
 
   # String properties

--- a/spec/unit/sensu_entity_spec.rb
+++ b/spec/unit/sensu_entity_spec.rb
@@ -28,6 +28,10 @@ describe Puppet::Type.type(:sensu_entity) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_filter_spec.rb
+++ b/spec/unit/sensu_filter_spec.rb
@@ -29,6 +29,10 @@ describe Puppet::Type.type(:sensu_filter) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_handler_spec.rb
+++ b/spec/unit/sensu_handler_spec.rb
@@ -31,6 +31,10 @@ describe Puppet::Type.type(:sensu_handler) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_hook_spec.rb
+++ b/spec/unit/sensu_hook_spec.rb
@@ -28,6 +28,10 @@ describe Puppet::Type.type(:sensu_hook) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_ldap_auth_spec.rb
+++ b/spec/unit/sensu_ldap_auth_spec.rb
@@ -32,6 +32,10 @@ describe Puppet::Type.type(:sensu_ldap_auth) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   defaults = {
   }
 

--- a/spec/unit/sensu_mutator_spec.rb
+++ b/spec/unit/sensu_mutator_spec.rb
@@ -28,6 +28,10 @@ describe Puppet::Type.type(:sensu_mutator) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_namespace_spec.rb
+++ b/spec/unit/sensu_namespace_spec.rb
@@ -27,6 +27,10 @@ describe Puppet::Type.type(:sensu_namespace) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   defaults = {
   }
 

--- a/spec/unit/sensu_oidc_auth_spec.rb
+++ b/spec/unit/sensu_oidc_auth_spec.rb
@@ -30,6 +30,11 @@ describe Puppet::Type.type(:sensu_oidc_auth) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
+
   defaults = {
   }
 

--- a/spec/unit/sensu_role_binding_spec.rb
+++ b/spec/unit/sensu_role_binding_spec.rb
@@ -29,6 +29,10 @@ describe Puppet::Type.type(:sensu_role_binding) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_role_spec.rb
+++ b/spec/unit/sensu_role_spec.rb
@@ -28,6 +28,10 @@ describe Puppet::Type.type(:sensu_role) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  include_examples 'name_regex' do
+    let(:default_params) { default_config }
+  end
+
   it 'should handle composite title' do
     config.delete(:namespace)
     config[:name] = 'test in dev'

--- a/spec/unit/sensu_user_spec.rb
+++ b/spec/unit/sensu_user_spec.rb
@@ -28,6 +28,31 @@ describe Puppet::Type.type(:sensu_user) do
     }.to raise_error(Puppet::Error, 'Title or name must be provided')
   end
 
+  valid_names = [
+    'foo',
+    'foo-bar',
+    'foo.bar',
+    'foo1',
+    'fooBar',
+    'foo_bar',
+  ]
+  invalid_names = [
+    'foo!',
+    'foo:',
+  ]
+  valid_names.each do |name|
+    it "allows valid name #{name}" do
+      config[:name] = name
+      expect { user }.to_not raise_error
+    end
+  end
+  invalid_names.each do |name|
+    it "does not allow invalid name #{name}" do
+      config[:name] = name
+      expect { user }.to raise_error(/name/)
+    end
+  end
+
   it 'should not accept ensure => absent' do
     config[:ensure] = 'absent'
     expect { user[:ensure] = 'absent' }.to raise_error(Puppet::Error, /ensure does not support absent/)


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update all resource name validations to match Sensu Go validations for names.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.15 (not yet released) added a colon as valid name character. This PR updates updates regex used by types but in a way where most types share the same regex so future updates require fewer code changes.

Upstream change: https://github.com/sensu/sensu-go/pull/3384/files

Any changes to our regex should be considered a bugfix as previous lack of regex or incorrect regex would have allowed Puppet to define things that Sensu Go would reject.