### PR TITLE
Add several parameters to sensu::agent class

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: 5.0.1
     stdlib:
       repo: git://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 4.25.1
+      ref: 5.1.0
     yumrepo_core:
       repo: git://github.com/puppetlabs/puppetlabs-yumrepo_core
       ref: 1.0.1

--- a/README.md
+++ b/README.md
@@ -179,10 +179,8 @@ associated to `linux` and `apache-servers` subscriptions.
 
 ```puppet
   class { 'sensu::agent':
-    backends    => ['sensu-backend.example.com:8081'],
-    config_hash => {
-      'subscriptions' => ['linux', 'apache-servers'],
-    },
+    backends      => ['sensu-backend.example.com:8081'],
+    subscriptions => ['linux', 'apache-servers'],
   }
 ```
 
@@ -192,10 +190,8 @@ This module supports Windows Sensu Go agent via chocolatey beginning with versio
 
 ```puppet
 class { 'sensu::agent':
-  backends    => ['sensu-backend.example.com:8081'],
-  config_hash => {
-    'subscriptions' => ['windows'],
-  },
+  backends      => ['sensu-backend.example.com:8081'],
+  subscriptions => ['windows'],
 }
 ```
 
@@ -268,10 +264,8 @@ class { 'sensu':
   ssl_ca_source => 'puppet:///modules/profile/sensu/ca.pem',
 }
 class { 'sensu::agent':
-  backends    => ['sensu-backend.example.com:8081'],
-  config_hash => {
-    'subscriptions' => ['linux', 'apache-servers'],
-  },
+  backends      => ['sensu-backend.example.com:8081'],
+  subscriptions => ['linux', 'apache-servers'],
 }
 ```
 
@@ -336,10 +330,8 @@ Example installing plugins on agent:
 
 ```puppet
   class { 'sensu::agent':
-    backends    => ['sensu-backend.example.com:8081'],
-    config_hash => {
-      'subscriptions' => ['linux', 'apache-servers'],
-    },
+    backends      => ['sensu-backend.example.com:8081'],
+    subscriptions => ['linux', 'apache-servers'],
   }
   class { 'sensu::plugins':
     plugins => ['disk-checks'],
@@ -350,10 +342,8 @@ The `plugins` parameter can also be a Hash that sets the version:
 
 ```puppet
   class { 'sensu::agent':
-    backends    => ['sensu-backend.example.com:8081'],
-    config_hash => {
-      'subscriptions' => ['linux', 'apache-servers'],
-    },
+    backends      => ['sensu-backend.example.com:8081'],
+    subscriptions => ['linux', 'apache-servers'],
   }
   class { 'sensu::plugins':
     plugins => {
@@ -383,10 +373,8 @@ You can uninstall plugins by passing `ensure` as `absent`.
 
 ```puppet
   class { 'sensu::agent':
-    backends    => ['sensu-backend.example.com:8081'],
-    config_hash => {
-      'subscriptions' => ['linux', 'apache-servers'],
-    },
+    backends      => ['sensu-backend.example.com:8081'],
+    subscriptions => ['linux', 'apache-servers'],
   }
   class { 'sensu::plugins':
     plugins => {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -4,9 +4,10 @@
 #
 # @example
 #   class { 'sensu::agent':
-#     backends    => ['sensu-backend.example.com:8081'],
-#     config_hash => {
-#       'subscriptions => ['linux', 'apache-servers'],
+#     backends      => ['sensu-backend.example.com:8081'],
+#     subscriptions => ['linux', 'apache-servers'],
+#     config_hash   => {
+#       'log-level' => 'info',
 #     },
 #   }
 #
@@ -41,6 +42,21 @@
 #   The protocol prefix of `ws://` or `wss://` are optional and will be determined
 #   based on `sensu::use_ssl` parameter by default.
 #   Passing `backend-url` as part of `config_hash` takes precedence.
+# @param entity_name
+#   The value for agent.yml `name`.
+#   Passing `name` as part of `config_hash` takes precedence
+# @param subscriptions
+#   The agent subscriptions to define in agent.yml
+#   Passing `subscriptions` as part of `config_hash` takes precedence
+# @param annotations
+#   The agent annotations value for agent.yml
+#   Passing `annotations` as part of `config_hash` takes precedence
+# @param labels
+#   The agent labels value for agent.yml
+#   Passing `labels` as part of `config_hash` takes precedence
+# @param namespace
+#   The agent namespace
+#   Passing `namespace` as part of `config_hash` takes precedence
 # @param show_diff
 #   Sets show_diff parameter for agent.yml configuration file
 # @param log_file
@@ -59,6 +75,11 @@ class sensu::agent (
   Boolean $service_enable = true,
   Hash $config_hash = {},
   Array[Sensu::Backend_URL] $backends = ['localhost:8081'],
+  Optional[String] $entity_name = undef,
+  Optional[Array] $subscriptions = undef,
+  Optional[Hash] $annotations = undef,
+  Optional[Hash] $labels = undef,
+  Optional[String] $namespace = undef,
   Boolean $show_diff = true,
   Optional[Stdlib::Absolutepath] $log_file = undef,
 ) {
@@ -88,9 +109,14 @@ class sensu::agent (
       "${backend_protocol}://${backend}"
     }
   }
-  $default_config = {
-    'backend-url' => $backend_urls,
-  }
+  $default_config = delete_undef_values({
+    'backend-url'   => $backend_urls,
+    'name'          => $entity_name,
+    'subscriptions' => $subscriptions,
+    'annotations'   => $annotations,
+    'labels'        => $labels,
+    'namespace'     => $namespace,
+  })
   $config = $default_config + $ssl_config + $config_hash
   $_service_env_vars = $service_env_vars.map |$key,$value| {
     "${key}=\"${value}\""

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 4.25.1 < 7.0.0"
+      "version_requirement": ">= 5.1.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/01_agent_spec.rb
+++ b/spec/acceptance/01_agent_spec.rb
@@ -7,11 +7,12 @@ describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
       pp = <<-EOS
       class { '::sensu': }
       class { '::sensu::agent':
-        backends    => ['sensu_backend:8081'],
-        config_hash => {
-          'name' => 'sensu_agent',
-        },
+        backends         => ['sensu_backend:8081'],
+        entity_name      => 'sensu_agent',
         service_env_vars => { 'SENSU_API_PORT' => '4041' },
+        config_hash      => {
+          'log-level' => 'info',
+        }
       }
       EOS
 

--- a/spec/acceptance/03_no_ssl_spec.rb
+++ b/spec/acceptance/03_no_ssl_spec.rb
@@ -51,9 +51,7 @@ describe 'sensu without SSL', unless: RSpec.configuration.sensu_cluster do
       }
       class { '::sensu::agent':
         backends    => ['sensu_backend:8081'],
-        config_hash => {
-          'name' => 'sensu_agent',
-        }
+        entity_name => 'sensu_agent',
       }
       EOS
 

--- a/spec/acceptance/04_plugins_spec.rb
+++ b/spec/acceptance/04_plugins_spec.rb
@@ -14,9 +14,7 @@ describe 'sensu::plugins class', unless: RSpec.configuration.sensu_cluster do
       class { '::sensu': }
       class { '::sensu::agent':
         backends    => ['sensu_backend:8081'],
-        config_hash => {
-          'name' => 'sensu_agent',
-        }
+        entity_name => 'sensu_agent',
       }
       class { '::sensu::plugins':
         plugins => ['disk-checks'],

--- a/spec/acceptance/sensu_bolt_tasks_spec.rb
+++ b/spec/acceptance/sensu_bolt_tasks_spec.rb
@@ -8,9 +8,7 @@ describe 'sensu event task', if: RSpec.configuration.sensu_full do
       pp = <<-EOS
       class { '::sensu::agent':
         backends    => ['sensu_backend:8081'],
-        config_hash => {
-          'name' => 'sensu_agent',
-        }
+        entity_name => 'sensu_agent',
       }
       EOS
 
@@ -166,9 +164,7 @@ describe 'sensu check_execute task', if: RSpec.configuration.sensu_full do
       agent_pp = <<-EOS
       class { '::sensu::agent':
         backends    => ['sensu_backend:8081'],
-        config_hash => {
-          'name' => 'sensu_agent',
-        }
+        entity_name => 'sensu_agent',
       }
       EOS
       apply_manifest_on(backend, pp, :catch_failures => true)
@@ -266,9 +262,7 @@ describe 'sensu agent_event task', if: RSpec.configuration.sensu_full do
       agent_pp = <<-EOS
       class { '::sensu::agent':
         backends    => ['sensu_backend:8081'],
-        config_hash => {
-          'name' => 'sensu_agent',
-        }
+        entity_name => 'sensu_agent',
       }
       EOS
       apply_manifest_on(agent, agent_pp, :catch_failures => true)

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -22,8 +22,8 @@ describe 'sensu::agent class', if: Gem.win_platform? do
         puts File.read('C:\manifest-agent.pp')
       end
 
-      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp') do
-        its(:exit_status) { is_expected.to eq 256 }
+      describe command('puppet apply --debug C:\manifest-agent.pp') do
+        its(:exit_status) { is_expected.to eq 0 }
       end
     end
 
@@ -65,8 +65,8 @@ describe 'sensu::agent class', if: Gem.win_platform? do
         its(:exit_status) { is_expected.to eq 0 }
       end
 
-      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp') do
-        its(:exit_status) { is_expected.to eq 256 }
+      describe command('puppet apply --debug C:\manifest-agent.pp') do
+        its(:exit_status) { is_expected.to eq 0 }
       end
     end
 

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -6,11 +6,12 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     pp = <<-EOS
     class { '::sensu': }
     class { '::sensu::agent':
-      backends       => ['sensu_backend:8081'],
-      config_hash    => {
-        'name' => 'sensu_agent',
-      },
+      backends         => ['sensu_backend:8081'],
+      entity_name      => 'sensu_agent',
       service_env_vars => { 'SENSU_API_PORT' => '4041' },
+      config_hash      => {
+        'log-level' => 'info',
+      }
     }
     EOS
 
@@ -46,8 +47,9 @@ describe 'sensu::agent class', if: Gem.win_platform? do
       package_name   => 'Sensu Agent',
       package_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.13.1/sensu-go-agent_5.13.1.5957_en-US.x64.msi',
       backends       => ['sensu_backend:8081'],
+      entity_name    => 'sensu_agent',
       config_hash    => {
-        'name' => 'sensu_agent',
+        'log-level' => 'info',
       }
     }
     EOS

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -176,6 +176,67 @@ describe 'sensu::agent', :type => :class do
         it { should contain_service('sensu-agent').without_notify }
       end
 
+      context 'with agent configs defined' do
+        let(:params) do
+          {
+            entity_name: 'hostname',
+            subscriptions: ['linux','base'],
+            annotations: { 'foo' => 'bar' },
+            labels: { 'bar' => 'baz' },
+            namespace: 'qa',
+          }
+        end
+
+        agent_content = <<-END.gsub(/^\s+\|/, '')
+          |---
+          |backend-url:
+          |- wss://localhost:8081
+          |name: hostname
+          |subscriptions:
+          |- linux
+          |- base
+          |annotations:
+          |  foo: bar
+          |labels:
+          |  bar: baz
+          |namespace: qa
+          |trusted-ca-file: #{platforms[facts[:osfamily]][:ca_path_yaml]}
+        END
+        it { should contain_file('sensu_agent_config').with_content(agent_content) }
+      end
+
+      context 'with agent configs defined and config_hash' do
+        let(:params) do
+          {
+            entity_name: 'hostname',
+            subscriptions: ['linux','base'],
+            annotations: { 'foo' => 'bar' },
+            labels: { 'bar' => 'baz' },
+            namespace: 'qa',
+            config_hash: {
+              'subscriptions' => ['windows'],
+              'namespace' => 'default',
+            }
+          }
+        end
+
+        agent_content = <<-END.gsub(/^\s+\|/, '')
+          |---
+          |backend-url:
+          |- wss://localhost:8081
+          |name: hostname
+          |subscriptions:
+          |- windows
+          |annotations:
+          |  foo: bar
+          |labels:
+          |  bar: baz
+          |namespace: default
+          |trusted-ca-file: #{platforms[facts[:osfamily]][:ca_path_yaml]}
+        END
+        it { should contain_file('sensu_agent_config').with_content(agent_content) }
+      end
+
       context 'with show_diff => false' do
         let(:params) {{ :show_diff => false }}
         it { should contain_file('sensu_agent_config').with_show_diff('false') }

--- a/tasks/install_agent_linux.rb
+++ b/tasks/install_agent_linux.rb
@@ -38,11 +38,9 @@ class { '::sensu':
   use_ssl => false,
 }
 class { '::sensu::agent':
-  backends    => ['#{backend}'],
-  config_hash => {
-    'subscriptions' => ['#{subscription}'],
-    'namespace'     => '#{namespace}',
-  },
+  backends      => ['#{backend}'],
+  subscriptions => ['#{subscription}'],
+  namespace     => '#{namespace}',
 }
 EOS
   return_output['manifest'] = manifest.split(/\n/)

--- a/tasks/install_agent_windows.ps1
+++ b/tasks/install_agent_windows.ps1
@@ -27,10 +27,8 @@ class { '::sensu':
 class { '::sensu::agent':
   package_source => '$Package_source',
   backends       => ['$Backend'],
-  config_hash    => {
-    'subscriptions' => ['$Subscription'],
-    'namespace'     => '$Namespace',
-  },
+  subscriptions  => ['$Subscription'],
+  namespace      => '$Namespace',
 }
 "@
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add several parameters to `sensu::agent` that are the more important configuration options. The old way of using `config_hash` is still valid and takes priority and is documented and unit tested.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Was thought of while thinking of solution for #1183 but won't actually solve the problem

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The very important config options for agents should be first class parameters with data types.
