### PR TITLE
Avoid facter 4, breaks unit tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ if puppetversion = ENV['PUPPET_GEM_VERSION']
 else
   gem 'puppet', :require => false
 end
+gem 'facter', '< 4.0', :require => false
 
 group :development, :unit_tests do
   gem 'rake'

--- a/lib/puppet/type/sensu_ad_auth.rb
+++ b/lib/puppet/type/sensu_ad_auth.rb
@@ -66,16 +66,19 @@ DESC
     * client_key_file: default is `""`
     * default_upn_domain: default is `""`
     * include_nested_groups: Boolean
+
     group_search keys:
     * base_dn: required
     * attribute: default is `member`
     * name_attribute: default is `cn`
     * object_class: default is `group`
+
     user_search Keys:
     * base_dn: required
     * attribute: default is `sAMAccountName`
     * name_attribute: default is `displayName`
     * object_class: default is `person`
+
     binding keys:
     * user_dn: required
     * password: required

--- a/lib/puppet/type/sensu_ldap_auth.rb
+++ b/lib/puppet/type/sensu_ldap_auth.rb
@@ -65,16 +65,19 @@ DESC
     * client_cert_file: default is `""`
     * client_key_file: default is `""`
     * default_upn_domain: default is `""`
+
     group_search keys:
     * base_dn: required
     * attribute: default is `member`
     * name_attribute: default is `cn`
     * object_class: default is `groupOfNames`
+
     user_search Keys:
     * base_dn: required
     * attribute: default is `uid`
     * name_attribute: default is `cn`
     * object_class: default is `person`
+
     binding keys:
     * user_dn: required
     * password: required


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Seems puppetlabs pushed a facter 4.0.11 rubygem that breaks unit tests. No supported version of puppet-agent uses facter 4 and we use facterdb for unit test facts. This avoids facter 4.