### PR TITLE
Remove workaround for sensuctl command json formatting

### DIFF
--- a/lib/puppet/provider/sensu_command/sensuctl.rb
+++ b/lib/puppet/provider/sensu_command/sensuctl.rb
@@ -9,13 +9,7 @@ Puppet::Type.type(:sensu_command).provide(:sensuctl, :parent => Puppet::Provider
   def self.instances
     commands = []
 
-    #TODO: Hack to force JSON format
-    # Fixed in https://github.com/sensu/sensu-go/pull/3495
-    current_format = config['format']
-    sensuctl(['config','set-format','json'])
-    data = sensuctl_list('command', false, false)
-    sensuctl(['config','set-format',current_format])
-
+    data = sensuctl_list('command', false)
     data.each do |d|
       command = {}
       command[:ensure] = :present

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -83,18 +83,14 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
     self.class.sensuctl(*args)
   end
 
-  def self.sensuctl_list(command, namespaces = true, format = true)
+  def self.sensuctl_list(command, namespaces = true)
     args = [command]
     args << 'list'
     if namespaces
       args << '--all-namespaces'
     end
-    #TODO: Making format optional is necessary to support sensuctl command list
-    # Fixed in https://github.com/sensu/sensu-go/pull/3495
-    if format
-      args << '--format'
-      args << 'json'
-    end
+    args << '--format'
+    args << 'json'
     if ! chunk_size.nil?
       args << '--chunk-size'
       args << chunk_size.to_s

--- a/spec/unit/provider/sensu_command/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_command/sensuctl_spec.rb
@@ -16,19 +16,13 @@ describe Puppet::Type.type(:sensu_command).provider(:sensuctl) do
   end
 
   describe 'self.instances' do
-    before(:each) do
-      allow(provider).to receive(:config).and_return('format' => 'tabular')
-      allow(provider).to receive(:sensuctl).with(['config','set-format','json'])
-      allow(provider).to receive(:sensuctl).with(['config','set-format','tabular'])
-    end
-
     it 'should create instances' do
-      allow(provider).to receive(:sensuctl_list).with('command', false, false).and_return(JSON.parse(my_fixture_read('list.json')))
+      allow(provider).to receive(:sensuctl_list).with('command', false).and_return(JSON.parse(my_fixture_read('list.json')))
       expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a command' do
-      allow(provider).to receive(:sensuctl_list).with('command', false, false).and_return(JSON.parse(my_fixture_read('list.json')))
+      allow(provider).to receive(:sensuctl_list).with('command', false).and_return(JSON.parse(my_fixture_read('list.json')))
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('command-test')
     end

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -35,12 +35,6 @@ describe Puppet::Provider::Sensuctl do
       subject.sensuctl_list('namespace', false)
     end
 
-    it 'should list a resource without all namespaces or json format' do
-      expected_args = ['command','list']
-      expect(subject).to receive(:sensuctl).with(expected_args).and_return("{}\n")
-      subject.sensuctl_list('command', false, false)
-    end
-
     it 'should return empty array for null' do
       allow(subject).to receive(:sensuctl).with(['check','list','--all-namespaces','--format','json']).and_return("null\n")
       data = subject.sensuctl_list('check')


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Removes workaround that is fixed with Sensu Go 5.17.