### PR TITLE
Document contact routing and bonsai asset bugfix

### DIFF
--- a/lib/puppet/provider/sensu_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_asset/sensuctl.rb
@@ -44,7 +44,7 @@ Puppet::Type.type(:sensu_asset).provide(:sensuctl, :parent => Puppet::Provider::
   end
 
   def exists?
-    @property_hash[:ensure] == :present
+    (@property_hash[:ensure] == :present || resource[:bonsai] == :true)
   end
 
   def initialize(value = {})

--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -151,6 +151,10 @@ DESC
   newproperty(:namespace, :namevar => true) do
     desc "The Sensu RBAC namespace that this asset belongs to."
     defaultto 'default'
+    def insync?(is)
+      return true if @resource[:bonsai] == :true
+      super(is)
+    end
   end
 
   newproperty(:labels, :parent => PuppetX::Sensu::HashProperty) do

--- a/lib/puppet/type/sensu_bonsai_asset.rb
+++ b/lib/puppet/type/sensu_bonsai_asset.rb
@@ -96,6 +96,7 @@ DESC
     asset_opts = {}
     asset_opts[:ensure] = self[:ensure]
     asset_opts[:name] = "#{self[:rename]} in #{self[:namespace]}"
+    asset_opts[:namespace] = self[:namespace]
     asset_opts[:require] = "Sensu_bonsai_asset[#{self[:name]}]"
     asset_opts[:bonsai] = true
     asset_opts[:provider] = self[:provider] if self[:provider]

--- a/spec/acceptance/examples_spec.rb
+++ b/spec/acceptance/examples_spec.rb
@@ -1,0 +1,77 @@
+require 'spec_helper_acceptance'
+
+describe 'contact routing', if: RSpec.configuration.sensu_full do
+  node = hosts_as('sensu_backend')[0]
+  context 'default' do
+    it 'should work without errors' do
+      pp = <<-EOS
+include sensu::backend
+sensu_bonsai_asset { 'sensu/sensu-go-has-contact-filter':
+  ensure  => 'present',
+  version => '0.2.0',
+}
+sensu_filter { 'contact_dev':
+  ensure         => 'present',
+  action         => 'allow',
+  runtime_assets => ['sensu/sensu-go-has-contact-filter'],
+  expressions    => ['has_contact(event, "dev")'],
+}
+sensu_filter { 'contact_ops':
+  ensure         => 'present',
+  action         => 'allow',
+  runtime_assets => ['sensu/sensu-go-has-contact-filter'],
+  expressions    => ['has_contact(event, "ops")'],
+}
+sensu_bonsai_asset { 'sensu/sensu-email-handler':
+  ensure  => 'present',
+  version => '0.2.0',
+}
+sensu_handler { 'email_dev':
+  ensure          => 'present',
+  type            => 'pipe',
+  command         => 'sensu-email-handler -f root@localhost -t dev@example.com -s localhost -i',
+  timeout         => 10,
+  runtime_assets  => ['sensu/sensu-email-handler'],
+  filters         => ['is_incident','not_silenced','contact_dev'],
+}
+sensu_handler { 'email_ops':
+  ensure          => 'present',
+  type            => 'pipe',
+  command         => 'sensu-email-handler -f root@localhost -t ops@example.com -s localhost -i',
+  timeout         => 10,
+  runtime_assets  => ['sensu/sensu-email-handler'],
+  filters         => ['is_incident','not_silenced','contact_ops'],
+}
+sensu_handler { 'email':
+  ensure    => 'present',
+  type      => 'set',
+  handlers  => ['email_dev','email_ops'],
+}
+sensu_check { 'check_cpu':
+  ensure         => 'present',
+  labels         => {
+    'contacts' => 'dev, ops',
+  },
+  command        => 'check-cpu.rb -w 75 -c 90',
+  handlers       => ['email'],
+  interval       => 30,
+  publish        => true,
+  subscriptions  => ['linux'],
+  runtime_assets => ['sensu-plugins-cpu-checks','sensu-ruby-runtime'],
+}
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Document contact routing.
Also add a bugfix to way bonsai assets define meta-assets in Puppet. The issue I saw was only manifesting itself when catalog contained multiple `sensu_bonsai_asset` resources. The issue was attempts to create invalid `sensu_assets` based on the meta resource. The changes avoid the meta resource ever getting created.

For context the meta-resource generated by `sensu_bonsai_asset` is necessary to support resource purging `sensu_asset` resources without deleting the assets defined by `sensu_bonsai_asset`.
