### PR TITLE
Use the lower bound version (5.1.0) of stdlib for Vagrant

### DIFF
--- a/tests/provision_basic_debian.sh
+++ b/tests/provision_basic_debian.sh
@@ -52,7 +52,7 @@ EOF
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version 4.25.1
+puppet module install puppetlabs/stdlib --version 5.1.0
 puppet module install puppetlabs/apt --version 4.1.0
 puppet module install richardc-datacat --version 0.6.2
 

--- a/tests/provision_basic_el.sh
+++ b/tests/provision_basic_el.sh
@@ -30,7 +30,7 @@ fi
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version 4.25.1
+puppet module install puppetlabs/stdlib --version 5.1.0
 puppet module install richardc-datacat --version 0.6.2
 
 puppet resource host sensu-backend.example.com ensure=present ip=192.168.52.10


### PR DESCRIPTION
# Pull Request Checklist

Vagrant environment is having issues bringing up default sensu-backend.

## Motivation and Context

Fix vagrant environment