### PR TITLE
Better documentation of private types

### DIFF
--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -6,7 +6,7 @@ require_relative '../../puppet_x/sensu/integer_property'
 Puppet::Type.newtype(:sensu_api_config) do
   desc <<-DESC
 @summary Abstract type to configure other types
-@api private
+**NOTE** This is a private type not intended to be used directly.
 DESC
 
   newparam(:name, :namevar => true) do

--- a/lib/puppet/type/sensu_api_validator.rb
+++ b/lib/puppet/type/sensu_api_validator.rb
@@ -1,5 +1,7 @@
 Puppet::Type.newtype(:sensu_api_validator) do
   desc <<-DESC
+**NOTE** This is a private type not intended to be used directly.
+
 Verify that a connection can be successfully established between a node
 and the sensu-backend server.  Its primary use is as a precondition to
 prevent configuration changes from being applied if the sensu_backend

--- a/lib/puppet/type/sensu_tessen.rb
+++ b/lib/puppet/type/sensu_tessen.rb
@@ -5,8 +5,8 @@ require_relative '../../puppet_x/sensu/integer_property'
 
 Puppet::Type.newtype(:sensu_tessen) do
   desc <<-DESC
-@summary Manages Sensu Tessen - This is a private type
-@api private
+@summary Manages Sensu Tessen
+**NOTE** This is a private type not intended to be used directly.
 
 **Autorequires**:
 * `Package[sensu-go-cli]`

--- a/lib/puppet/type/sensuctl_config.rb
+++ b/lib/puppet/type/sensuctl_config.rb
@@ -6,7 +6,7 @@ require_relative '../../puppet_x/sensu/integer_property'
 Puppet::Type.newtype(:sensuctl_config) do
   desc <<-DESC
 @summary Abstract type to configure other types
-@api private
+**NOTE** This is a private type not intended to be used directly.
 DESC
 
   newparam(:name, :namevar => true) do

--- a/lib/puppet/type/sensuctl_configure.rb
+++ b/lib/puppet/type/sensuctl_configure.rb
@@ -5,8 +5,8 @@ require_relative '../../puppet_x/sensu/integer_property'
 
 Puppet::Type.newtype(:sensuctl_configure) do
   desc <<-DESC
-@summary Manages `sensuctl configure`. This is a private type not intended to be used directly.
-@api private
+@summary Manages 'sensuctl configure'
+**NOTE** This is a private type not intended to be used directly.
 
 **Autorequires**:
 * `Package[sensu-go-cli]`


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The previous use of `@api private` doesn't do anything for type documentation with Puppet Strings so move to just bold `NOTE` to make it clear which types are considered private.