### PR TITLE
Several fixes for sensu_bonsai_asset

### DIFF
--- a/lib/puppet/provider/sensu_api.rb
+++ b/lib/puppet/provider/sensu_api.rb
@@ -225,4 +225,21 @@ class Puppet::Provider::SensuAPI < Puppet::Provider
   def get_bonsai_asset(name)
     self.class.get_bonsai_asset(name)
   end
+  def self.get_bonsai_latest_version(namespace, name)
+    return nil if namespace.nil? || name.nil?
+    full_name = "#{namespace}/#{name}"
+    @latest_version = {} if @latest_version.nil?
+    return @latest_version[full_name] if @latest_version[full_name]
+    @latest_version[full_name] = nil
+    versions = []
+    bonsai_asset = Puppet::Provider::SensuAPI.get_bonsai_asset(full_name)
+    (bonsai_asset['versions'] || []).each do |bonsai_version|
+      version = bonsai_version['version']
+      next unless version =~ /^[0-9]/
+      versions << version
+    end
+    versions = versions.sort_by { |v| Gem::Version.new(v) }
+    @latest_version[full_name] = versions.last
+    @latest_version[full_name]
+  end
 end

--- a/lib/puppet/provider/sensu_bonsai_asset/sensu_api.rb
+++ b/lib/puppet/provider/sensu_bonsai_asset/sensu_api.rb
@@ -45,19 +45,7 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensu_api, :parent => Puppet::Pr
   end
 
   def self.latest_version(namespace, name)
-    return @latest_version if @latest_version
-    @latest_version = nil
-    return nil if namespace.nil? || name.nil?
-    versions = []
-    bonsai_asset = self.get_bonsai_asset("#{namespace}/#{name}")
-    (bonsai_asset['versions'] || []).each do |bonsai_version|
-      version = bonsai_version['version']
-      next unless version =~ /^[0-9]/
-      versions << version
-    end
-    versions = versions.sort_by { |v| Gem::Version.new(v) }
-    @latest_version = versions.last
-    @latest_version
+    get_bonsai_latest_version(namespace, name)
   end
 
   def exists?

--- a/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
@@ -46,19 +46,7 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensuctl, :parent => Puppet::Pro
   end
 
   def self.latest_version(namespace, name)
-    return @latest_version if @latest_version
-    @latest_version = nil
-    return nil if namespace.nil? || name.nil?
-    versions = []
-    bonsai_asset = Puppet::Provider::SensuAPI.get_bonsai_asset("#{namespace}/#{name}")
-    (bonsai_asset['versions'] || []).each do |bonsai_version|
-      version = bonsai_version['version']
-      next unless version =~ /^[0-9]/
-      versions << version
-    end
-    versions = versions.sort_by { |v| Gem::Version.new(v) }
-    @latest_version = versions.last
-    @latest_version
+    Puppet::Provider::SensuAPI.get_bonsai_latest_version(namespace, name)
   end
 
   def exists?

--- a/lib/puppet/type/sensu_bonsai_asset.rb
+++ b/lib/puppet/type/sensu_bonsai_asset.rb
@@ -93,15 +93,19 @@ DESC
   # Generate sensu_asset resource to avoid resource purging deleting
   # sensu_bonsai_asset resources
   def generate
-    asset_opts = {}
-    asset_opts[:ensure] = self[:ensure]
-    asset_opts[:name] = "#{self[:rename]} in #{self[:namespace]}"
-    asset_opts[:namespace] = self[:namespace]
-    asset_opts[:require] = "Sensu_bonsai_asset[#{self[:name]}]"
-    asset_opts[:bonsai] = true
-    asset_opts[:provider] = self[:provider] if self[:provider]
-    asset = Puppet::Type.type(:sensu_asset).new(asset_opts)
-    [asset]
+    resources = []
+    if self[:ensure].to_s == 'present'
+      asset_opts = {}
+      asset_opts[:ensure] = self[:ensure]
+      asset_opts[:name] = "#{self[:rename]} in #{self[:namespace]}"
+      asset_opts[:namespace] = self[:namespace]
+      asset_opts[:require] = "Sensu_bonsai_asset[#{self[:name]}]"
+      asset_opts[:bonsai] = true
+      asset_opts[:provider] = self[:provider] if self[:provider]
+      asset = Puppet::Type.type(:sensu_asset).new(asset_opts)
+      resources << asset
+    end
+    resources
   end
 
   def self.title_patterns

--- a/spec/acceptance/sensu_bonsai_asset.rb
+++ b/spec/acceptance/sensu_bonsai_asset.rb
@@ -49,9 +49,16 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
 
   context 'install bonsai asset - latest' do
     it 'should work without errors' do
+      # Define two assets as 'latest' using different providers
+      # to ensure the latest of each is used
+      # See https://github.com/sensu/sensu-puppet/pull/1202
       pp = <<-EOS
       include sensu::backend
       sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
+        ensure  => 'present',
+        version => 'latest',
+      }
+      sensu_bonsai_asset { 'sensu/sensu-go-has-contact-filter':
         ensure  => 'present',
         version => 'latest',
       }
@@ -59,10 +66,6 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
         ensure   => 'present',
         version  => 'latest',
         provider => 'sensu_api',
-      }
-      sensu_bonsai_asset { 'sensu/sensu-go-has-contact-filter':
-        ensure  => 'present',
-        version => 'latest',
       }
       EOS
 

--- a/spec/acceptance/sensu_bonsai_asset.rb
+++ b/spec/acceptance/sensu_bonsai_asset.rb
@@ -60,6 +60,10 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
         version  => 'latest',
         provider => 'sensu_api',
       }
+      sensu_bonsai_asset { 'sensu/sensu-go-has-contact-filter':
+        ensure  => 'present',
+        version => 'latest',
+      }
       EOS
 
       if RSpec.configuration.sensu_use_agent


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix sensu_bonsai_asset so that when multiple bonsai assets with different latest version are defined, don't use latest version for first resource queried from bonsai. Previous code attempted to cache the wrong value from bonsai API query.

Also fix issue where deleting a bonsai asset would generate an `absent` resource for `sensu_asset` that would cause an attempt to delete non-existent asset which would cause errors.

These issues were not seen before because the assets being tested with multiple `latest` values just so happened to have same version in Bonsai.
