### PR TITLE
Better support for agent redact

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,17 +351,35 @@ If you wish to change the `agent` password you must provide the new and old pass
 It is advisable to set `show_diff` to `false` to avoid exposing the agent password.
 
 ```puppet
-class { 'sensu::backend':
+class { 'sensu':
   agent_password     => 'supersecret',
   agent_old_password => 'P@ssw0rd!',
 }
 class { 'sensu::agent':
-  config_hash => {
-    'password' => 'supersecret',
-  },
-  show_diff   => false,
+  show_diff => false,
 }
 ```
+
+The `config_hash` parameter allows custom configuration for `agent.yml` outside the `sensu::agent` class parameters.
+
+```puppet
+class { 'sensu::agent':
+  config_hash => {
+    'log-level' => 'debug',
+  },
+}
+```
+
+The following parameters in `sensu::agent` class are used to populate `agent.yml`:
+
+* entity_name - Passed to `name` key in `agent.yml`
+* subscriptions
+* annotations
+* labels
+* namespace
+* redact
+
+Agent configurations can also be set via `sensu::agent::config_entry`. See [Advanced agent - Custom config entries](#advanced-agent---custom-config-entries).
 
 ### Advanced agent - Subscriptions
 
@@ -417,6 +435,19 @@ annotations:
 ```
 
 **NOTE** `sensu::agent::annotation` and `sensu::agent::label` take precedence over values set by the class `sensu::agent`
+
+If you wish to redact a label or annotation you can use the `redact` parameter and the key will be added to the `redact` list in `agent.yml`:
+
+```puppet
+sensu::agent::label { 'secret':
+  value  => 'mysecret',
+  redact => true,
+}
+sensu::agent::annotation { 'ec2_access_key':
+  value  => 'some-key',
+  redact => true,
+}
+```
 
 ### Advanced agent - Custom config entries
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -58,6 +58,11 @@
 # @param namespace
 #   The agent namespace
 #   Passing `namespace` as part of `config_hash` takes precedence
+# @param redact
+#   The agent entity redact list
+#   Passing `redact` as part of `config_hash` takes precedence
+#   Defaults come from Sensu documentation:
+#   https://docs.sensu.io/sensu-go/latest/reference/agent/#security-configuration-flags
 # @param show_diff
 #   Sets show_diff parameter for agent.yml configuration file
 # @param log_file
@@ -81,6 +86,7 @@ class sensu::agent (
   Optional[Hash] $annotations = undef,
   Optional[Hash] $labels = undef,
   Optional[String] $namespace = undef,
+  Array[String[1]] $redact = ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret'],
   Boolean $show_diff = true,
   Optional[Stdlib::Absolutepath] $log_file = undef,
 ) {
@@ -116,6 +122,7 @@ class sensu::agent (
     'annotations'   => $annotations,
     'labels'        => $labels,
     'namespace'     => $namespace,
+    'redact'        => $redact,
     'password'      => $sensu::agent_password,
   }
   $config = filter($default_config + $ssl_config + $config_hash) |$key, $value| { $value =~ NotUndef }

--- a/manifests/agent/annotation.pp
+++ b/manifests/agent/annotation.pp
@@ -7,12 +7,15 @@
 #   Key of the annotation to add to agent.yml, defaults to `$name`.
 # @param value
 #   Label value to add to agent.yml
+# @param redact
+#   Boolean that sets if this entry should be added to redact list
 # @param order
 #   Order of the datacat fragment
 #
 define sensu::agent::annotation (
   String[1] $value,
   String[1] $key   = $name,
+  Boolean $redact = false,
   String[1] $order = '50',
 ) {
   datacat_fragment { "sensu_agent_config-annotation-${name}":
@@ -21,5 +24,12 @@ define sensu::agent::annotation (
       'annotations' => { $key => $value },
     },
     order  => $order,
+  }
+
+  if $redact {
+    sensu::agent::config_entry { "redact-annotation-${name}":
+      key   => 'redact',
+      value => [$key],
+    }
   }
 }

--- a/manifests/agent/label.pp
+++ b/manifests/agent/label.pp
@@ -7,12 +7,15 @@
 #   Key of the label to add to agent.yml, defaults to `$name`.
 # @param value
 #   Label value to add to agent.yml
+# @param redact
+#   Boolean that sets if this entry should be added to redact list
 # @param order
 #   Order of the datacat fragment
 #
 define sensu::agent::label (
   String[1] $value,
   String[1] $key   = $name,
+  Boolean $redact = false,
   String[1] $order = '50',
 ) {
   datacat_fragment { "sensu_agent_config-label-${name}":
@@ -21,5 +24,12 @@ define sensu::agent::label (
       'labels' => { $key => $value },
     },
     order  => $order,
+  }
+
+  if $redact {
+    sensu::agent::config_entry { "redact-label-${name}":
+      key   => 'redact',
+      value => [$key],
+    }
   }
 }

--- a/spec/acceptance/01_agent_spec.rb
+++ b/spec/acceptance/01_agent_spec.rb
@@ -21,8 +21,8 @@ describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
       sensu::agent::subscription { 'linux': }
       sensu::agent::label { 'cpu.warning': value => '90' }
       sensu::agent::label { 'cpu.critical': value => '95' }
-      sensu::agent::label { 'bar': value => 'baz2' }
-      sensu::agent::annotation { 'foo': value => 'bar' }
+      sensu::agent::label { 'bar': value => 'baz2', redact => true }
+      sensu::agent::annotation { 'foo': value => 'bar', redact => true }
       sensu::agent::annotation { 'cpu.message': value => 'bar' }
       sensu::agent::config_entry { 'keepalive-interval': value => 20 }
       EOS
@@ -56,6 +56,7 @@ describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
           'cpu.message' => 'bar',
           'foo'         => 'bar',
         },
+        'redact'             => ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret','bar','foo'],
         'log-level'          => 'info',
         'trusted-ca-file'    => '/etc/sensu/ssl/ca.crt',
         'keepalive-interval' => 20,

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -72,6 +72,7 @@ describe 'sensu::agent class', if: Gem.win_platform? do
           'password'        => 'P@ssw0rd!',
           'name'            => 'sensu-agent',
           'subscriptions'   => ['base','windows'],
+          'redact'          => ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret'],
           'log-level'       => 'info',
           'trusted-ca-file' => 'C:\ProgramData\Sensu\config\ssl\ca.crt',
         }

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -68,6 +68,7 @@ describe 'sensu::agent', :type => :class do
             'target' => 'sensu_agent_config',
             'data'   => {
               'backend-url'     => ['wss://localhost:8081'],
+              'redact'          => ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret'],
               'password'        => 'P@ssw0rd!',
               'trusted-ca-file' => platforms[facts[:osfamily]][:ca_path],
             },
@@ -181,6 +182,7 @@ describe 'sensu::agent', :type => :class do
             'target' => 'sensu_agent_config',
             'data'   => {
               'backend-url' => ['ws://localhost:8081'],
+              'redact'      => ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret'],
               'password'    => 'P@ssw0rd!',
             },
           })
@@ -197,6 +199,7 @@ describe 'sensu::agent', :type => :class do
             annotations: { 'foo' => 'bar' },
             labels: { 'bar' => 'baz' },
             namespace: 'qa',
+            redact: ['secret'],
           }
         end
 
@@ -210,6 +213,7 @@ describe 'sensu::agent', :type => :class do
               'annotations'     => {'foo' => 'bar'},
               'labels'          => {'bar' => 'baz'},
               'namespace'       => 'qa',
+              'redact'          => ['secret'],
               'password'        => 'P@ssw0rd!',
               'trusted-ca-file' => platforms[facts[:osfamily]][:ca_path],
             },
@@ -242,6 +246,7 @@ describe 'sensu::agent', :type => :class do
               'annotations'     => {'foo' => 'bar'},
               'labels'          => {'bar' => 'baz'},
               'namespace'       => 'default',
+              'redact'          => ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret'],
               'password'        => 'P@ssw0rd!',
               'trusted-ca-file' => platforms[facts[:osfamily]][:ca_path],
             },
@@ -327,6 +332,7 @@ describe 'sensu::agent', :type => :class do
               'target' => 'sensu_agent_config',
               'data'   => {
                 'backend-url'     => [backend],
+                'redact'          => ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret'],
                 'password'        => 'P@ssw0rd!',
                 'trusted-ca-file' => platforms[facts[:osfamily]][:ca_path],
               },

--- a/spec/defines/agent_annotation_spec.rb
+++ b/spec/defines/agent_annotation_spec.rb
@@ -18,6 +18,18 @@ describe 'sensu::agent::annotation' do
         })
       }
 
+      it { is_expected.not_to contain_sensu__agent__config_entry('redact-annotation-cpu.title') }
+
+      context 'redact' do
+        let(:params) { { :redact => true, :value => 'foo' } }
+        it {
+          is_expected.to contain_sensu__agent__config_entry('redact-annotation-cpu.title').with({
+            'key'   => 'redact',
+            'value' => ['cpu.title'],
+          })
+        }
+      end
+
       context 'all params' do
         let(:params) do
           {

--- a/spec/defines/agent_label_spec.rb
+++ b/spec/defines/agent_label_spec.rb
@@ -18,6 +18,18 @@ describe 'sensu::agent::label' do
         })
       }
 
+      it { is_expected.not_to contain_sensu__agent__config_entry('redact-label-cpu.warning') }
+
+      context 'redact' do
+        let(:params) { { :redact => true, :value => '90' } }
+        it {
+          is_expected.to contain_sensu__agent__config_entry('redact-label-cpu.warning').with({
+            'key'   => 'redact',
+            'value' => ['cpu.warning'],
+          })
+        }
+      end
+
       context 'all params' do
         let(:params) do
           {


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `redact` parameter to `sensu::agent` with documented defaults and supports adding `sensu::agent::label` and `sensu::agent::annotation` keys to `redact` list via new `redact` boolean.

Also better documentation around ways to configure agents.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Mentioned in #1239 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Make it easier to redact secrets and other sensitive data.