### PR TITLE
Allow SSL files to be defined via content parameters

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -28,16 +28,16 @@
 #   Sensu backend configuration hash used to define backend.yml.
 # @param ssl_cert_source
 #   The SSL certificate source
-#   Do not define with ssl_cert_content
+#   This parameter is mutually exclusive with ssl_cert_content
 # @param ssl_cert_content
 #   The SSL certificate content
-#   Do not define with ssl_cert_source
+#   This parameter is mutually exclusive with ssl_cert_source
 # @param ssl_key_source
 #   The SSL private key source
-#   Do not define with ssl_key_content
+#   This parameter is mutually exclusive with ssl_key_content
 # @param ssl_key_content
 #   The SSL private key content
-#   Do not define with ssl_key_content
+#   This parameter is mutually exclusive with ssl_key_source
 # @param include_default_resources
 #   Sets if default sensu resources should be included
 # @param show_diff

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -28,8 +28,16 @@
 #   Sensu backend configuration hash used to define backend.yml.
 # @param ssl_cert_source
 #   The SSL certificate source
+#   Do not define with ssl_cert_content
+# @param ssl_cert_content
+#   The SSL certificate content
+#   Do not define with ssl_cert_source
 # @param ssl_key_source
 #   The SSL private key source
+#   Do not define with ssl_key_content
+# @param ssl_key_content
+#   The SSL private key content
+#   Do not define with ssl_key_content
 # @param include_default_resources
 #   Sets if default sensu resources should be included
 # @param show_diff
@@ -78,7 +86,9 @@ class sensu::backend (
   Stdlib::Absolutepath $state_dir = '/var/lib/sensu/sensu-backend',
   Hash $config_hash = {},
   Optional[String] $ssl_cert_source = $facts['puppet_hostcert'],
+  Optional[String] $ssl_cert_content = undef,
   Optional[String] $ssl_key_source = $facts['puppet_hostprivkey'],
+  Optional[String] $ssl_key_content = undef,
   Boolean $include_default_resources = true,
   Boolean $show_diff = true,
   Optional[String] $license_source = undef,
@@ -118,14 +128,24 @@ class sensu::backend (
   $api_protocol = $sensu::api_protocol
   $password = $sensu::password
 
-  if $use_ssl and ! $ssl_cert_source {
-    fail('sensu::backend: ssl_cert_source must be defined when sensu::use_ssl is true')
+  if $ssl_cert_content {
+    $_ssl_cert_source = undef
+  } else {
+    $_ssl_cert_source = $ssl_cert_source
   }
-  if $use_ssl and ! $ssl_key_source {
-    fail('sensu::backend: ssl_key_source must be defined when sensu::use_ssl is true')
+  if $ssl_key_content {
+    $_ssl_key_source = undef
+  } else {
+    $_ssl_key_source = $ssl_key_source
   }
 
   if $use_ssl {
+    if !($_ssl_cert_source or $ssl_cert_content) {
+      fail('sensu::backend: ssl_cert_source or ssl_cert_content must be defined when sensu::use_ssl is true')
+    }
+    if !($_ssl_key_source or $ssl_key_content) {
+      fail('sensu::backend: ssl_key_source or ssl_key_content must be defined when sensu::use_ssl is true')
+    }
     $trusted_ca_file = "${ssl_dir}/ca.crt"
     $ssl_config = {
       'cert-file'       => "${ssl_dir}/cert.pem",
@@ -202,7 +222,8 @@ class sensu::backend (
     file { 'sensu_ssl_cert':
       ensure    => 'file',
       path      => "${ssl_dir}/cert.pem",
-      source    => $ssl_cert_source,
+      source    => $_ssl_cert_source,
+      content   => $ssl_cert_content,
       owner     => $sensu::user,
       group     => $sensu::group,
       mode      => '0644',
@@ -212,7 +233,8 @@ class sensu::backend (
     file { 'sensu_ssl_key':
       ensure    => 'file',
       path      => "${ssl_dir}/key.pem",
-      source    => $ssl_key_source,
+      source    => $_ssl_key_source,
+      content   => $ssl_key_content,
       owner     => $sensu::user,
       group     => $sensu::group,
       mode      => '0600',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,6 +41,11 @@
 #
 # @param ssl_ca_source
 #   Source of SSL CA used by sensu services
+#   Do not define with ssl_ca_content
+#
+# @param ssl_ca_content
+#   Content of SSL CA used by sensu services
+#   Do not define with ssl_ca_source
 #
 # @param api_host
 #   Sensu backend host used to configure sensuctl and verify API access.
@@ -67,6 +72,7 @@ class sensu (
   Boolean $manage_repo = true,
   Boolean $use_ssl = true,
   Optional[String] $ssl_ca_source = $facts['puppet_localcacert'],
+  Optional[String] $ssl_ca_content = undef,
   String $api_host = $trusted['certname'],
   Stdlib::Port $api_port = 8080,
   String $password = 'P@ssw0rd!',
@@ -75,8 +81,13 @@ class sensu (
   Optional[String] $agent_old_password = undef,
 ) {
 
-  if $use_ssl and ! $ssl_ca_source {
-    fail('sensu: ssl_ca_source must be defined when use_ssl is true')
+  if $ssl_ca_content {
+    $_ssl_ca_source = undef
+  } else {
+    $_ssl_ca_source = $ssl_ca_source
+  }
+  if $use_ssl and !($_ssl_ca_source or $ssl_ca_content) {
+    fail('sensu: ssl_ca_source or ssl_ca_content must be defined when use_ssl is true')
   }
 
   if $facts['os']['family'] == 'windows' {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,11 +41,11 @@
 #
 # @param ssl_ca_source
 #   Source of SSL CA used by sensu services
-#   Do not define with ssl_ca_content
+#   This parameter is mutually exclusive with ssl_ca_content
 #
 # @param ssl_ca_content
 #   Content of SSL CA used by sensu services
-#   Do not define with ssl_ca_source
+#   This parameter is mutually exclusive with ssl_ca_source
 #
 # @param api_host
 #   Sensu backend host used to configure sensuctl and verify API access.

--- a/manifests/ssl.pp
+++ b/manifests/ssl.pp
@@ -30,6 +30,7 @@ class sensu::ssl {
     group     => $sensu::sensu_group,
     mode      => $file_mode,
     show_diff => false,
-    source    => $sensu::ssl_ca_source,
+    source    => $sensu::_ssl_ca_source,
+    content   => $sensu::ssl_ca_content,
   }
 }

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -53,6 +53,7 @@ describe 'sensu::backend', :type => :class do
             'ensure'    => 'file',
             'path'      => '/etc/sensu/ssl/cert.pem',
             'source'    => '/dne/cert.pem',
+            'content'   => nil,
             'owner'     => 'sensu',
             'group'     => 'sensu',
             'mode'      => '0644',
@@ -66,6 +67,7 @@ describe 'sensu::backend', :type => :class do
             'ensure'    => 'file',
             'path'      => '/etc/sensu/ssl/key.pem',
             'source'    => '/dne/key.pem',
+            'content'   => nil,
             'owner'     => 'sensu',
             'group'     => 'sensu',
             'mode'      => '0600',
@@ -153,12 +155,22 @@ describe 'sensu::backend', :type => :class do
 
       context 'when puppet_hostcert undefined' do
         let(:facts) { facts.merge(puppet_hostcert: nil) }
-        it { should compile.and_raise_error(/ssl_cert_source must be defined/) }
+        it { should compile.and_raise_error(/ssl_cert_source or ssl_cert_content must be defined/) }
       end
 
       context 'when puppet_hostprivkey undefined' do
         let(:facts) { facts.merge(puppet_hostprivkey: nil) }
-        it { should compile.and_raise_error(/ssl_key_source must be defined/) }
+        it { should compile.and_raise_error(/ssl_key_source or ssl_key_content must be defined/) }
+      end
+
+      context 'when ssl_cert_content defined' do
+        let(:params) { { ssl_cert_content: 'foo' } }
+        it { should contain_file('sensu_ssl_cert').with_content('foo').without_source }
+      end
+
+      context 'when ssl_key_content defined' do
+        let(:params) { { ssl_key_content: 'foo' } }
+        it { should contain_file('sensu_ssl_key').with_content('foo').without_source }
       end
 
       context 'with use_ssl => false' do

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -22,7 +22,7 @@ describe 'sensu', :type => :class do
 
       context 'when puppet_localcacert undefined' do
         let(:facts) { facts.merge!(puppet_localcacert: nil) }
-        it { should compile.and_raise_error(/ssl_ca_source must be defined/) }
+        it { should compile.and_raise_error(/ssl_ca_source or ssl_ca_content must be defined/) }
       end
     end
   end

--- a/spec/classes/ssl_spec.rb
+++ b/spec/classes/ssl_spec.rb
@@ -37,8 +37,14 @@ describe 'sensu::ssl', :type => :class do
             'mode'      => platforms[facts[:osfamily]][:ca_mode],
             'show_diff' => 'false',
             'source'    => facts['puppet_localcacert'],
+            'content'   => nil,
           })
         }
+
+        context 'when ssl_ca_content is defined' do
+          let(:pre_condition) { "class { 'sensu': ssl_ca_content => 'foo' }" }
+          it { should contain_file('sensu_ssl_ca').with_content('foo').without_source }
+        end
       end
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow SSL CA cert, cert and key to be defined via content.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1196 and replaces #1197 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This allows one to define SSL file contents via Hiera using EYAML.