### PR TITLE
Several fixes for sensu_bonsai_asset

### DIFF
--- a/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
@@ -25,11 +25,12 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensuctl, :parent => Puppet::Pro
         next
       end
       asset[:rename] = d['metadata']['name']
-      if found_assets.include?(asset[:rename])
+      asset[:namespace] = d['metadata']['namespace']
+      asset_name = "#{asset[:rename]} in #{asset[:namespace]}"
+      if found_assets.include?(asset_name)
         next
       end
-      found_assets << asset[:rename]
-      asset[:namespace] = d['metadata']['namespace']
+      found_assets << asset_name
       asset[:name] = "#{asset[:bonsai_namespace]}/#{asset[:bonsai_name]} in #{asset[:namespace]}"
       assets << new(asset)
     end

--- a/lib/puppet/type/sensu_bonsai_asset.rb
+++ b/lib/puppet/type/sensu_bonsai_asset.rb
@@ -91,7 +91,7 @@ DESC
   newparam(:rename) do
     desc "Name for Sensu Go asset"
     defaultto do
-      @resource[:name]
+      "#{@resource[:bonsai_namespace]}/#{@resource[:bonsai_name]}"
     end
   end
 

--- a/spec/acceptance/sensu_bonsai_asset.rb
+++ b/spec/acceptance/sensu_bonsai_asset.rb
@@ -15,6 +15,10 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
         version  => '0.1.0',
         provider => 'sensu_api',
       }
+      sensu_bonsai_asset { 'sensu/sensu-ruby-runtime in default':
+        ensure  => 'present',
+        version => 'latest',
+      }
       EOS
 
       if RSpec.configuration.sensu_use_agent
@@ -43,6 +47,14 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
         data = JSON.parse(stdout)
         version = data['metadata']['annotations']['io.sensu.bonsai.version']
         expect(version).to eq('0.1.0')
+      end
+    end
+
+    it 'should have bonsai asset' do
+      on node, 'sensuctl asset info sensu/sensu-ruby-runtime --format json' do
+        data = JSON.parse(stdout)
+        name = data['metadata']['name']
+        expect(name).to eq('sensu/sensu-ruby-runtime')
       end
     end
   end

--- a/spec/acceptance/sensu_bonsai_asset.rb
+++ b/spec/acceptance/sensu_bonsai_asset.rb
@@ -19,6 +19,11 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
         ensure  => 'present',
         version => 'latest',
       }
+      sensu_namespace { 'dev': ensure => 'present' }
+      sensu_bonsai_asset { 'sensu/sensu-ruby-runtime in dev':
+        ensure  => 'present',
+        version => 'latest',
+      }
       EOS
 
       if RSpec.configuration.sensu_use_agent
@@ -50,11 +55,19 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
       end
     end
 
-    it 'should have bonsai asset' do
-      on node, 'sensuctl asset info sensu/sensu-ruby-runtime --format json' do
+    it 'should have bonsai asset in default namespace' do
+      on node, 'sensuctl asset info sensu/sensu-ruby-runtime --format json --namespace=default' do
         data = JSON.parse(stdout)
-        name = data['metadata']['name']
-        expect(name).to eq('sensu/sensu-ruby-runtime')
+        expect(data['metadata']['name']).to eq('sensu/sensu-ruby-runtime')
+        expect(data['metadata']['namespace']).to eq('default')
+      end
+    end
+
+    it 'should have bonsai asset in dev namespace' do
+      on node, 'sensuctl asset info sensu/sensu-ruby-runtime --format json --namespace=dev' do
+        data = JSON.parse(stdout)
+        expect(data['metadata']['name']).to eq('sensu/sensu-ruby-runtime')
+        expect(data['metadata']['namespace']).to eq('dev')
       end
     end
   end

--- a/spec/unit/sensu_bonsai_asset_spec.rb
+++ b/spec/unit/sensu_bonsai_asset_spec.rb
@@ -31,6 +31,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset) do
     expect(asset[:bonsai_namespace]).to eq('sensu')
     expect(asset[:bonsai_name]).to eq('sensu-pagerduty-handler')
     expect(asset[:namespace]).to eq('default')
+    expect(asset[:rename]).to eq('sensu/sensu-pagerduty-handler')
   end
 
   it 'should handle title pattern with namespace' do
@@ -38,6 +39,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset) do
     expect(asset[:bonsai_namespace]).to eq('sensu')
     expect(asset[:bonsai_name]).to eq('sensu-pagerduty-handler')
     expect(asset[:namespace]).to eq('dev')
+    expect(asset[:rename]).to eq('sensu/sensu-pagerduty-handler')
   end
 
   it 'should have bonsai_namespace over composite name' do
@@ -46,6 +48,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset) do
     expect(asset[:bonsai_namespace]).to eq('sensu')
     expect(asset[:bonsai_name]).to eq('bar')
     expect(asset[:name]).to eq('foo/bar')
+    expect(asset[:rename]).to eq('sensu/bar')
   end
 
   it 'should have bonsai_name over composite name' do
@@ -54,6 +57,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset) do
     expect(asset[:bonsai_namespace]).to eq('foo')
     expect(asset[:bonsai_name]).to eq('baz')
     expect(asset[:name]).to eq('foo/bar')
+    expect(asset[:rename]).to eq('foo/baz')
   end
 
   it 'should have namespace over composite name' do
@@ -61,6 +65,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset) do
     config[:namespace] = 'test'
     expect(asset[:name]).to eq('sensu/sensu-pagerduty-handler in dev')
     expect(asset[:namespace]).to eq('test')
+    expect(asset[:rename]).to eq('sensu/sensu-pagerduty-handler')
   end
 
   defaults = {}


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Several fixes for `sensu_bonsai_asset` when using composite names and the same asset in multiple namespaces. Previous behavior was broken for default value of `rename` property. New default matches what `sensuctl` does when you do `sensuctl asset add <bonsai asset>`. This is not breaking because past behavior for a name like `sensu/sensu-pagerduty-handler` will still behave the same while the composite name where change takes place would have never actually worked and would have raised errors if used before this fix.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1210 