### PR TITLE
Support bonsai version with v prefix

### DIFF
--- a/lib/puppet/type/sensu_bonsai_asset.rb
+++ b/lib/puppet/type/sensu_bonsai_asset.rb
@@ -59,7 +59,8 @@ DESC
 
   newproperty(:version) do
     desc "Specific version to install, or latest"
-    newvalues(:latest, /[0-9\.]+/)
+    # Matches versions like v0.1.0 and 0.1.0
+    newvalues(:latest, /^(v)?[0-9\.]+$/)
     def insync?(is)
       if @should.is_a?(Array) && @should.size == 1
         should = @should[0]

--- a/spec/acceptance/sensu_bonsai_asset.rb
+++ b/spec/acceptance/sensu_bonsai_asset.rb
@@ -24,6 +24,10 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
         ensure  => 'present',
         version => 'latest',
       }
+      sensu_bonsai_asset { 'nixwiz/sensu-go-fatigue-check-filter':
+        ensure  => 'present',
+        version => 'v0.2.2',
+      }
       EOS
 
       if RSpec.configuration.sensu_use_agent
@@ -68,6 +72,14 @@ describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
         data = JSON.parse(stdout)
         expect(data['metadata']['name']).to eq('sensu/sensu-ruby-runtime')
         expect(data['metadata']['namespace']).to eq('dev')
+      end
+    end
+
+    it 'should have bonsai asset' do
+      on node, 'sensuctl asset info nixwiz/sensu-go-fatigue-check-filter --format json' do
+        data = JSON.parse(stdout)
+        version = data['metadata']['annotations']['io.sensu.bonsai.version']
+        expect(version).to eq('v0.2.2')
       end
     end
   end

--- a/spec/unit/sensu_bonsai_asset_spec.rb
+++ b/spec/unit/sensu_bonsai_asset_spec.rb
@@ -206,6 +206,10 @@ describe Puppet::Type.type(:sensu_bonsai_asset) do
       config[:version] = '1.0.0'
       expect(asset[:version]).to eq('1.0.0')
     end
+    it 'should allow a version with v prefix' do
+      config[:version] = 'v1.0.0'
+      expect(asset[:version]).to eq('v1.0.0')
+    end
     it 'should raise error if not latest or version' do
       config[:version] = 'foo'
       expect { asset }.to raise_error(Puppet::Error, /Invalid value/)


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Support sensu_bonsai_asset with version starting with "v". This is something added to Sensu Go v5.18.0.