### PR TITLE
Change how it's determined when to run specific acceptance tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,52 +64,77 @@ matrix:
     stage: acceptance
   - rvm: 2.4.9
     services: docker
-    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=full
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
-    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=full
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
-    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=full
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=examples
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=examples
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.9
     services: docker
-    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_full=yes BEAKER_sensu_use_agent=yes
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=types
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
-    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes BEAKER_sensu_use_agent=yes
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.9
     services: docker
-    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=types BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
-    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.9
     services: docker
-    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_cluster=yes BEAKER_sensu_use_agent=yes
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=cluster
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
-    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes BEAKER_sensu_use_agent=yes
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.4.9
+    services: docker
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=cluster BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
     services: docker
-    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster BEAKER_sensu_use_agent=yes
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.4.9
@@ -242,9 +267,13 @@ matrix:
   - rvm: 2.5.7
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
   - rvm: 2.5.7
-    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_full=yes
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=full
   - rvm: 2.5.7
-    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_cluster=yes
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=examples
+  - rvm: 2.5.7
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types
+  - rvm: 2.5.7
+    env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster
   - rvm: 2.5.7
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet6
   - rvm: 2.5.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -77,6 +77,11 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=full
     script: bundle exec rake beaker
     stage: acceptance
+  - rvm: 2.4.9
+    services: docker
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=examples
+    script: bundle exec rake beaker
+    stage: acceptance
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=examples

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -82,6 +82,15 @@ The class tests are ordered with numeric prefixes to control the order they run.
 
 The type of `sensu_check` will have its tests in `sensu_check_spec.rb`. The tests to run are adding resources, updating resources, and deleting resources. Some extra test cases should be added based on any complexities of a given type.
 
+The resources `sensu_cluster_role`, `sensu_cluster_role_binding`, `sensu_role`, and `sensu_role_binding` are grouped into `sensu_rbac_resources_spec.rb` with the goal of speeding up testing times.
+
+By default only tests for class resources run which is the same as setting the enviornment variable `BEAKER_sensu_mode=base`.  The other possible modes are the following:
+
+* `BEAKER_sensu_mode=types` - Run tests for all types
+* `BEAKER_sensu_mode=full` - Run same tests as base but also runs more complex tests like PostgreSQL and Bolt integrations
+* `BEAKER_sensu_mode=cluster` - Run cluster tests
+* `BEAKER_sensu_mode=examples` - Run the test around examples in the `examples` directory
+
 Technologies for acceptance testing:
 
 * Docker - provides running system where configurations can be made and tests can be executed

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
+describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/01_agent_spec.rb
+++ b/spec/acceptance/01_agent_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu::agent class', unless: RSpec.configuration.sensu_cluster do
+describe 'sensu::agent class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   node = hosts_as('sensu-agent')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/02_backend_cluster_spec.rb
+++ b/spec/acceptance/02_backend_cluster_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu::backend cluster class', if: RSpec.configuration.sensu_cluster do
+describe 'sensu::backend cluster class', if: RSpec.configuration.sensu_mode == 'cluster' do
   node1 = hosts_with_name(hosts, 'sensu-backend1')[0]
   node2 = hosts_with_name(hosts, 'sensu-backend2')[0]
   node3 = hosts_with_name(hosts, 'sensu-backend3')[0]

--- a/spec/acceptance/03_no_ssl_spec.rb
+++ b/spec/acceptance/03_no_ssl_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu without SSL', unless: RSpec.configuration.sensu_cluster do
+describe 'sensu without SSL', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   backend = hosts_as('sensu-backend')[0]
   agent = hosts_as('sensu-agent')[0]
   context 'backend' do

--- a/spec/acceptance/04_plugins_spec.rb
+++ b/spec/acceptance/04_plugins_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu::plugins class', unless: RSpec.configuration.sensu_cluster do
+describe 'sensu::plugins class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   agent = hosts_as('sensu-agent')[0]
   backend = hosts_as('sensu-backend')[0]
   before do

--- a/spec/acceptance/05_enterprise_spec.rb
+++ b/spec/acceptance/05_enterprise_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu::backend class', unless: RSpec.configuration.sensu_cluster do
+describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   node = hosts_as('sensu-backend')[0]
   before do
     if ! RSpec.configuration.sensu_test_enterprise

--- a/spec/acceptance/06_postgresql_spec.rb
+++ b/spec/acceptance/06_postgresql_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'postgresql datastore', if: RSpec.configuration.sensu_full do
+describe 'postgresql datastore', if: RSpec.configuration.sensu_mode == 'full' do
   node = hosts_as('sensu-backend')[0]
   before do
     if ! RSpec.configuration.sensu_test_enterprise

--- a/spec/acceptance/07_cli_spec.rb
+++ b/spec/acceptance/07_cli_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu::cli class', unless: RSpec.configuration.sensu_cluster do
+describe 'sensu::cli class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   node = hosts_as('sensu-agent')[0]
   backend = hosts_as('sensu-backend')[0]
   context 'default' do

--- a/spec/acceptance/99_facts_spec.rb
+++ b/spec/acceptance/99_facts_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu::backend class', if: !(RSpec.configuration.sensu_cluster || RSpec.configuration.sensu_full) do
+describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   backend = hosts_as('sensu-backend')[0]
   agent = hosts_as('sensu-agent')[0]
   context 'backend facts' do

--- a/spec/acceptance/examples_spec.rb
+++ b/spec/acceptance/examples_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'examples', if: RSpec.configuration.sensu_full do
+describe 'examples', if: RSpec.configuration.sensu_mode == 'examples' do
   agent = hosts_as('sensu-agent')[0]
   backend = hosts_as('sensu-backend')[0]
 
@@ -42,7 +42,7 @@ describe 'examples', if: RSpec.configuration.sensu_full do
       sleep 5
     end
 
-    describe command("PGPASSWORD='sensu' psql -U sensu -h sensu-agent -c \"select * from events WHERE sensu_check = 'keepalive' LIMIT 1;\""), :node => backend do
+    describe command("PGPASSWORD='sensu' psql -U sensu -h sensu-agent -c \"select * from events WHERE sensu_check = 'keepalive' LIMIT 1;\""), :node => agent do
       its(:stdout) { should contain('keepalive') }
     end
   end

--- a/spec/acceptance/sensu_ad_auth_spec.rb
+++ b/spec/acceptance/sensu_ad_auth_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_ad_auth', if: RSpec.configuration.sensu_full do
+describe 'sensu_ad_auth', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   before do
     if ! RSpec.configuration.sensu_test_enterprise

--- a/spec/acceptance/sensu_api_spec.rb
+++ b/spec/acceptance/sensu_api_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_api providers', if: RSpec.configuration.sensu_full do
+describe 'sensu_api providers', if: RSpec.configuration.sensu_mode == 'types' do
   agent = hosts_as('sensu-agent')[0]
   backend = hosts_as('sensu-backend')[0]
   context 'setup' do

--- a/spec/acceptance/sensu_asset_spec.rb
+++ b/spec/acceptance/sensu_asset_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_asset', if: RSpec.configuration.sensu_full do
+describe 'sensu_asset', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_bolt_tasks_spec.rb
+++ b/spec/acceptance/sensu_bolt_tasks_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu event task', if: RSpec.configuration.sensu_full do
+describe 'sensu event task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   agent = hosts_as('sensu-agent')[0]
   context 'setup agent' do
@@ -57,7 +57,7 @@ describe 'sensu event task', if: RSpec.configuration.sensu_full do
   end
 end
 
-describe 'sensu silenced task', if: RSpec.configuration.sensu_full do
+describe 'sensu silenced task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   context 'setup agent' do
     it 'should work without errors' do
@@ -104,7 +104,7 @@ describe 'sensu silenced task', if: RSpec.configuration.sensu_full do
   end
 end
 
-describe 'sensu install_agent task', if: RSpec.configuration.sensu_full do
+describe 'sensu install_agent task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   agent = hosts_as('sensu-agent')[0]
   context 'setup' do
@@ -148,7 +148,7 @@ describe 'sensu install_agent task', if: RSpec.configuration.sensu_full do
   end
 end
 
-describe 'sensu check_execute task', if: RSpec.configuration.sensu_full do
+describe 'sensu check_execute task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   agent = hosts_as('sensu-agent')[0]
   context 'setup' do
@@ -186,7 +186,7 @@ describe 'sensu check_execute task', if: RSpec.configuration.sensu_full do
   end
 end
 
-describe 'sensu assets_outdated task', if: RSpec.configuration.sensu_full do
+describe 'sensu assets_outdated task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   context 'setup' do
     it 'should work without errors' do
@@ -209,7 +209,7 @@ describe 'sensu assets_outdated task', if: RSpec.configuration.sensu_full do
   end
 end
 
-describe 'sensu apikey task', if: RSpec.configuration.sensu_full do
+describe 'sensu apikey task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   context 'setup' do
     it 'should work without errors' do
@@ -251,7 +251,7 @@ describe 'sensu apikey task', if: RSpec.configuration.sensu_full do
   end
 end
 
-describe 'sensu agent_event task', if: RSpec.configuration.sensu_full do
+describe 'sensu agent_event task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   agent = hosts_as('sensu-agent')[0]
   context 'setup' do
@@ -285,7 +285,7 @@ describe 'sensu agent_event task', if: RSpec.configuration.sensu_full do
   end
 end
 
-describe 'sensu bolt inventory', if: RSpec.configuration.sensu_full do
+describe 'sensu bolt inventory', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
   agent = hosts_as('sensu-agent')[0]
   context 'setup' do

--- a/spec/acceptance/sensu_bonsai_asset.rb
+++ b/spec/acceptance/sensu_bonsai_asset.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_full do
+describe 'sensu_bonsai_asset', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'install bonsai asset' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_check', if: RSpec.configuration.sensu_full do
+describe 'sensu_check', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_cluster_federation_member_spec.rb
+++ b/spec/acceptance/sensu_cluster_federation_member_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_cluster_federation_member', if: RSpec.configuration.sensu_full do
+describe 'sensu_cluster_federation_member', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_cluster_federation_spec.rb
+++ b/spec/acceptance/sensu_cluster_federation_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_cluster_federation', if: RSpec.configuration.sensu_full do
+describe 'sensu_cluster_federation', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_command_spec.rb
+++ b/spec/acceptance/sensu_command_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_command', if: RSpec.configuration.sensu_full do
+describe 'sensu_command', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'install command' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_entity_spec.rb
+++ b/spec/acceptance/sensu_entity_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_entity', if: RSpec.configuration.sensu_full do
+describe 'sensu_entity', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_etcd_replicator_spec.rb
+++ b/spec/acceptance/sensu_etcd_replicator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_etcd_replicator', if: RSpec.configuration.sensu_full do
+describe 'sensu_etcd_replicator', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_filter_spec.rb
+++ b/spec/acceptance/sensu_filter_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_filter', if: RSpec.configuration.sensu_full do
+describe 'sensu_filter', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_handler_spec.rb
+++ b/spec/acceptance/sensu_handler_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_handler', if: RSpec.configuration.sensu_full do
+describe 'sensu_handler', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_hook_spec.rb
+++ b/spec/acceptance/sensu_hook_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_hook', if: RSpec.configuration.sensu_full do
+describe 'sensu_hook', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_ldap_auth_spec.rb
+++ b/spec/acceptance/sensu_ldap_auth_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_ldap_auth', if: RSpec.configuration.sensu_full do
+describe 'sensu_ldap_auth', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   before do
     if ! RSpec.configuration.sensu_test_enterprise

--- a/spec/acceptance/sensu_mutator_spec.rb
+++ b/spec/acceptance/sensu_mutator_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_mutator', if: RSpec.configuration.sensu_full do
+describe 'sensu_mutator', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_namespace_spec.rb
+++ b/spec/acceptance/sensu_namespace_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_namespace', if: RSpec.configuration.sensu_full do
+describe 'sensu_namespace', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_oidc_auth_spec.rb
+++ b/spec/acceptance/sensu_oidc_auth_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_full do
+describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   before do
     if ! RSpec.configuration.sensu_test_enterprise

--- a/spec/acceptance/sensu_plugin_spec.rb
+++ b/spec/acceptance/sensu_plugin_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_plugin', if: RSpec.configuration.sensu_full do
+describe 'sensu_plugin', if: RSpec.configuration.sensu_mode == 'types' do
   agent = hosts_as('sensu-agent')[0]
   before do
     if fact_on(agent, 'operatingsystem') == 'Debian'

--- a/spec/acceptance/sensu_rbac_resources_spec.rb
+++ b/spec/acceptance/sensu_rbac_resources_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu RBAC resources', if: RSpec.configuration.sensu_full do
+describe 'sensu RBAC resources', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/acceptance/sensu_secrets_spec.rb
+++ b/spec/acceptance/sensu_secrets_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_secrets_vault_provider', if: RSpec.configuration.sensu_full do
+describe 'sensu_secrets_vault_provider', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   before do
     if ! RSpec.configuration.sensu_test_enterprise

--- a/spec/acceptance/sensu_user_spec.rb
+++ b/spec/acceptance/sensu_user_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper_acceptance'
 
-describe 'sensu_user', if: RSpec.configuration.sensu_full do
+describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
   node = hosts_as('sensu-backend')[0]
   context 'default' do
     it 'should work without errors' do

--- a/spec/classes/repo_community_spec.rb
+++ b/spec/classes/repo_community_spec.rb
@@ -10,7 +10,7 @@ describe 'sensu::repo::community', :type => :class do
       let(:facts) { facts }
       makecache = false
       case os
-      when /(redhat-6|centos-6|amazon-2017|amazon-2018)-x86_64/
+      when /(redhat-6|centos-6|amazon-201\d)-x86_64/
         baseurl = "https://packagecloud.io/sensu/community/el/6/$basearch"
       when /(redhat-7|centos-7|amazon-2)-x86_64/
         baseurl = "https://packagecloud.io/sensu/community/el/7/$basearch"

--- a/spec/classes/repo_spec.rb
+++ b/spec/classes/repo_spec.rb
@@ -10,7 +10,7 @@ describe 'sensu::repo', :type => :class do
       let(:facts) { facts }
       makecache = false
       case os
-      when /(redhat-6|centos-6|amazon-2017|amazon-2018)-x86_64/
+      when /(redhat-6|centos-6|amazon-201\d)-x86_64/
         baseurl = "https://packagecloud.io/sensu/stable/el/6/$basearch"
       when /(redhat-7|centos-7|amazon-2)-x86_64/
         baseurl = "https://packagecloud.io/sensu/stable/el/7/$basearch"


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Tests are run based on `BEAKER_sensu_mode` environment variable which defaults to `base`

This doesn't change when or how things are tested, just splits tests into smaller groups so things like examples will run separate than custom types.  The core centos7 tests will run like all other OSes but also include postgresql tests and bolt which were also only done with centos7 before. It's still only centos7 that is used to test clusters and custom types.