### PR TITLE
Support defining agent annotations, labels and config entrys via defined type

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
     * [Manage Windows Agent](#manage-windows-agent)
     * [Advanced agent](#advanced-agent)
     * [Advanced agent - Subscriptions](#advanced-agent---subscriptions)
+    * [Advanced agent - Annotations and Labels](#advanced-agent---annotations-and-labels)
+    * [Advanced agent - Custom config entries](#advanced-agent---custom-config-entries)
     * [Advanced SSL](#advanced-ssl)
     * [Enterprise support](#enterprise-support)
     * [Contact routing](#contact-routing)
@@ -217,7 +219,7 @@ The output should look like the following:
 
 The following example will configure sensu-backend, sensu-agent on backend and add a check.
 By default this module will configure the backend to use Puppet's SSL certificate and CA.
-It's advisable to not rely on the default password. Changing the password requires providing the previous password via `old_password`.
+It is advisable to not rely on the default password. Changing the password requires providing the previous password via `old_password`.
 
 ```puppet
   class { 'sensu':
@@ -345,7 +347,7 @@ class { 'sensu::agent':
 ### Advanced agent
 
 If you wish to change the `agent` password you must provide the new and old password.
-It's advisable to set `show_diff` to `false` to avoid exposing the agent password.
+It is advisable to set `show_diff` to `false` to avoid exposing the agent password.
 
 ```puppet
 class { 'sensu::backend':
@@ -362,7 +364,7 @@ class { 'sensu::agent':
 
 ### Advanced agent - Subscriptions
 
-It's possible to define subscriptions in many locations and the values merged into `agent.yml`:
+It is possible to define subscriptions in many locations and the values merged into `agent.yml`:
 
 ```
 class { 'sensu::agent':
@@ -377,6 +379,59 @@ sensu::agent::subscription { 'apache': }
 ```
 
 The resulting `agent.yml` would contain subscriptions for both `base` and `apache`.
+
+**NOTE**: Subscriptions defined using the `sensu::agent` class and `sensu::agent::subscription` are merged to produce the final subscription array.
+
+### Advanced agent - Annotations and Labels
+
+It is possible to define annotations and labels in many locations and the values merged into `agent.yml`:
+
+```puppet
+class { 'sensu::agent':
+  labels      => { 'location' => 'uswest', 'contacts' => 'ops@example.com' },
+  annotations => { 'cpu.warning' => '90', 'cpu.critical' => '100' },
+}
+```
+
+Then in a profile class you can define the following:
+
+```puppet
+sensu::agent::label { 'contacts': value => 'devs@example.com' }
+sensu::agent::label { 'environment': value => 'dev' }
+sensu::agent::annotation { 'cpu.warning': value => '75' }
+sensu::agent::annotation { 'fatigue_check/occurrences': value => '2' }
+```
+
+The resulting `agent.yml` will contain the following:
+
+```yaml
+labels:
+  location: uswest
+  contacts: devs@example.com
+  environment: dev
+annotations:
+  cpu.warning: '75'
+  cpu.critical: '100'
+  fatigue_check/occurrences: '2'
+```
+
+**NOTE** `sensu::agent::annotation` and `sensu::agent::label` take precedence over values set by the class `sensu::agent`
+
+### Advanced agent - Custom config entries
+
+It is possible to define config entries for `agent.yml` in many locations in Puppet:
+
+```puppet
+sensu::agent::config_entry { 'keepalive-interval': value => 20 }
+```
+
+This would add the following to `agent.yml`:
+
+```yaml
+keepalive-interval: 20
+```
+
+**NOTE** `sensu::agent::config_entry` takes precendence over values defined in `sensu::agent` class.
 
 ### Advanced SSL
 
@@ -822,7 +877,7 @@ The first step will not fully add the node to the cluster until the second step 
 ### Sensu backend federation
 
 This module supports defining Etcd replicators which allows resources to be sent from one Sensu cluster to another cluster.
-It's necessary that Etcd be listening on an interface that can be accessed by other Sensu backends.
+It is necessary that Etcd be listening on an interface that can be accessed by other Sensu backends.
 First configure backend Etcd to listen on an interface besides localhost and also use SSL:
 
 ```puppet
@@ -868,7 +923,7 @@ sensu_cluster_federation { 'us-west-2a':
 }
 ```
 
-It's also possible to add a backend to an existing Sensu federated cluster.
+It is also possible to add a backend to an existing Sensu federated cluster.
 The following example adds the API URL https://sensu-backend-site3.example.com:8080 to the federated cluster named us-west-2a.
 
 ```puppet

--- a/manifests/agent/annotation.pp
+++ b/manifests/agent/annotation.pp
@@ -1,0 +1,25 @@
+# @summary Add agent annotation
+#
+# @example
+#   sensu::agent::annotation { 'fatigue_check/occurrences:': value => '2' }
+#
+# @param key
+#   Key of the annotation to add to agent.yml, defaults to `$name`.
+# @param value
+#   Label value to add to agent.yml
+# @param order
+#   Order of the datacat fragment
+#
+define sensu::agent::annotation (
+  String[1] $value,
+  String[1] $key   = $name,
+  String[1] $order = '50',
+) {
+  datacat_fragment { "sensu_agent_config-annotation-${name}":
+    target => 'sensu_agent_config',
+    data   => {
+      'annotations' => { $key => $value },
+    },
+    order  => $order,
+  }
+}

--- a/manifests/agent/config_entry.pp
+++ b/manifests/agent/config_entry.pp
@@ -1,0 +1,25 @@
+# @summary Add custom agent config entry
+#
+# @example
+#   sensu::agent::config_entry { 'disable-api'': value => true }
+#
+# @param key
+#   Key of the config entry to add to agent.yml, defaults to `$name`.
+# @param value
+#   Config entry value to add to agent.yml
+# @param order
+#   Order of the datacat fragment
+#
+define sensu::agent::config_entry (
+  Any $value,
+  String[1] $key   = $name,
+  String[1] $order = '50',
+) {
+  datacat_fragment { "sensu_agent_config-entry-${name}":
+    target => 'sensu_agent_config',
+    data   => {
+      $key => $value,
+    },
+    order  => $order,
+  }
+}

--- a/manifests/agent/label.pp
+++ b/manifests/agent/label.pp
@@ -1,0 +1,25 @@
+# @summary Add agent label
+#
+# @example
+#   sensu::agent::label { 'contacts': value => 'ops@example.com' }
+#
+# @param key
+#   Key of the label to add to agent.yml, defaults to `$name`.
+# @param value
+#   Label value to add to agent.yml
+# @param order
+#   Order of the datacat fragment
+#
+define sensu::agent::label (
+  String[1] $value,
+  String[1] $key   = $name,
+  String[1] $order = '50',
+) {
+  datacat_fragment { "sensu_agent_config-label-${name}":
+    target => 'sensu_agent_config',
+    data   => {
+      'labels' => { $key => $value },
+    },
+    order  => $order,
+  }
+}

--- a/spec/acceptance/01_agent_spec.rb
+++ b/spec/acceptance/01_agent_spec.rb
@@ -10,12 +10,21 @@ describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
         backends         => ['sensu-backend:8081'],
         entity_name      => 'sensu-agent',
         subscriptions    => ['base'],
+        labels           => { 'foo' => 'bar', 'bar' => 'baz' },
+        annotations      => { 'cpu.message' => 'foo' },
         service_env_vars => { 'SENSU_API_PORT' => '4041' },
         config_hash      => {
           'log-level' => 'info',
+          'keepalive-interval' => 30,
         }
       }
       sensu::agent::subscription { 'linux': }
+      sensu::agent::label { 'cpu.warning': value => '90' }
+      sensu::agent::label { 'cpu.critical': value => '95' }
+      sensu::agent::label { 'bar': value => 'baz2' }
+      sensu::agent::annotation { 'foo': value => 'bar' }
+      sensu::agent::annotation { 'cpu.message': value => 'bar' }
+      sensu::agent::config_entry { 'keepalive-interval': value => 20 }
       EOS
 
       if RSpec.configuration.sensu_use_agent
@@ -33,12 +42,23 @@ describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
 
     describe file('/etc/sensu/agent.yml'), :node => node do
       expected_content = {
-        'backend-url'     => ['wss://sensu-backend:8081'],
-        'password'        => 'P@ssw0rd!',
-        'name'            => 'sensu-agent',
-        'subscriptions'   => ['base','linux'],
-        'log-level'       => 'info',
-        'trusted-ca-file' => '/etc/sensu/ssl/ca.crt',
+        'backend-url'        => ['wss://sensu-backend:8081'],
+        'password'           => 'P@ssw0rd!',
+        'name'               => 'sensu-agent',
+        'subscriptions'      => ['base','linux'],
+        'labels'             => {
+          'foo'          => 'bar',
+          'bar'          => 'baz2',
+          'cpu.warning'  => '90',
+          'cpu.critical' => '95',
+        },
+        'annotations'        => {
+          'cpu.message' => 'bar',
+          'foo'         => 'bar',
+        },
+        'log-level'          => 'info',
+        'trusted-ca-file'    => '/etc/sensu/ssl/ca.crt',
+        'keepalive-interval' => 20,
       }
       its(:content_as_yaml) { is_expected.to eq(expected_content) }
     end

--- a/spec/defines/agent_annotation_spec.rb
+++ b/spec/defines/agent_annotation_spec.rb
@@ -1,17 +1,18 @@
 require 'spec_helper'
 
-describe 'sensu::agent::subscription' do
+describe 'sensu::agent::annotation' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
       let(:node) { 'localhost' }
-      let(:title) { 'apache' }
+      let(:title) { 'cpu.title' }
+      let(:params) { { :value => 'foo' } }
 
       it {
-        is_expected.to contain_datacat_fragment('sensu_agent_config-subscription-apache').with({
+        is_expected.to contain_datacat_fragment('sensu_agent_config-annotation-cpu.title').with({
           'target' => 'sensu_agent_config',
           'data'   => {
-            'subscriptions' => ['apache'],
+            'annotations' => { 'cpu.title' => 'foo' },
           },
           'order'  => '50',
         })
@@ -20,15 +21,16 @@ describe 'sensu::agent::subscription' do
       context 'all params' do
         let(:params) do
           {
-            :subscription => 'foo',
-            :order        => '01',
+            :value  => '90',
+            :key    => 'cpu.critical',
+            :order  => '01',
           }
         end
         it {
-          is_expected.to contain_datacat_fragment('sensu_agent_config-subscription-apache').with({
+          is_expected.to contain_datacat_fragment('sensu_agent_config-annotation-cpu.title').with({
             'target' => 'sensu_agent_config',
             'data'   => {
-              'subscriptions' => ['foo'],
+              'annotations' => { 'cpu.critical' => '90' },
             },
             'order'  => '01',
           })

--- a/spec/defines/agent_config_entry_spec.rb
+++ b/spec/defines/agent_config_entry_spec.rb
@@ -1,17 +1,18 @@
 require 'spec_helper'
 
-describe 'sensu::agent::subscription' do
+describe 'sensu::agent::config_entry' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
       let(:node) { 'localhost' }
-      let(:title) { 'apache' }
+      let(:title) { 'keepalive-interval' }
+      let(:params) { { :value => 20 } }
 
       it {
-        is_expected.to contain_datacat_fragment('sensu_agent_config-subscription-apache').with({
+        is_expected.to contain_datacat_fragment('sensu_agent_config-entry-keepalive-interval').with({
           'target' => 'sensu_agent_config',
           'data'   => {
-            'subscriptions' => ['apache'],
+            'keepalive-interval' => 20,
           },
           'order'  => '50',
         })
@@ -20,15 +21,16 @@ describe 'sensu::agent::subscription' do
       context 'all params' do
         let(:params) do
           {
-            :subscription => 'foo',
-            :order        => '01',
+            :value  => '90',
+            :key    => 'foo',
+            :order  => '01',
           }
         end
         it {
-          is_expected.to contain_datacat_fragment('sensu_agent_config-subscription-apache').with({
+          is_expected.to contain_datacat_fragment('sensu_agent_config-entry-keepalive-interval').with({
             'target' => 'sensu_agent_config',
             'data'   => {
-              'subscriptions' => ['foo'],
+              'foo' => '90',
             },
             'order'  => '01',
           })

--- a/spec/defines/agent_label_spec.rb
+++ b/spec/defines/agent_label_spec.rb
@@ -1,17 +1,18 @@
 require 'spec_helper'
 
-describe 'sensu::agent::subscription' do
+describe 'sensu::agent::label' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
       let(:node) { 'localhost' }
-      let(:title) { 'apache' }
+      let(:title) { 'cpu.warning' }
+      let(:params) { { :value => '90' } }
 
       it {
-        is_expected.to contain_datacat_fragment('sensu_agent_config-subscription-apache').with({
+        is_expected.to contain_datacat_fragment('sensu_agent_config-label-cpu.warning').with({
           'target' => 'sensu_agent_config',
           'data'   => {
-            'subscriptions' => ['apache'],
+            'labels' => { 'cpu.warning' => '90' },
           },
           'order'  => '50',
         })
@@ -20,15 +21,16 @@ describe 'sensu::agent::subscription' do
       context 'all params' do
         let(:params) do
           {
-            :subscription => 'foo',
-            :order        => '01',
+            :value  => '90',
+            :key    => 'cpu.critical',
+            :order  => '01',
           }
         end
         it {
-          is_expected.to contain_datacat_fragment('sensu_agent_config-subscription-apache').with({
+          is_expected.to contain_datacat_fragment('sensu_agent_config-label-cpu.warning').with({
             'target' => 'sensu_agent_config',
             'data'   => {
-              'subscriptions' => ['foo'],
+              'labels' => { 'cpu.critical' => '90' },
             },
             'order'  => '01',
           })


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add defined types to allow profile classes to define `annotations`, `labels` and custom config entries for `agent.yml`.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1239 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This is similar to #1227 so that labels, annotations and other config entries can be defined in places like profile classes and the values merged into agent.yml