### PR TITLE
Add manage_agent_user parameter to sensu::backend

### DIFF
--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -55,8 +55,11 @@ DESC
     desc "The user's password."
 
     def insync?(is)
+      if @resource[:disabled].to_sym == :true
+        return true
+      end
       if @resource.provider
-        if @resource[:disabled].to_sym == :true
+        if @resource.provider.disabled.to_sym == :true
           return true
         end
         @resource.provider.password_insync?(@resource[:name], @should)

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -40,6 +40,13 @@
 #   This parameter is mutually exclusive with ssl_key_source
 # @param include_default_resources
 #   Sets if default sensu resources should be included
+# @param manage_agent_user
+#   Sets if the Sensu agent user should be managed
+# @param agent_user_disabled
+#   Sets if the Sensu agent user should be disabled
+#   Not applicable if `manage_agent_user` is `false`
+#   This is useful if using agent TLS authentication
+#   See https://docs.sensu.io/sensu-go/latest/guides/securing-sensu/#sensu-agent-tls-authentication
 # @param show_diff
 #   Sets show_diff parameter for backend.yml configuration file
 # @param license_source
@@ -90,6 +97,8 @@ class sensu::backend (
   Optional[String] $ssl_key_source = $facts['puppet_hostprivkey'],
   Optional[String] $ssl_key_content = undef,
   Boolean $include_default_resources = true,
+  Boolean $manage_agent_user = true,
+  Boolean $agent_user_disabled = false,
   Boolean $show_diff = true,
   Optional[String] $license_source = undef,
   Optional[String] $license_content = undef,
@@ -193,12 +202,14 @@ class sensu::backend (
     configure_url => $api_url,
   }
 
-  sensu_user { 'agent':
-    ensure       => 'present',
-    disabled     => false,
-    password     => $sensu::agent_password,
-    old_password => $sensu::agent_old_password,
-    groups       => ['system:agents'],
+  if $manage_agent_user {
+    sensu_user { 'agent':
+      ensure       => 'present',
+      disabled     => $agent_user_disabled,
+      password     => $sensu::agent_password,
+      old_password => $sensu::agent_old_password,
+      groups       => ['system:agents'],
+    }
   }
 
   if $manage_tessen {

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -131,6 +131,32 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
     end
   end
 
+  context 'backend without agent' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      class { '::sensu':
+        password     => 'supersecret',
+        old_password => 'P@ssw0rd!',
+      }
+      class { 'sensu::backend':
+        agent_user_disabled => true,
+      }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+  end
+
   context 'reset admin password and opt-out tessen' do
     it 'should work without errors' do
       pp = <<-EOS

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -239,6 +239,18 @@ describe 'sensu::backend', :type => :class do
         it { should_not contain_class('sensu::backend::default_resources') }
       end
 
+      context 'with manage_agent_user => false' do
+        let(:params) {{ :manage_agent_user => false }}
+        it { should compile.with_all_deps }
+        it { should_not contain_sensu_user('agent') }
+      end
+
+      context 'with agent_user_disabled => true' do
+        let(:params) {{ :agent_user_disabled => true }}
+        it { should compile.with_all_deps }
+        it { should contain_sensu_user('agent').with_disabled('true') }
+      end
+
       context 'with license_source defined' do
         let(:params) {{ :license_source => 'puppet:///modules/site_sensu/license.json' }}
         it { should compile.with_all_deps }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow disabling management of `agent` Sensu user. Also allow agent user to be disabled.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1205 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go docs describe agent authentication via TLS rather than a password and this facilitates that. Need to either stop managing the agent user or disable the user. This pull requests adds support for both.
