### PR TITLE
Update default resources to match Sensu Go defaults

### DIFF
--- a/manifests/backend/default_resources.pp
+++ b/manifests/backend/default_resources.pp
@@ -91,10 +91,6 @@ class sensu::backend::default_resources {
         'verbs'     => ['get', 'update'],
         'resources' => ['localselfuser'],
       },
-      {
-        'verbs'     => ['get', 'list'],
-        'resources' => ['namespaces'],
-      },
     ],
   }
   sensu_cluster_role { 'view':

--- a/spec/classes/backend_default_resources_spec.rb
+++ b/spec/classes/backend_default_resources_spec.rb
@@ -113,11 +113,6 @@ describe 'sensu::backend::default_resources', :type => :class do
                 'resources' => ['localselfuser'],
                 'resource_names' => nil,
               },
-              {
-                'verbs'     => ['get', 'list'],
-                'resources' => ['namespaces'],
-                'resource_names' => nil,
-              },
             ],
           })
         }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Update defaults to match latest Sensu Go. Also add acceptance tests to catch when defaults do not match Sensu Go.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1180 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 5.14.2 updated the default resources to not give `system:user` access to all namespaces, this change matches that upstream change.
