### PR TITLE
Manage license through sensu_license type

### DIFF
--- a/lib/puppet/provider/sensu_license/sensuctl.rb
+++ b/lib/puppet/provider/sensu_license/sensuctl.rb
@@ -1,0 +1,34 @@
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'sensuctl'))
+
+Puppet::Type.type(:sensu_license).provide(:sensuctl, :parent => Puppet::Provider::Sensuctl) do
+  desc "Provider sensu_license using sensuctl"
+
+  def exists?
+    sensuctl(['license', 'info'])
+  rescue Puppet::ExecutionFailure => e
+    return false
+  true
+  end
+
+  def initialize(value = {})
+    super(value)
+    @property_flush = {}
+  end
+
+  def create
+    begin
+      sensuctl(['create','-f',resource[:file]])
+    rescue Puppet::ExecutionFailure => e
+      raise Puppet::Error, "sensuctl create failed\nOutput: #{output}\nError message: #{e.message}"
+    end
+  end
+
+  def destroy
+    begin
+      sensuctl(['delete','-f',resource[:file]])
+    rescue Puppet::ExecutionFailure => e
+      raise Puppet::Error, "sensuctl create failed\nOutput: #{output}\nError message: #{e.message}"
+    end
+  end
+end
+

--- a/lib/puppet/type/sensu_license.rb
+++ b/lib/puppet/type/sensu_license.rb
@@ -1,0 +1,46 @@
+require_relative '../../puppet_x/sensu/type'
+require_relative '../../puppet_x/sensu/array_property'
+require_relative '../../puppet_x/sensu/hash_property'
+require_relative '../../puppet_x/sensu/integer_property'
+
+Puppet::Type.newtype(:sensu_license) do
+  desc <<-DESC
+@summary Manage a sensu license
+**NOTE** This is a private type not intended to be used directly.
+
+**Autorequires**:
+* `Package[sensu-go-cli]`
+* `Service[sensu-backend]`
+* `Sensu_api_validator[sensu]`
+* `file` - Puppet will autorequire `file` resources defined in `file` property.
+DESC
+
+  extend PuppetX::Sensu::Type
+  add_autorequires(false, false)
+
+  ensurable
+
+  newparam(:name, :namevar => true) do
+    desc "The name of the resource."
+  end
+
+  newparam(:file) do
+    desc "Path to license file"
+  end
+
+  autorequire(:file) do
+    [ self[:file] ]
+  end
+
+  def refresh
+    if (@parameters[:ensure] || newattr(:ensure)).retrieve == :present
+      provider.create
+    end
+  end
+
+  validate do
+    if self[:file].nil?
+      fail "You must provide file parameter"
+    end
+  end
+end

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -217,14 +217,12 @@ class sensu::backend (
       group     => $sensu::group,
       mode      => '0600',
       show_diff => false,
-      notify    => Exec['sensu-add-license'],
+      notify    => Sensu_license['puppet'],
     }
 
-    exec { 'sensu-add-license':
-      path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-      command     => "sensuctl create --file ${sensu::etc_dir}/license.json",
-      refreshonly => true,
-      require     => Sensuctl_configure['puppet'],
+    sensu_license { 'puppet':
+      ensure => 'present',
+      file   => "${sensu::etc_dir}/license.json",
     }
   }
 

--- a/spec/acceptance/05_enterprise_spec.rb
+++ b/spec/acceptance/05_enterprise_spec.rb
@@ -32,4 +32,55 @@ describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
       its(:exit_status) { should eq 0 }
     end
   end
+  context 'updates license file' do
+    it 'should work without errors and be idempotent' do
+      pp = <<-EOS
+      class { 'sensu::backend':
+        license_source => '/root/sensu_license.json',
+      }
+      EOS
+
+      # Remove license file to ensure refresh works
+      on node, puppet("resource file /etc/sensu/license.json ensure=absent")
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [2]
+      else
+        apply_manifest_on(node, pp, :expect_changes => true)
+      end
+    end
+
+    describe command('sensuctl license info'), :node => node do
+      its(:exit_status) { should eq 0 }
+    end
+  end
+  context 're-adds license file' do
+    it 'should work without errors and be idempotent' do
+      pp = <<-EOS
+      class { 'sensu::backend':
+        license_source => '/root/sensu_license.json',
+      }
+      EOS
+
+      # Remove license to verify it can re-add
+      on node, puppet("resource sensu_license puppet ensure=absent file=/etc/sensu/license.json")
+      if RSpec.configuration.sensu_use_agent
+        site_pp = "node 'sensu_backend' { #{pp} }"
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        # Run it twice and test for idempotency
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    describe command('sensuctl license info'), :node => node do
+      its(:exit_status) { should eq 0 }
+    end
+  end
 end

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -55,7 +55,7 @@ describe 'sensu::backend', :type => :class do
         it { should contain_sensu_tessen('puppet').with_ensure('present') }
 
         it { should_not contain_file('sensu_license') }
-        it { should_not contain_exec('sensu-add-license') }
+        it { should_not contain_sensu_license('puppet') }
 
         it {
           should contain_file('sensu_ssl_cert').with({
@@ -278,15 +278,13 @@ describe 'sensu::backend', :type => :class do
             'group'     => 'sensu',
             'mode'      => '0600',
             'show_diff' => 'false',
-            'notify'    => 'Exec[sensu-add-license]',
+            'notify'    => 'Sensu_license[puppet]',
           })
         }
         it {
-          should contain_exec('sensu-add-license').with({
-            'path'        => '/usr/bin:/bin:/usr/sbin:/sbin',
-            'command'     => 'sensuctl create --file /etc/sensu/license.json',
-            'refreshonly' => 'true',
-            'require'     => 'Sensuctl_configure[puppet]',
+          should contain_sensu_license('puppet').with({
+            'ensure' => 'present',
+            'file'   => '/etc/sensu/license.json',
           })
         }
       end
@@ -304,15 +302,13 @@ describe 'sensu::backend', :type => :class do
             'group'     => 'sensu',
             'mode'      => '0600',
             'show_diff' => 'false',
-            'notify'    => 'Exec[sensu-add-license]',
+            'notify'    => 'Sensu_license[puppet]',
           })
         }
         it {
-          should contain_exec('sensu-add-license').with({
-            'path'        => '/usr/bin:/bin:/usr/sbin:/sbin',
-            'command'     => 'sensuctl create --file /etc/sensu/license.json',
-            'refreshonly' => 'true',
-            'require'     => 'Sensuctl_configure[puppet]',
+          should contain_sensu_license('puppet').with({
+            'ensure' => 'present',
+            'file'   => '/etc/sensu/license.json',
           })
         }
       end

--- a/spec/unit/provider/sensu_bonsai_asset/sensu_api_spec.rb
+++ b/spec/unit/provider/sensu_bonsai_asset/sensu_api_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensu_api) do
 
   describe 'self.latest_version' do
     it 'should return latest version' do
-      allow(provider).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler').and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
+      allow(Puppet::Provider::SensuAPI).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler').and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
       latest_version = provider.latest_version('sensu', 'sensu-pagerduty-handler')
       expect(latest_version).to eq('1.2.0')
     end

--- a/spec/unit/provider/sensu_bonsai_asset/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_bonsai_asset/sensuctl_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensuctl) do
 
   describe 'self.latest_version' do
     it 'should return latest version' do
-      allow(provider).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler').and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
+      allow(Puppet::Provider::SensuAPI).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler').and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
       latest_version = provider.latest_version('sensu', 'sensu-pagerduty-handler')
       expect(latest_version).to eq('1.2.0')
     end

--- a/spec/unit/provider/sensu_license/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_license/sensuctl_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe Puppet::Type.type(:sensu_license).provider(:sensuctl) do
+  let(:provider) { described_class }
+  let(:type) { Puppet::Type.type(:sensu_license) }
+  let(:resource) do
+    type.new({
+      :name => 'puppet',
+      :file => '/etc/sensu/license.json',
+    })
+  end
+
+  describe 'create' do
+    it 'should add license' do
+      expect(resource.provider).to receive(:sensuctl).with(['create','-f','/etc/sensu/license.json'])
+      resource.provider.create
+    end
+  end
+
+  describe 'destroy' do
+    it 'should remove license' do
+      expect(resource.provider).to receive(:sensuctl).with(['delete','-f','/etc/sensu/license.json'])
+      resource.provider.destroy
+    end
+  end
+end
+

--- a/spec/unit/sensu_license.rb
+++ b/spec/unit/sensu_license.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'puppet/type/sensu_license'
+
+describe Puppet::Type.type(:sensu_license) do
+  let(:default_config) do
+    {
+      name: 'puppet',
+      file: '/etc/sensu/license.json',
+    }
+  end
+  let(:config) do
+    default_config
+  end
+  let(:configure) do
+    described_class.new(config)
+  end
+
+  it 'should add to catalog without raising an error' do
+    catalog = Puppet::Resource::Catalog.new
+    expect {
+      catalog.add_resource configure
+    }.to_not raise_error
+  end
+
+  it 'should require a name' do
+    expect {
+      described_class.new({})
+    }.to raise_error(Puppet::Error, 'Title or name must be provided')
+  end
+
+  it 'should autorequire file' do
+    file = Puppet::Type.type(:file).new(:name => '/etc/sensu/license.json')
+    config[:file] = '/etc/sensu/license.json'
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource configure
+    catalog.add_resource file
+    rel = configure.autorequire[0]
+    expect(rel.source.ref).to eq(file.ref)
+    expect(rel.target.ref).to eq(configure.ref)
+  end
+
+  include_examples 'autorequires', false, false do
+    let(:res) { configure }
+  end
+
+  [
+    :file,
+  ].each do |property|
+    it "should require property #{property} when ensure => present" do
+      config.delete(property)
+      config[:ensure] = :present
+      expect { configure }.to raise_error(Puppet::Error, /You must provide #{property}/)
+    end
+    it "should require property #{property} when ensure => absent" do
+      config.delete(property)
+      config[:ensure] = :absent
+      expect { configure }.to raise_error(Puppet::Error, /You must provide #{property}/)
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Manage licenses through `sensu_license` type.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1217 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Previously a failed license add would not retry if license wasn't added and only way to force Puppet to re-add failed Exec was to modify or delete the license file and let it get re-created and trigger the Exec. This ensures some better logic around license management and ensures changes to the license file still refresh the license inside `sensuctl`.
