### PR TITLE
Move PostgresConfig to a type

### DIFF
--- a/lib/puppet/provider/sensu_postgres_config/sensuctl.rb
+++ b/lib/puppet/provider/sensu_postgres_config/sensuctl.rb
@@ -1,0 +1,132 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sensuctl'))
+
+Puppet::Type.type(:sensu_postgres_config).provide(:sensuctl, :parent => Puppet::Provider::Sensuctl) do
+  desc "Provider sensu_postgres_config using sensuctl"
+
+  mk_resource_methods
+
+  def self.instances
+    configs = []
+
+    data = dump('store/v1.PostgresConfig')
+
+    data.each do |d|
+      config = {}
+      config[:ensure] = :present
+      config[:name] = d['metadata']['name']
+      d['spec'].each_pair do |key,value|
+        if !!value == value
+          value = value.to_s.to_sym
+        end
+        if type_properties.include?(key.to_sym)
+          config[key.to_sym] = value
+        else
+          next
+        end
+      end
+      configs << new(config)
+    end
+    configs
+  end
+
+  def self.prefetch(resources)
+    configs = instances
+    resources.keys.each do |name|
+      if provider = configs.find { |c| c.name == name }
+        resources[name].provider = provider
+      end
+    end
+  end
+
+  def exists?
+    @property_hash[:ensure] == :present
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  type_properties.each do |prop|
+    define_method "#{prop}=".to_sym do |value|
+      @property_flush[prop] = value
+    end
+  end
+
+  def create
+    spec = {}
+    metadata = {}
+    metadata[:name] = resource[:name]
+    type_properties.each do |property|
+      value = resource[property]
+      next if value.nil?
+      if [:true, :false].include?(value)
+        value = convert_boolean_property_value(value)
+      elsif value == :absent
+        value = nil
+      end
+      spec[property] = value
+    end
+    begin
+      sensuctl_create('PostgresConfig', metadata, spec, 'store/v1')
+    rescue Exception => e
+      raise Puppet::Error, "sensuctl create #{resource[:name]} failed\nError message: #{e.message}"
+    end
+    @property_hash[:ensure] = :present
+  end
+
+  def flush
+    if !@property_flush.empty?
+      spec = {}
+      metadata = {}
+      metadata[:name] = resource[:name]
+      type_properties.each do |property|
+        if @property_flush[property]
+          value = @property_flush[property]
+        else
+          value = resource[property]
+        end
+        next if value.nil?
+        if [:true, :false].include?(value)
+          value = convert_boolean_property_value(value)
+        elsif value == :absent
+          value = nil
+        end
+        spec[property] = value
+      end
+      begin
+        sensuctl_create('PostgresConfig', metadata, spec, 'store/v1')
+      rescue Exception => e
+        raise Puppet::Error, "sensuctl create #{resource[:name]} failed\nError message: #{e.message}"
+      end
+    end
+    @property_hash = resource.to_hash
+  end
+
+  def destroy
+    spec = {}
+    metadata = {}
+    metadata[:name] = resource[:name]
+    type_properties.each do |property|
+      if @property_hash[property]
+        value = @property_hash[property]
+      else
+        value = resource[property]
+      end
+      next if value.nil?
+      if [:true, :false].include?(value)
+        value = convert_boolean_property_value(value)
+      elsif value == :absent
+        value = nil
+      end
+      spec[property] = value
+    end
+    begin
+      sensuctl_delete('PostgresConfig', resource[:name], nil, metadata, spec, 'store/v1')
+    rescue Exception => e
+      raise Puppet::Error, "sensuctl delete check #{resource[:name]} failed\nError message: #{e.message}"
+    end
+    @property_hash.clear
+  end
+end
+

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -129,6 +129,8 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
   end
 
   def self.dump(resource_type)
+    # Dump YAML because 'sensuctl dump' does not yet support '--format json'
+    # https://github.com/sensu/sensu-go/issues/3424
     output = sensuctl(['dump',resource_type,'--format','yaml','--all-namespaces'])
     Puppet.debug("YAML dump of #{resource_type}:\n#{output}")
     resources = []

--- a/lib/puppet/type/sensu_postgres_config.rb
+++ b/lib/puppet/type/sensu_postgres_config.rb
@@ -1,0 +1,52 @@
+require_relative '../../puppet_x/sensu/type'
+require_relative '../../puppet_x/sensu/array_property'
+require_relative '../../puppet_x/sensu/array_of_hashes_property'
+require_relative '../../puppet_x/sensu/hash_property'
+require_relative '../../puppet_x/sensu/integer_property'
+
+Puppet::Type.newtype(:sensu_postgres_config) do
+  desc <<-DESC
+@summary Manages Sensu postgres config
+@example Create an PostgreSQL datastore
+  sensu_postgres_config { 'puppet':
+    ensure    => 'present',
+    dsn       => 'postgresql://sensu:changeme@localhost:5432/sensu',
+    pool_size => 20, 
+  }
+
+**Autorequires**:
+* `Package[sensu-go-cli]`
+* `Service[sensu-backend]`
+* `Sensu_configure[puppet]`
+* `Sensu_api_validator[sensu]`
+DESC
+
+  extend PuppetX::Sensu::Type
+  add_autorequires(false)
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the postgres config"
+  end
+
+  newproperty(:dsn) do
+    desc "Use the dsn attribute to specify the data source names as a URL or PostgreSQL connection string"
+  end
+
+  newproperty(:pool_size, :parent => PuppetX::Sensu::IntegerProperty) do
+    desc "The maximum number of connections to hold in the PostgreSQL connection pool"
+    newvalues(/^[0-9]+$/)
+  end
+
+  def pre_run_check
+    required_properties = [
+      :dsn,
+    ]
+    required_properties.each do |property|
+      if self[:ensure] == :present && self[property].nil?
+        fail "You must provide a #{property}"
+      end
+    end
+  end
+end

--- a/manifests/backend/datastore/postgresql.pp
+++ b/manifests/backend/datastore/postgresql.pp
@@ -5,58 +5,24 @@ class sensu::backend::datastore::postgresql {
   include ::sensu
   include ::sensu::backend
 
-  $config_path = "${::sensu::etc_dir}/postgresql.yaml"
   $user = $::sensu::backend::postgresql_user
   $password = $::sensu::backend::postgresql_password
   $host = $::sensu::backend::postgresql_host
   $port = $::sensu::backend::postgresql_port
   $dbname = $::sensu::backend::postgresql_dbname
-  $config = {
-    'type'        => 'PostgresConfig',
-    'api_version' => 'store/v1',
-    'metadata'    => { 'name' => $::sensu::backend::postgresql_name },
-    'spec'        => {
-      'dsn'         => "postgresql://${user}:${password}@${host}:${port}/${dbname}",
-      'pool_size'   => $::sensu::backend::postgresql_pool_size,
-    },
-  }
-  $yaml_config = to_yaml($config)
+  $dsn = "postgresql://${user}:${password}@${host}:${port}/${dbname}"
 
-  case $::sensu::backend::datastore_ensure {
-    'absent': {
-      $sensuctl_command = 'sensuctl delete'
-    }
-    default: {
-      $sensuctl_command = 'sensuctl create'
-    }
-  }
-
-  file { $config_path:
-    ensure    => 'file',
-    owner     => $::sensu::user,
-    group     => $::sensu::group,
-    mode      => '0640',
-    show_diff => false,
-    content   => "${yaml_config}\n# File managed by Puppet\n# ${::sensu::backend::datastore_ensure}\n",
-    require   => Package['sensu-go-backend'],
-    notify    => Exec['sensuctl-postgresql'],
-  }
-
-  exec { 'sensuctl-postgresql':
-    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-    command     => "${sensuctl_command} --file ${config_path}",
-    refreshonly => true,
-    require     => [
-      Sensu_configure['puppet'],
-      Sensu_user['admin'],
-    ],
+  sensu_postgres_config { $::sensu::backend::postgresql_name:
+    ensure    => $::sensu::backend::datastore_ensure,
+    dsn       => Sensitive($dsn),
+    pool_size => $::sensu::backend::postgresql_pool_size,
   }
 
   if $::sensu::backend::manage_postgresql_db and $::sensu::backend::datastore_ensure == 'present' {
     postgresql::server::db { $dbname:
       user     => $user,
       password => postgresql_password($user, $password),
-      before   => Exec['sensuctl-postgresql'],
+      before   => Sensu_postgres_config[$::sensu::backend::postgresql_name],
     }
   }
 }

--- a/spec/acceptance/06_postgresql_spec.rb
+++ b/spec/acceptance/06_postgresql_spec.rb
@@ -43,6 +43,14 @@ describe 'postgresql datastore', if: RSpec.configuration.sensu_full do
       on node, 'sensuctl check execute event-test'
     end
 
+    it 'configured postgres' do
+      on node, 'sensuctl dump store/v1.PostgresConfig --format yaml --all-namespaces' do
+        data = YAML.load(stdout)
+        expect(data['spec']['dsn']).to eq('postgresql://sensu:changeme@localhost:5432/sensu')
+        expect(data['spec']['pool_size']).to eq(20)
+      end
+    end
+
     it 'should have an event' do
       on node, 'sensuctl event info sensu_agent event-test --format json' do
         data = JSON.parse(stdout)
@@ -81,6 +89,12 @@ describe 'postgresql datastore', if: RSpec.configuration.sensu_full do
       end
       apply_manifest_on(node, check_pp, :catch_failures => true)
       on node, 'sensuctl check execute event-test'
+    end
+
+    it 'removed postgres config' do
+      on node, 'sensuctl dump store/v1.PostgresConfig --format yaml --all-namespaces' do
+        expect(stdout).to be_empty
+      end
     end
 
     it 'should have an event' do

--- a/spec/acceptance/06_postgresql_spec.rb
+++ b/spec/acceptance/06_postgresql_spec.rb
@@ -44,6 +44,8 @@ describe 'postgresql datastore', if: RSpec.configuration.sensu_full do
     end
 
     it 'configured postgres' do
+      # Dump YAML because 'sensuctl dump' does not yet support '--format json'
+      # https://github.com/sensu/sensu-go/issues/3424
       on node, 'sensuctl dump store/v1.PostgresConfig --format yaml --all-namespaces' do
         data = YAML.load(stdout)
         expect(data['spec']['dsn']).to eq('postgresql://sensu:changeme@localhost:5432/sensu')
@@ -92,6 +94,8 @@ describe 'postgresql datastore', if: RSpec.configuration.sensu_full do
     end
 
     it 'removed postgres config' do
+      # Dump YAML because 'sensuctl dump' does not yet support '--format json'
+      # https://github.com/sensu/sensu-go/issues/3424
       on node, 'sensuctl dump store/v1.PostgresConfig --format yaml --all-namespaces' do
         expect(stdout).to be_empty
       end

--- a/spec/classes/backend_datastore_postgresql_spec.rb
+++ b/spec/classes/backend_datastore_postgresql_spec.rb
@@ -19,43 +19,11 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
 
       it { should compile.with_all_deps }
 
-      let(:config_content) do
-        content = <<-END.gsub(/^\s+\|/, '')
-        |---
-        |type: PostgresConfig
-        |api_version: store/v1
-        |metadata:
-        |  name: postgresql
-        |spec:
-        |  dsn: postgresql://sensu:changeme@localhost:5432/sensu
-        |  pool_size: 20
-        |
-        |# File managed by Puppet
-        |# present
-      END
-        content
-      end
-
       it do
-        should contain_file('/etc/sensu/postgresql.yaml').with({
-          :ensure   => 'file',
-          :owner    => 'sensu',
-          :group    => 'sensu',
-          :mode     => '0640',
-          :content  => config_content,
-          :require  => 'Package[sensu-go-backend]',
-          :notify   => 'Exec[sensuctl-postgresql]',
-        })
-      end
-
-      it do
-        should contain_exec('sensuctl-postgresql').with({
-          :path => '/usr/bin:/bin:/usr/sbin:/sbin',
-          :command  => 'sensuctl create --file /etc/sensu/postgresql.yaml',
-          :require  => [
-            'Sensu_configure[puppet]',
-            'Sensu_user[admin]',
-          ]
+        should contain_sensu_postgres_config('postgresql').with({
+          :ensure    => 'present',
+          :dsn       => 'postgresql://sensu:changeme@localhost:5432/sensu',
+          :pool_size => '20',
         })
       end
 
@@ -74,25 +42,15 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
           }
           EOS
         end
-        let(:config_content) do
-          content = <<-END.gsub(/^\s+\|/, '')
-          |---
-          |type: PostgresConfig
-          |api_version: store/v1
-          |metadata:
-          |  name: postgresql
-          |spec:
-          |  dsn: postgresql://sensu:changeme@localhost:5432/sensu
-          |  pool_size: 20
-          |
-          |# File managed by Puppet
-          |# absent
-        END
-          content
-        end
+
         it { should compile.with_all_deps }
-        it { should contain_file('/etc/sensu/postgresql.yaml').with_ensure('file').with_content(config_content) }
-        it { should contain_exec('sensuctl-postgresql').with_command('sensuctl delete --file /etc/sensu/postgresql.yaml') }
+        it do
+          should contain_sensu_postgres_config('postgresql').with({
+           :ensure    => 'absent',
+           :dsn       => 'postgresql://sensu:changeme@localhost:5432/sensu',
+           :pool_size => '20',
+         })
+        end
         it { should_not contain_postgresql__server__db('sensu') }
       end
 

--- a/spec/fixtures/unit/provider/sensu_postgres_config/sensuctl/dump.txt
+++ b/spec/fixtures/unit/provider/sensu_postgres_config/sensuctl/dump.txt
@@ -1,0 +1,8 @@
+type: PostgresConfig
+api_version: store/v1
+metadata:
+  name: my-postgres
+  namespace: default
+spec:
+  dsn: postgresql://user:secret@host:port/dbname
+  pool_size: 20

--- a/spec/unit/provider/sensu_postgres_config/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_postgres_config/sensuctl_spec.rb
@@ -1,0 +1,70 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_postgres_config).provider(:sensuctl) do
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_postgres_config) }
+  let(:resource) do
+    type.new({
+      :name => 'test',
+      :dsn => 'postgresql://sensu:changeme@localhost:5432/sensu',
+    })
+  end
+
+  describe 'self.instances' do
+    it 'should create instances' do
+      allow(provider).to receive(:sensuctl).with(['dump','store/v1.PostgresConfig','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      expect(provider.instances.length).to eq(1)
+    end
+
+    it 'should return the resource for a postres config' do
+      allow(provider).to receive(:sensuctl).with(['dump','store/v1.PostgresConfig','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      property_hash = provider.instances[0].instance_variable_get("@property_hash")
+      expect(property_hash[:name]).to eq('my-postgres')
+    end
+  end
+
+  describe 'create' do
+    it 'should create a postgres config' do
+      expected_metadata = {
+        :name => 'test',
+      }
+      expected_spec = {
+        :dsn => 'postgresql://sensu:changeme@localhost:5432/sensu',
+      }
+      expect(resource.provider).to receive(:sensuctl_create).with('PostgresConfig', expected_metadata, expected_spec, 'store/v1')
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+  end
+
+  describe 'flush' do
+    it 'should update a postgres config' do
+      expected_metadata = {
+        :name => 'test',
+      }
+      expected_spec = {
+        :dsn => 'postgresql://sensu:changeme@localhost:5432/sensu2',
+      }
+      expect(resource.provider).to receive(:sensuctl_create).with('PostgresConfig', expected_metadata, expected_spec, 'store/v1')
+      resource.provider.dsn = 'postgresql://sensu:changeme@localhost:5432/sensu2'
+      resource.provider.flush
+    end
+  end
+
+  describe 'destroy' do
+    it 'should delete a check' do
+      expected_metadata = {
+        :name => 'test',
+      }
+      expected_spec = {
+        :dsn => 'postgresql://sensu:changeme@localhost:5432/sensu',
+      }
+      expect(resource.provider).to receive(:sensuctl_delete).with('PostgresConfig', 'test', nil, expected_metadata, expected_spec, 'store/v1')
+      resource.provider.destroy
+      property_hash = resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash).to eq({})
+    end
+  end
+end
+

--- a/spec/unit/sensu_postgres_config_spec.rb
+++ b/spec/unit/sensu_postgres_config_spec.rb
@@ -1,0 +1,175 @@
+require 'spec_helper'
+require 'puppet/type/sensu_postgres_config'
+
+describe Puppet::Type.type(:sensu_postgres_config) do
+  let(:default_config) do
+    {
+      name: 'test',
+      dsn: 'postgresql://sensu:changeme@localhost:5432/sensu',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:resource) do
+    described_class.new(config)
+  end
+
+  it 'should add to catalog without raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource resource
+    }.to_not raise_error
+  end
+
+  it 'should require a name' do
+    expect {
+      described_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  defaults = {}
+
+  # String properties
+  [
+    :dsn,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 'foo'
+      expect(resource[property]).to eq('foo')
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(resource[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(resource[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # String regex validated properties
+  [
+  ].each do |property|
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo bar'
+      expect { resource }.to raise_error(Puppet::Error, /#{property.to_s} invalid/)
+    end
+  end
+
+  # Array properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = ['foo', 'bar']
+      expect(resource[property]).to eq(['foo', 'bar'])
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(resource[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(resource[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Integer properties
+  [
+    :pool_size,
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = 30
+      expect(resource[property]).to eq(30)
+    end
+    it "should accept valid #{property} as string" do
+      config[property] = '30'
+      expect(resource[property]).to eq(30)
+    end
+    it "should not accept invalid value for #{property}" do
+      config[property] = 'foo'
+      expect { resource }.to raise_error(Puppet::Error, /should be an Integer/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(resource[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(resource[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Boolean properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = true
+      expect(resource[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = false
+      expect(resource[property]).to eq(:false)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'true'
+      expect(resource[property]).to eq(:true)
+    end
+    it "should accept valid #{property}" do
+      config[property] = 'false'
+      expect(resource[property]).to eq(:false)
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { resource }.to raise_error(Puppet::Error, /Invalid value "foo". Valid values are true, false/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(resource[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(resource[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  # Hash properties
+  [
+  ].each do |property|
+    it "should accept valid #{property}" do
+      config[property] = { 'foo': 'bar' }
+      expect(resource[property]).to eq({'foo': 'bar'})
+    end
+    it "should not accept invalid #{property}" do
+      config[property] = 'foo'
+      expect { resource }.to raise_error(Puppet::Error, /should be a Hash/)
+    end
+    if default = defaults[property]
+      it "should have default for #{property}" do
+        expect(resource[property]).to eq(default)
+      end
+    else
+      it "should not have default for #{property}" do
+        expect(resource[property]).to eq(default_config[property])
+      end
+    end
+  end
+
+  include_examples 'autorequires', false do
+    let(:res) { resource }
+  end
+
+  [
+    :dsn,
+  ].each do |property|
+    it "should require property when ensure => present" do
+      config.delete(property)
+      config[:ensure] = :present
+      expect { resource.pre_run_check }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Move the configuration of Postgres in Sensu to a native type.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This replaces an file + exec with a custom type to make the postgres config management more streamlined.

This is backwards compatible as no behavior will change except if a site used this code we will remove a file that's no longer needed that was fed into sensuctl from the private class.  All parameters and behavior remain the same, just replacing File + Exec with Sensu_postgres_config type.