### PR TITLE
Only execute future release Rake function when generating changelog or release

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -58,6 +58,7 @@ namespace :acceptance do
 end
 
 def future_release
+  return unless (Rake.application.top_level_tasks.include?("changelog") || Rake.application.top_level_tasks.include?("release"))
   returnVal = "v%s" % JSON.load(File.read('metadata.json'))['version']
   raise "unable to find the future_release (version) in metadata.json" if returnVal.nil?
   puts "future_release:#{returnVal}"


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Only use `future_release` rake function when running changelog or release rake tasks which are only tasks that need this function.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1178 