### PR TITLE
Changes to support Sensu Go 5.17.1

### DIFF
--- a/lib/puppet/provider/sensu_user/sensu_api.rb
+++ b/lib/puppet/provider/sensu_user/sensu_api.rb
@@ -69,7 +69,12 @@ Puppet::Type.type(:sensu_user).provide(:sensu_api, :parent => Puppet::Provider::
     data[:disabled] = convert_boolean_property_value(resource[:disabled]) unless resource[:disabled].nil?
     api_request('users', data, {:method => 'post'})
     if resource[:configure] == :true
-      Puppet::Provider::Sensuctl.sensuctl(['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', resource[:password]])
+      configure_cmd = ['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', resource[:password]]
+      if resource[:configure_trusted_ca_file] != "absent"
+        configure_cmd << '--trusted-ca-file'
+        configure_cmd << resource[:configure_trusted_ca_file]
+      end
+      Puppet::Provider::Sensuctl.sensuctl(configure_cmd)
     end
     @property_hash[:ensure] = :present
   end
@@ -87,7 +92,12 @@ Puppet::Type.type(:sensu_user).provide(:sensu_api, :parent => Puppet::Provider::
       end
       api_request("users/#{resource[:name]}", data, {:method => 'put'})
       if @property_flush[:password] && resource[:configure] == :true
-        Puppet::Provider::Sensuctl.sensuctl(['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password]])
+        configure_cmd = ['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password]]
+        if resource[:configure_trusted_ca_file] != "absent"
+          configure_cmd << '--trusted-ca-file'
+          configure_cmd << resource[:configure_trusted_ca_file]
+        end
+        Puppet::Provider::Sensuctl.sensuctl(configure_cmd)
       end
     end
     @property_hash = resource.to_hash

--- a/lib/puppet/provider/sensu_user/sensuctl.rb
+++ b/lib/puppet/provider/sensu_user/sensuctl.rb
@@ -81,7 +81,12 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
       sensuctl(['user', 'disable', resource[:name], '--skip-confirm'])
     end
     if resource[:configure] == :true
-      sensuctl(['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', resource[:password]])
+      configure_cmd = ['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', resource[:password]]
+      if resource[:configure_trusted_ca_file] != "absent"
+        configure_cmd << '--trusted-ca-file'
+        configure_cmd << resource[:configure_trusted_ca_file]
+      end
+      sensuctl(configure_cmd)
     end
     @property_hash[:ensure] = :present
   end
@@ -97,7 +102,12 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
         end
         sensuctl(['user', 'change-password', resource[:name], '--current-password', resource[:old_password], '--new-password', @property_flush[:password]])
         if resource[:configure] == :true
-          sensuctl(['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password]])
+          configure_cmd = ['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password]]
+          if resource[:configure_trusted_ca_file] != "absent"
+            configure_cmd << '--trusted-ca-file'
+            configure_cmd << resource[:configure_trusted_ca_file]
+          end
+          sensuctl(configure_cmd)
         end
       end
       if @property_flush[:groups]

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -38,17 +38,6 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
     self.class.sensuctl_config(*args)
   end
 
-  def self.save_config(config, path = nil)
-    path ||= config_path
-    return unless File.exist?(path)
-    File.open(path, "w") do |f|
-      f.write(JSON.pretty_generate(config))
-    end
-  end
-  def save_config(*args)
-    self.class.save_config(*args)
-  end
-
   def self.type_properties
     resource_type.validproperties.reject { |p| p.to_sym == :ensure }
   end

--- a/lib/puppet/provider/sensuctl_configure/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl_configure/sensuctl.rb
@@ -120,12 +120,6 @@ Puppet::Type.type(:sensuctl_configure).provide(:sensuctl, :parent => Puppet::Pro
   def flush
     if !@property_flush.empty?
       begin
-        if @property_flush[:trusted_ca_file] == 'absent'
-          Puppet.info("Clearing trusted-ca-file in #{config_path}")
-          config = sensuctl_config
-          config['trusted-ca-file'] = ''
-          save_config(config)
-        end
         backend_init
         configure_cmd()
         sensuctl(['config','set-format',@property_flush[:config_format]]) if @property_flush[:config_format]

--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -76,8 +76,8 @@ DESC
   newparam(:resource_name, :namevar => true) do
     desc "The name of the asset."
     validate do |value|
-      # Must only contain lower case letters, numbers, underscores, periods, hyphens and colons
-      unless value =~ %r{^[a-z0-9\/\_\.\-\:]+$}
+      # Must only contain upper case letters, lower case letters, numbers, underscores, periods, hyphens and colons
+      unless value =~ %r{^[A-Za-z0-9\/\_\.\-\:]+$}
         raise ArgumentError, "sensu_asset name invalid"
       end
     end

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -102,6 +102,11 @@ DESC
     defaultto 'http://127.0.0.1:8080'
   end
 
+  newparam(:configure_trusted_ca_file) do
+    desc "Path to trusted CA to use with 'sensuctl configure'"
+    defaultto('/etc/sensu/ssl/ca.crt')
+  end
+
   validate do
     required_properties = [
       :password

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -193,13 +193,14 @@ class sensu::backend (
   }
 
   sensu_user { 'admin':
-    ensure        => 'present',
-    password      => $password,
-    old_password  => $sensu::old_password,
-    groups        => ['cluster-admins'],
-    disabled      => false,
-    configure     => true,
-    configure_url => $api_url,
+    ensure                    => 'present',
+    password                  => $password,
+    old_password              => $sensu::old_password,
+    groups                    => ['cluster-admins'],
+    disabled                  => false,
+    configure                 => true,
+    configure_url             => $api_url,
+    configure_trusted_ca_file => $trusted_ca_file,
   }
 
   if $manage_agent_user {

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -32,13 +32,14 @@ describe 'sensu::backend', :type => :class do
         it { should have_sensu_user_resource_count(2) }
         it {
           should contain_sensu_user('admin').with({
-            'ensure'        => 'present',
-            'password'      => 'P@ssw0rd!',
-            'old_password'  => nil,
-            'groups'        => ['cluster-admins'],
-            'disabled'      => 'false',
-            'configure'     => 'true',
-            'configure_url' => 'https://test.example.com:8080',
+            'ensure'                    => 'present',
+            'password'                  => 'P@ssw0rd!',
+            'old_password'              => nil,
+            'groups'                    => ['cluster-admins'],
+            'disabled'                  => 'false',
+            'configure'                 => 'true',
+            'configure_url'             => 'https://test.example.com:8080',
+            'configure_trusted_ca_file' => '/etc/sensu/ssl/ca.crt',
           })
         }
         it {
@@ -190,6 +191,19 @@ describe 'sensu::backend', :type => :class do
         it { should compile.with_all_deps }
         it { should_not contain_file('sensu_ssl_cert') }
         it { should_not contain_file('sensu_ssl_key') }
+
+        it {
+          should contain_sensu_user('admin').with({
+            'ensure'                    => 'present',
+            'password'                  => 'P@ssw0rd!',
+            'old_password'              => nil,
+            'groups'                    => ['cluster-admins'],
+            'disabled'                  => 'false',
+            'configure'                 => 'true',
+            'configure_url'             => 'http://test.example.com:8080',
+            'configure_trusted_ca_file' => 'absent',
+          })
+        }
 
         backend_content = <<-END.gsub(/^\s+\|/, '')
           |---

--- a/spec/unit/provider/sensu_user/sensu_api_spec.rb
+++ b/spec/unit/provider/sensu_user/sensu_api_spec.rb
@@ -48,7 +48,7 @@ describe Puppet::Type.type(:sensu_user).provider(:sensu_api) do
         :disabled => false,
       }
       expect(resource.provider).to receive(:api_request).with('users', data, {:method => 'post'})
-      expect(Puppet::Provider::Sensuctl).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','P@ssw0rd!'])
+      expect(Puppet::Provider::Sensuctl).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','P@ssw0rd!','--trusted-ca-file','/etc/sensu/ssl/ca.crt'])
       resource.provider.create
       property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
@@ -76,7 +76,7 @@ describe Puppet::Type.type(:sensu_user).provider(:sensu_api) do
         :disabled => false,
       }
       expect(resource.provider).to receive(:api_request).with('users/test', data, {:method => 'put'})
-      expect(Puppet::Provider::Sensuctl).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','foobar'])
+      expect(Puppet::Provider::Sensuctl).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','foobar','--trusted-ca-file','/etc/sensu/ssl/ca.crt'])
       resource.provider.password = 'foobar'
       resource.provider.flush
     end

--- a/spec/unit/provider/sensu_user/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_user/sensuctl_spec.rb
@@ -35,7 +35,7 @@ describe Puppet::Type.type(:sensu_user).provider(:sensuctl) do
     it 'should create user and reconfigure sensuctl' do
       resource[:configure] = true
       expect(resource.provider).to receive(:sensuctl).with(['user', 'create', 'test', '--password', 'P@ssw0rd!', '--groups', 'test'])
-      expect(resource.provider).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','P@ssw0rd!'])
+      expect(resource.provider).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','P@ssw0rd!','--trusted-ca-file','/etc/sensu/ssl/ca.crt'])
       resource.provider.create
       property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
@@ -61,7 +61,7 @@ describe Puppet::Type.type(:sensu_user).provider(:sensuctl) do
       resource[:old_password] = 'foo'
       expect(resource.provider).to receive(:password_insync?).with('test', 'foo').and_return(true)
       expect(resource.provider).to receive(:sensuctl).with(['user', 'change-password', 'test', '--current-password', 'foo', '--new-password', 'foobar'])
-      expect(resource.provider).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','foobar'])
+      expect(resource.provider).to receive(:sensuctl).with(['configure','-n','--url','http://127.0.0.1:8080','--username','test','--password','foobar','--trusted-ca-file','/etc/sensu/ssl/ca.crt'])
       resource.provider.password = 'foobar'
       resource.provider.flush
     end

--- a/spec/unit/provider/sensuctl_configure/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_configure/sensuctl_spec.rb
@@ -117,16 +117,7 @@ describe Puppet::Type.type(:sensuctl_configure).provider(:sensuctl) do
       resource.provider.flush
     end
     it 'should remove SSL trusted ca' do
-      sensuctl_config = {
-        "api-url" => 'foo.example.com:8081',
-        "trusted-ca-file" => '/etc/sensu/ssl/ca.crt',
-      }
-      expected_config = sensuctl_config.clone
-      expected_config['trusted-ca-file'] = ''
-      allow(resource.provider).to receive(:config_path).and_return('/root/.config/sensu/sensuctl/cluster')
-      allow(resource.provider).to receive(:sensuctl_config).and_return(sensuctl_config)
       expect(resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
-      expect(resource.provider).to receive(:save_config).with(expected_config)
       resource.provider.trusted_ca_file = 'absent'
       resource.provider.flush
     end

--- a/spec/unit/sensu_asset_spec.rb
+++ b/spec/unit/sensu_asset_spec.rb
@@ -32,6 +32,8 @@ describe Puppet::Type.type(:sensu_asset) do
   end
 
   valid_names = [
+    'Foo',
+    'fooBar',
     'foo',
     'foo-bar',
     'foo.bar',
@@ -42,8 +44,6 @@ describe Puppet::Type.type(:sensu_asset) do
   ]
   invalid_names = [
     'foo!',
-    'Foo',
-    'fooBar',
   ]
   valid_names.each do |name|
     it "allows valid name #{name}" do

--- a/spec/unit/sensu_user_spec.rb
+++ b/spec/unit/sensu_user_spec.rb
@@ -62,13 +62,15 @@ describe Puppet::Type.type(:sensu_user) do
     'disabled': :false,
     'configure': :false,
     'configure_url': 'http://127.0.0.1:8080',
+    'configure_trusted_ca_file': '/etc/sensu/ssl/ca.crt',
   }
 
   # String properties
   [
     :password,
     :old_password,
-    :configure_url
+    :configure_url,
+    :configure_trusted_ca_file,
   ].each do |property|
     it "should accept valid #{property}" do
       config[property] = 'foo'


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure that when executing `sensuctl configure` we are passing all flags to avoid breaking the config on disk.
Allow upper case letters for `sensu_asset`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is changes necessary to support Sensu Go 5.17.1. The change for executing `sensuctl configure` is to address fact that now all executions of that command will reset the on-disk config for sensuctl. Previously we had to read the file and modify the JSON and then save the new JSON when changing `trusted-ca-file`. Now we just have to ensure we are passing `--trusted-ca-file` if using SSL to avoid breaking the config.