### PR TITLE
Add check name to ArgumentError

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -67,7 +67,7 @@ DESC
     desc "The name of the check."
     validate do |value|
       unless value =~ PuppetX::Sensu::Type.name_regex
-        raise ArgumentError, "sensu_check name invalid"
+        raise ArgumentError, "sensu_check name invalid - check name #{value}"
       end
     end
     defaultto do


### PR DESCRIPTION

# Pull Request Checklist

Added "value" variable to output of ArgumentError message. 

## Description

Added "value" variable to output of ArgumentError message. 

## Related Issue

## Motivation and Context

"sensu_check name invalid" needs more information about *which* check name is failing the ArgumentError. Otherwise it makes it hard to debug when you have thousands of checks. 

## How Has This Been Tested?

Edited code on our puppet server, pushed out, works great. Told me the name of the check which had accidentally gotten a space in the name during a giant sed. 

## General

- [x] Update `README.md` with any necessary configuration snippets - No new info. 

- [x] New parameters are documented - no new parameters

- [x] New parameters have tests - no new parameters

- [ ] Tests pass - `bundle exec rake validate lint spec` - haven't tested this. 
