### PR TITLE
Fix issue where absent HOME would break Dir.home

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 ---
 language: ruby
 
-bundler_args: --without system_tests development
-
 cache: bundler
 
 before_install:
@@ -28,241 +26,210 @@ matrix:
   - rvm: 2.4.5
     env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 5"
     stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.5.7
     env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 6"
     stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.4.5
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5"
     stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.4.5
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
     stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.5.7
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6"
     stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.5.7
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
     stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes BEAKER_sensu_use_agent=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes BEAKER_sensu_use_agent=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes BEAKER_sensu_use_agent=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes BEAKER_sensu_use_agent=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6 
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.5
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet5
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6
-    bundler_args:
     script: bundle exec rake beaker
     stage: acceptance
   - env: DEPLOY_TO_FORGE=yes

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -45,7 +45,7 @@ test_script:
 - ps: Copy-Item -Path $ENV:APPVEYOR_BUILD_FOLDER -Destination C:/ProgramData/PuppetLabs/code/environments/production/modules/sensu -Recurse
 - set BEAKER_skip_apply=yes
 - '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" task show'
-- '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" --debug task run sensu::install_agent backend=sensu_backend:8081 subscription=windows output=true --nodes localhost'
+- '"C:\Program Files\Puppet Labs\Bolt\bin\bolt" --debug task run sensu::install_agent backend=sensu_backend:8081 subscription=windows output=true --targets localhost'
 - bundle exec rake acceptance:windows
 image:
   # Windows 2012 R2

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -13,9 +13,9 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
   end
 
   def self.config_path
-    if Dir.respond_to?(:home)
+    begin
       home = Dir.home
-    else
+    rescue ArgumentError, NoMethodError
       # https://github.com/sensu/sensu-puppet/issues/1072
       # since $HOME is not set in systemd service File.expand_path('~') won't work
       home = Etc.getpwuid(Process.uid).dir

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -7,13 +7,21 @@ describe Puppet::Provider::Sensuctl do
 
   context 'config_path' do
     it 'should return path' do
-      allow(Dir).to receive(:respond_to?).with(:home).and_return(true)
       allow(Dir).to receive(:home).and_return('/root')
       expect(subject.config_path).to eq('/root/.config/sensu/sensuctl/cluster')
     end
 
     it 'should return path without Dir.home' do
-      allow(Dir).to receive(:respond_to?).with(:home).and_return(false)
+      allow(Dir).to receive(:home).and_raise(NoMethodError)
+      allow(Process).to receive(:uid).and_return(0)
+      user = OpenStruct.new
+      user.dir = '/root'
+      allow(Etc).to receive(:getpwuid).with(0).and_return(user)
+      expect(subject.config_path).to eq('/root/.config/sensu/sensuctl/cluster')
+    end
+
+    it 'should return path without HOME set' do
+      allow(Dir).to receive(:home).and_raise(ArgumentError)
       allow(Process).to receive(:uid).and_return(0)
       user = OpenStruct.new
       user.dir = '/root'


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix regression due to how `Dir.home` does the home directory lookup.  Seems `Dir.home` will try to expand `~` which won't work if `HOME` env var is not set.  This change will catch that exception as well as if `Dir.home` is not supported and fall back to home directory lookup via `Etc` module.

I tried to add acceptance tests for this but all attempts to unset `HOME` but I was able to reproduce the issue interactively inside Docker.

```
[root@sensu_agent /]# unset HOME
[root@sensu_agent /]# /opt/puppetlabs/puppet/bin/ruby -e 'print Dir.home'
-e:1:in `home': couldn't find login name -- expanding `~' (ArgumentError)
        from -e:1:in `<main>'
```

Before this patch:

```
[root@sensu_agent /]# unset HOME ; puppet apply -e "include sensu::cli"
Notice: Compiled catalog for sensu_agent in environment production in 0.14 seconds
Error: /Stage[main]/Sensu::Cli/Sensuctl_configure[puppet]: Could not evaluate: couldn't find login name -- expanding `~'
```

After this patch:

```
[root@sensu_agent /]# puppet apply -e 'include sensu::cli'
Notice: Compiled catalog for sensu_agent in environment production in 0.14 seconds
Notice: Applied catalog in 0.85 seconds
```

Attempts to do the `unset HOME` in acceptance tests failed as no matter how I tried it seemed that the issue would not occur, something with how the acceptance tests are executed would cause `unset HOME` to have no effect.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1072 
