### PR TITLE
Fix release process

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,7 @@ The `master` branch is for development against Sensu Go v5.
 
 1. Update version in `metadata.json`
 1. Run Rake task to release module: `pdk bundle exec rake release`
+1. Update GitHub pages: `pdk bundle exec rake strings:gh_pages:update`
 1. Tag the release, such as `git tag -a 'v3.11.0' -m 'v3.11.0'`
 1. Push release to upstream master: `git push upstream master`
 1. Push tags upstream master: `git push upstream --tags`

--- a/Rakefile
+++ b/Rakefile
@@ -105,4 +105,4 @@ namespace :release do
 end
 
 desc "Release new module version"
-task :release => [:changelog, :reference, "release:commit", "strings:gh_pages:update"]
+task :release => [:changelog, :reference, "release:commit"]

--- a/Rakefile
+++ b/Rakefile
@@ -76,7 +76,7 @@ if Bundler.rubygems.find_name('github_changelog_generator').any?
     config.max_issues = 100
     config.exclude_labels = ["sensu v2","sensu v1"]
     config.add_pr_wo_labels = true
-    config.merge_prefix = "### UNCATEGORIZED PRS; GO LABEL THEM"
+    config.merge_prefix = "### Merged Pull Requests"
     config.configure_sections = {
       "Changed" => {
         "prefix" => "### Changed",


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix issue where `rake release` was not updating Github pages. If you execute both the gh_pages task and reference task in same command, the one that comes second will fail. I've not figured out why this is. This just adds one extra step to the release process. Also make it so unlabeled pull request header in CHANGELOG.md is more friendly.
