### PR TITLE
Use Ruby 2.4.10 for testing Puppet 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script: 'bundle exec rake $CHECK'
 matrix:
   fast_finish: true
   include:
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 5"
     stage: unit
     bundler_args: --without system_tests development
@@ -31,11 +31,11 @@ matrix:
     env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 6"
     stage: unit
     bundler_args: --without system_tests development
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5"
     stage: unit
     bundler_args: --without system_tests development
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
     stage: unit
     bundler_args: --without system_tests development
@@ -47,7 +47,7 @@ matrix:
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
     stage: unit
     bundler_args: --without system_tests development
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -62,7 +62,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-6" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=full
     script: bundle exec rake beaker
@@ -77,7 +77,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=full
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=examples
     script: bundle exec rake beaker
@@ -92,7 +92,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=examples
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=types
     script: bundle exec rake beaker
@@ -107,7 +107,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=types BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
@@ -117,7 +117,7 @@ matrix:
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=cluster
     script: bundle exec rake beaker
@@ -127,7 +127,7 @@ matrix:
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=cluster BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
@@ -142,7 +142,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -157,7 +157,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -172,7 +172,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6 
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -187,7 +187,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -202,7 +202,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="ubuntu-1604" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -217,7 +217,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="debian-8" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -232,7 +232,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -247,7 +247,7 @@ matrix:
     env: BEAKER_sensu_ci_build=yes BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     services: docker
     env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet5
     script: bundle exec rake beaker
@@ -265,7 +265,7 @@ matrix:
   - env: DEPLOY_TO_FORGE=yes
     stage: deploy
   allow_failures:
-  - rvm: 2.4.9
+  - rvm: 2.4.10
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.7
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"


### PR DESCRIPTION
Puppet has released a new version of Puppet 5 that uses Ruby 2.4.10.