### PR TITLE
Added content parameters to allow usage of both source and content in cert and keys

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -186,19 +186,8 @@ Default value: `true`
 Data type: `Optional[String]`
 
 Source of SSL CA used by sensu services
-Supports any valid Puppet File sources such as absolute paths or puppet:///
-Do not define with ssl_ca_content
 
-Default value: `undef`
-
-##### `ssl_ca_content`
-
-Data type: `Optional[String]`
-
-Content of SSL CA used by sensu services
-Do not define with ssl_ca_source
-
-Default value: `undef`
+Default value: $facts['puppet_localcacert']
 
 ##### `api_host`
 
@@ -538,38 +527,16 @@ Default value: {}
 Data type: `Optional[String]`
 
 The SSL certificate source
-Supports any valid Puppet File sources such as absolute paths or puppet:///
-Do not define with ssl_cert_content
 
-Default value: `undef`
-
-##### `ssl_cert_content`
-
-Data type: `Optional[String]`
-
-The SSL certificate content
-Do not define with ssl_cert_source
-
-Default value: `undef`
+Default value: $facts['puppet_hostcert']
 
 ##### `ssl_key_source`
 
 Data type: `Optional[String]`
 
 The SSL private key source
-Supports any valid Puppet File sources such as absolute paths or puppet:///
-Do not define with ssl_key_content
 
-Default value: `undef`
-
-##### `ssl_key_content`
-
-Data type: `Optional[String]`
-
-The SSL private key content
-Do not define with ssl_key_source
-
-Default value: `undef`
+Default value: $facts['puppet_hostprivkey']
 
 ##### `include_default_resources`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -186,8 +186,19 @@ Default value: `true`
 Data type: `Optional[String]`
 
 Source of SSL CA used by sensu services
+Supports any valid Puppet File sources such as absolute paths or puppet:///
+Do not define with ssl_ca_content
 
-Default value: $facts['puppet_localcacert']
+Default value: `undef`
+
+##### `ssl_ca_content`
+
+Data type: `Optional[String]`
+
+Content of SSL CA used by sensu services
+Do not define with ssl_ca_source
+
+Default value: `undef`
 
 ##### `api_host`
 
@@ -527,16 +538,38 @@ Default value: {}
 Data type: `Optional[String]`
 
 The SSL certificate source
+Supports any valid Puppet File sources such as absolute paths or puppet:///
+Do not define with ssl_cert_content
 
-Default value: $facts['puppet_hostcert']
+Default value: `undef`
+
+##### `ssl_cert_content`
+
+Data type: `Optional[String]`
+
+The SSL certificate content
+Do not define with ssl_cert_source
+
+Default value: `undef`
 
 ##### `ssl_key_source`
 
 Data type: `Optional[String]`
 
 The SSL private key source
+Supports any valid Puppet File sources such as absolute paths or puppet:///
+Do not define with ssl_key_content
 
-Default value: $facts['puppet_hostprivkey']
+Default value: `undef`
+
+##### `ssl_key_content`
+
+Data type: `Optional[String]`
+
+The SSL private key content
+Do not define with ssl_key_source
+
+Default value: `undef`
 
 ##### `include_default_resources`
 

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -128,17 +128,17 @@ class sensu::backend (
   $api_protocol = $sensu::api_protocol
   $password = $sensu::password
 
-  if $use_ssl and ! ($ssl_cert_source or $ssl_cert_content) {
-    fail('sensu::backend: ssl_cert_source or ssl_cert_content must be defined when sensu::use_ssl is true')
-  }
   if $use_ssl and $ssl_cert_source and $ssl_cert_content {
     fail('sensu::backend: Do not define both ssl_cert_source and ssl_cert_content_content')
   }
-  if $use_ssl and ! ($ssl_key_source or $ssl_key_content) {
-    fail('sensu::backend: ssl_key_source or ssl_cert_content must be defined when sensu::use_ssl is true')
+  if $use_ssl and ! ($ssl_cert_source and $ssl_cert_content) {
+    $ssl_cert_source = $facts['puppet_hostcert']
   }
   if $use_ssl and $ssl_key_source and $ssl_key_content {
     fail('sensu::backend: Do not define both ssl_key_source and ssl_key_content')
+  }
+  if $use_ssl and ! ($ssl_key_source and $ssl_key_content) {
+    $ssl_key_source = $facts['puppet_hostprivkey']
   }
 
   if $use_ssl {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,8 +41,10 @@
 #
 # @param ssl_ca_source
 #   Source of SSL CA used by sensu services
+#   Do not define with ssl_ca_content
 # @param ssl_ca_content
 #   Content of SSL CA used by sensu services
+#   Do not define with ssl_ca_source
 #
 # @param api_host
 #   Sensu backend host used to configure sensuctl and verify API access.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,8 @@
 #
 # @param ssl_ca_source
 #   Source of SSL CA used by sensu services
+# @param ssl_ca_content
+#   Content of SSL CA used by sensu services
 #
 # @param api_host
 #   Sensu backend host used to configure sensuctl and verify API access.
@@ -66,7 +68,8 @@ class sensu (
   Boolean $ssl_dir_purge = true,
   Boolean $manage_repo = true,
   Boolean $use_ssl = true,
-  Optional[String] $ssl_ca_source = $facts['puppet_localcacert'],
+  Optional[String] $ssl_ca_source = undef,
+  Optional[String] $ssl_ca_content = undef,
   String $api_host = $trusted['certname'],
   Stdlib::Port $api_port = 8080,
   String $password = 'P@ssw0rd!',
@@ -75,8 +78,11 @@ class sensu (
   Optional[String] $agent_old_password = undef,
 ) {
 
-  if $use_ssl and ! $ssl_ca_source {
-    fail('sensu: ssl_ca_source must be defined when use_ssl is true')
+  if $use_ssl and ! ($ssl_ca_source or $ssl_ca_content) {
+    fail('sensu: ssl_ca_source or $ssl_ca_content must be defined when use_ssl is true')
+  }
+  if $use_ssl and $ssl_ca_source and $ssl_ca_content {
+    fail('sensu::backend: Do not define both ssl_ca_source and ssl_ca_content_content')
   }
 
   if $facts['os']['family'] == 'windows' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -80,11 +80,11 @@ class sensu (
   Optional[String] $agent_old_password = undef,
 ) {
 
-  if $use_ssl and ! ($ssl_ca_source or $ssl_ca_content) {
-    fail('sensu: ssl_ca_source or $ssl_ca_content must be defined when use_ssl is true')
-  }
   if $use_ssl and $ssl_ca_source and $ssl_ca_content {
     fail('sensu::backend: Do not define both ssl_ca_source and ssl_ca_content_content')
+  }
+  if $use_ssl and ! ($ssl_ca_source or $ssl_ca_content) {
+    $ssl_ca_source = $facts['puppet_localcacert']
   }
 
   if $facts['os']['family'] == 'windows' {

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -31,5 +31,6 @@ class sensu::ssl {
     mode      => $file_mode,
     show_diff => false,
     source    => $sensu::ssl_ca_source,
+    content   => $sensu::ssl_ca_content,
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Changes to the backend.pp
- Added content parameters for ssl_cert and ssl_key
- Added if statements to check if at least one variable is used in combination with `$use_ssl`
- Added if statements to check if not both source and content are in use

Changes to init.pp
- Added content parameters for ssl_ca
- Added if statements to check if at least one variable is used in combination with `$use_ssl`
- Added if statements to check if not both source and content are in use

## Related Issue
https://github.com/sensu/sensu-puppet/issues/1196

## Motivation and Context
These changes allow the use of either content or source parameters for the ssl_ca, ssl_cert and ssl_key. 

When using a puppet server which pulls the puppet code from a git repository, it would result in a private key to be uploaded to git to allow the puppet server access to the code. When that git server is accessible by multiple users it allows for the private key to be leaked and therefore be insecure.

## How Has This Been Tested?
I have not yet been able to test this.
