### PR TITLE
Remove unnecessary auto requirement

### DIFF
--- a/lib/puppet/type/sensu_ad_auth.rb
+++ b/lib/puppet/type/sensu_ad_auth.rb
@@ -6,7 +6,7 @@ require_relative '../../puppet_x/sensu/integer_property'
 
 Puppet::Type.newtype(:sensu_ad_auth) do
   desc <<-DESC
-@summary Manages Sensu AD auth. Requires valid enterprise license.
+@summary Manages Sensu AD auth.
 @example Add a AD auth
   sensu_ldap_auth { 'ad':
     ensure              => 'present',
@@ -33,7 +33,6 @@ Puppet::Type.newtype(:sensu_ad_auth) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
-* `Exec[sensu-add-license]`
 DESC
 
   extend PuppetX::Sensu::Type
@@ -220,10 +219,6 @@ DESC
 
   newproperty(:username_prefix) do
     desc 'The prefix added to all LDAP usernames.'
-  end
-
-  autorequire(:exec) do
-    [ 'sensu-add-license' ]
   end
 
   validate do

--- a/lib/puppet/type/sensu_ldap_auth.rb
+++ b/lib/puppet/type/sensu_ldap_auth.rb
@@ -6,7 +6,7 @@ require_relative '../../puppet_x/sensu/integer_property'
 
 Puppet::Type.newtype(:sensu_ldap_auth) do
   desc <<-DESC
-@summary Manages Sensu LDAP auth. Requires valid enterprise license.
+@summary Manages Sensu LDAP auth.
 @example Add a LDAP auth
   sensu_ldap_auth { 'openldap':
     ensure              => 'present',
@@ -33,7 +33,6 @@ Puppet::Type.newtype(:sensu_ldap_auth) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
-* `Exec[sensu-add-license]`
 DESC
 
   extend PuppetX::Sensu::Type
@@ -214,10 +213,6 @@ DESC
 
   newproperty(:username_prefix) do
     desc 'The prefix added to all LDAP usernames.'
-  end
-
-  autorequire(:exec) do
-    [ 'sensu-add-license' ]
   end
 
   validate do

--- a/lib/puppet/type/sensu_oidc_auth.rb
+++ b/lib/puppet/type/sensu_oidc_auth.rb
@@ -6,7 +6,7 @@ require_relative '../../puppet_x/sensu/integer_property'
 
 Puppet::Type.newtype(:sensu_oidc_auth) do
   desc <<-DESC
-@summary Manages Sensu OIDC auth. Requires valid enterprise license.
+@summary Manages Sensu OIDC auth.
 @example Add an Active Directory auth
   sensu_oidc_auth { 'oidc':
     ensure            => 'present',
@@ -26,7 +26,6 @@ Puppet::Type.newtype(:sensu_oidc_auth) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
-* `Exec[sensu-add-license]`
 DESC
 
   extend PuppetX::Sensu::Type
@@ -87,10 +86,6 @@ DESC
 
   newproperty(:additional_scopes, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
     desc 'Scopes to include in the claims'
-  end
-
-  autorequire(:exec) do
-    [ 'sensu-add-license' ]
   end
 
   validate do

--- a/spec/unit/sensu_ad_auth_spec.rb
+++ b/spec/unit/sensu_ad_auth_spec.rb
@@ -267,16 +267,6 @@ describe Puppet::Type.type(:sensu_ad_auth) do
     let(:res) { auth }
   end
 
-  it 'should autorequire Exec[sensu-add-license]' do
-    exec = Puppet::Type.type(:exec).new(:name => 'sensu-add-license', :path => '/usr/bin')
-    catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource auth
-    catalog.add_resource exec
-    rel = auth.autorequire[0]
-    expect(rel.source.ref).to eq(exec.ref)
-    expect(rel.target.ref).to eq(auth.ref)
-  end
-
   [
     :servers,
   ].each do |property|

--- a/spec/unit/sensu_ldap_auth_spec.rb
+++ b/spec/unit/sensu_ldap_auth_spec.rb
@@ -267,16 +267,6 @@ describe Puppet::Type.type(:sensu_ldap_auth) do
     let(:res) { auth }
   end
 
-  it 'should autorequire Exec[sensu-add-license]' do
-    exec = Puppet::Type.type(:exec).new(:name => 'sensu-add-license', :path => '/usr/bin')
-    catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource auth
-    catalog.add_resource exec
-    rel = auth.autorequire[0]
-    expect(rel.source.ref).to eq(exec.ref)
-    expect(rel.target.ref).to eq(auth.ref)
-  end
-
   [
     :servers,
   ].each do |property|

--- a/spec/unit/sensu_oidc_auth_spec.rb
+++ b/spec/unit/sensu_oidc_auth_spec.rb
@@ -179,16 +179,6 @@ describe Puppet::Type.type(:sensu_oidc_auth) do
     let(:res) { auth }
   end
 
-  it 'should autorequire Exec[sensu-add-license]' do
-    exec = Puppet::Type.type(:exec).new(:name => 'sensu-add-license', :path => '/usr/bin')
-    catalog = Puppet::Resource::Catalog.new
-    catalog.add_resource auth
-    catalog.add_resource exec
-    rel = auth.autorequire[0]
-    expect(rel.source.ref).to eq(exec.ref)
-    expect(rel.target.ref).to eq(auth.ref)
-  end
-
   [
     :client_id,
     :client_secret,


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Remove unnecessary auto requirement on license being added.  The authentication types no longer require a license to manage below 100 entities. This is backwards compatible as this extra code wasn't doing anything in most cases and no longer necessary to setup this dependency.  This would only break installs before 5.16 which the latest version of this module no longer supports.