### PR TITLE
READ DESCRIPTION: Improved handling of passwords for sensu_user

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,12 +217,12 @@ The output should look like the following:
 
 The following example will configure sensu-backend, sensu-agent on backend and add a check.
 By default this module will configure the backend to use Puppet's SSL certificate and CA.
-It is advisable to not rely on the default password. Changing the password requires providing the previous password via `old_password`.
+It is advisable to not rely on the default password.
+**NOTE** When changing the password value, it's necessary to run Puppet on the backend first to update the `admin` password.
 
 ```puppet
   class { 'sensu':
-    password     => 'supersecret',
-    old_password => 'P@ssw0rd!',
+    password => 'supersecret',
   }
   include sensu::backend
   include sensu::agent
@@ -299,7 +299,6 @@ sensu::api_host: sensu-backend.example.com
 sensu::api_port: 8080
 sensu::username: admin
 sensu::password: supersecret
-sensu::old_password: 'P@ssw0rd!'
 ```
 
 ### Manage Windows Agent
@@ -349,8 +348,7 @@ It is advisable to set `show_diff` to `false` to avoid exposing the agent passwo
 
 ```puppet
 class { 'sensu':
-  agent_password     => 'supersecret',
-  agent_old_password => 'P@ssw0rd!',
+  agent_password => 'supersecret',
 }
 class { 'sensu::agent':
   show_diff => false,
@@ -703,8 +701,7 @@ Example installing extension on backend:
 
 ```puppet
   class { 'sensu':
-    password     => 'supersecret',
-    old_password => 'P@ssw0rd!',
+    password => 'supersecret',
   }
   include sensu::backend
   class { 'sensu::plugins':
@@ -716,8 +713,7 @@ The `extensions` parameter can also be a Hash that sets the version:
 
 ```puppet
   class { 'sensu':
-    password     => 'supersecret',
-    old_password => 'P@ssw0rd!',
+    password => 'supersecret',
   }
   include sensu::backend
   class { 'sensu::plugins':
@@ -731,8 +727,7 @@ You can uninstall extensions by passing `ensure` as `absent`.
 
 ```puppet
   class { 'sensu':
-    password     => 'supersecret',
-    old_password => 'P@ssw0rd!',
+    password => 'supersecret',
   }
   include sensu::backend
   class { 'sensu::plugins':

--- a/README.md
+++ b/README.md
@@ -1176,6 +1176,8 @@ Examples can be found in the [examples](https://github.com/sensu/sensu-puppet/tr
 
 The type `sensu_user` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#2540](https://github.com/sensu/sensu-go/issues/2540).
 
+When changing the `sensu::password` value, it's necessary to run Puppet on the backend first to update the `admin` password.
+
 ### Notes regarding support
 
 This module is built for use with Puppet versions 5 and 6 and the ruby

--- a/lib/puppet/provider/sensu_api.rb
+++ b/lib/puppet/provider/sensu_api.rb
@@ -9,7 +9,6 @@ class Puppet::Provider::SensuAPI < Puppet::Provider
     attr_accessor :url
     attr_accessor :username
     attr_accessor :password
-    attr_accessor :old_password
     attr_accessor :access_token
     attr_accessor :refresh_token
   end
@@ -17,8 +16,6 @@ class Puppet::Provider::SensuAPI < Puppet::Provider
   def self.update_access_token
     auth_success = self.auth(@username, @password)
     return if auth_success
-    auth_old_success = self.auth(@username, @old_password)
-    return if auth_old_success
     auth_token_success = self.auth_token()
     return if auth_token_success
   end

--- a/lib/puppet/provider/sensu_user/sensu_api.rb
+++ b/lib/puppet/provider/sensu_user/sensu_api.rb
@@ -74,6 +74,7 @@ Puppet::Type.type(:sensu_user).provide(:sensu_api, :parent => Puppet::Provider::
         configure_cmd << '--trusted-ca-file'
         configure_cmd << resource[:configure_trusted_ca_file]
       end
+      Puppet.notice('Executing sensuctl configure')
       Puppet::Provider::Sensuctl.sensuctl(configure_cmd)
     end
     @property_hash[:ensure] = :present
@@ -97,6 +98,7 @@ Puppet::Type.type(:sensu_user).provide(:sensu_api, :parent => Puppet::Provider::
           configure_cmd << '--trusted-ca-file'
           configure_cmd << resource[:configure_trusted_ca_file]
         end
+        Puppet.notice('Executing sensuctl configure')
         Puppet::Provider::Sensuctl.sensuctl(configure_cmd)
       end
     end

--- a/lib/puppet/provider/sensu_user/sensu_api.rb
+++ b/lib/puppet/provider/sensu_user/sensu_api.rb
@@ -9,7 +9,7 @@ Puppet::Type.type(:sensu_user).provide(:sensu_api, :parent => Puppet::Provider::
   def self.instances
     users = []
 
-    data = api_request('users')
+    data = api_request('users', nil, {:failonfail => false})
 
     data.each do |d|
       user = {}

--- a/lib/puppet/provider/sensu_user/sensuctl.rb
+++ b/lib/puppet/provider/sensu_user/sensuctl.rb
@@ -102,6 +102,7 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
         configure_cmd << '--trusted-ca-file'
         configure_cmd << resource[:configure_trusted_ca_file]
       end
+      Puppet.notice('Executing sensuctl configure')
       sensuctl(configure_cmd)
     end
     @property_hash[:ensure] = :present
@@ -134,6 +135,7 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
           configure_cmd << '--trusted-ca-file'
           configure_cmd << resource[:configure_trusted_ca_file]
         end
+        Puppet.notice('Executing sensuctl configure')
         sensuctl(configure_cmd)
       end
     end

--- a/lib/puppet/provider/sensu_user/sensuctl.rb
+++ b/lib/puppet/provider/sensu_user/sensuctl.rb
@@ -52,6 +52,22 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
     exitstatus == 0
   end
 
+  def password_hash(password)
+    begin
+      hash = sensuctl(['user', 'hash-password', password])
+      # TODO: Remove once no longer need to support Sensu Go before 5.21
+      # Returns nil if output does not start with $, which means a hash was not provided
+      # If the hash-password command is not present, sensuctl will exit 0 and print help
+      if hash !~ /\$/
+        return nil
+      end
+      return hash.strip
+    rescue Exception => e
+      Puppet.warning("Unable to generate password hash for user #{resource[:name]}: #{e.to_s}")
+      return nil
+    end
+  end
+
   def initialize(value = {})
     super(value)
     @property_flush = {}
@@ -64,21 +80,21 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
   end
 
   def create
-    cmd = ['user', 'create']
-    cmd << resource[:name]
-    cmd << '--password'
-    cmd << resource[:password]
-    if resource[:groups]
-      cmd << '--groups'
-      cmd << resource[:groups].join(',')
+    spec = {}
+    metadata = {}
+    spec[:username] = resource[:name]
+    spec[:groups] = resource[:groups] unless resource[:groups].nil?
+    spec[:disabled] = convert_boolean_property_value(resource[:disabled]) unless resource[:disabled].nil?
+    hash = password_hash(resource[:password])
+    if hash
+      spec[:password_hash] = hash
+    else
+      spec[:password] = resource[:password]
     end
     begin
-      sensuctl(cmd)
+      sensuctl_create('User', metadata, spec)
     rescue Exception => e
-      raise Puppet::Error, "sensuctl user create #{resource[:name]} failed\nError message: #{e.message}"
-    end
-    if ! resource[:disabled].nil? && resource[:disabled].to_s == 'true'
-      sensuctl(['user', 'disable', resource[:name], '--skip-confirm'])
+      raise Puppet::Error, "sensuctl create #{resource[:name]} failed\nError message: #{e.message}"
     end
     if resource[:configure] == :true
       configure_cmd = ['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', resource[:password]]
@@ -93,45 +109,32 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
 
   def flush
     if !@property_flush.empty?
-      if @property_flush[:password]
-        if ! resource[:old_password]
-          fail("old_password is manditory when changing a password")
-        end
-        if ! password_insync?(resource[:name], resource[:old_password])
-          fail("old_password given for #{resource[:name]} is incorrect")
-        end
-        sensuctl(['user', 'change-password', resource[:name], '--current-password', resource[:old_password], '--new-password', @property_flush[:password]])
-        if resource[:configure] == :true
-          configure_cmd = ['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password]]
-          if resource[:configure_trusted_ca_file] != "absent"
-            configure_cmd << '--trusted-ca-file'
-            configure_cmd << resource[:configure_trusted_ca_file]
-          end
-          sensuctl(configure_cmd)
-        end
+      spec = {}
+      metadata = {}
+      spec[:username] = resource[:name]
+      groups = @property_flush[:groups] || resource[:groups]
+      spec[:groups] = groups unless groups.nil?
+      disabled = @property_flush[:disabled] || resource[:disabled]
+      spec[:disabled] = convert_boolean_property_value(disabled) unless disabled.nil?
+      password = @property_flush[:password] || resource[:password]
+      hash = password_hash(password)
+      if hash
+        spec[:password_hash] = hash
+      else
+        spec[:password] = password
       end
-      if @property_flush[:groups]
-        current_groups = @property_hash[:groups] || []
-        # Add groups not currently set
-        @property_flush[:groups].each do |group|
-          if ! current_groups.include?(group)
-            sensuctl(['user', 'add-group', resource[:name], group])
-          end
-        end
-        # Remove current groups not set by Puppet
-        current_groups.each do |group|
-          if ! @property_flush[:groups].include?(group)
-            sensuctl(['user', 'remove-group', resource[:name], group])
-          end
-        end
+      begin
+        sensuctl_create('User', metadata, spec)
+      rescue Exception => e
+        raise Puppet::Error, "sensuctl create #{resource[:name]} failed\nError message: #{e.message}"
       end
-      if ! @property_flush[:disabled].nil?
-        if @property_flush[:disabled].to_s == 'true'
-          sensuctl(['user', 'disable', resource[:name], '--skip-confirm'])
+      if @property_flush[:password] && resource[:configure] == :true
+        configure_cmd = ['configure', '-n', '--url', resource[:configure_url], '--username', resource[:name], '--password', @property_flush[:password]]
+        if resource[:configure_trusted_ca_file] != "absent"
+          configure_cmd << '--trusted-ca-file'
+          configure_cmd << resource[:configure_trusted_ca_file]
         end
-        if @property_flush[:disabled].to_s == 'false'
-          sensuctl(['user', 'reinstate', resource[:name]])
-        end
+        sensuctl(configure_cmd)
       end
     end
     @property_hash = resource.to_hash

--- a/lib/puppet/provider/sensuctl_configure/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl_configure/sensuctl.rb
@@ -64,7 +64,6 @@ Puppet::Type.type(:sensuctl_configure).provide(:sensuctl, :parent => Puppet::Pro
     backend = which('sensu-backend')
     return if backend.nil?
     return if Puppet::Provider::SensuAPI.auth_test(resource[:url], resource[:username], resource[:password])
-    return if Puppet::Provider::SensuAPI.auth_test(resource[:url], resource[:username], resource[:old_password])
     return if Puppet::Provider::SensuAPI.auth_test(resource[:url], resource[:username], bootstrap_password)
     custom_environment = {
       'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME' => resource[:username],
@@ -88,11 +87,7 @@ Puppet::Type.type(:sensuctl_configure).provide(:sensuctl, :parent => Puppet::Pro
     cmd << resource[:username]
     cmd << '--password'
     if exists?
-      if resource[:old_password] && Puppet::Provider::SensuAPI.auth_test(resource[:url], resource[:username], resource[:old_password])
-        cmd << resource[:old_password]
-      else
-        cmd << resource[:password]
-      end
+      cmd << resource[:password]
     else
       # Test if default password works and use that password first
       # This supports bootstrapping sensuctl on fresh installs of sensu backend

--- a/lib/puppet/type/sensu_ad_auth.rb
+++ b/lib/puppet/type/sensu_ad_auth.rb
@@ -33,6 +33,7 @@ Puppet::Type.newtype(:sensu_ad_auth) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -25,10 +25,6 @@ DESC
     desc "Sensu API password"
   end
 
-  newparam(:old_password) do
-    desc "Sensu API old password"
-  end
-
   # First collect all types with sensu_api provider that come from this module
   # For each sensu_api type, set the class variable 'chunk_size' used by
   # each provider to list resources
@@ -44,7 +40,6 @@ DESC
       provider_class.url = self[:url]
       provider_class.username = self[:username]
       provider_class.password = self[:password]
-      provider_class.old_password = self[:old_password]
     end
     []
   end

--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -64,6 +64,7 @@ Puppet::Type.newtype(:sensu_asset) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 

--- a/lib/puppet/type/sensu_bonsai_asset.rb
+++ b/lib/puppet/type/sensu_bonsai_asset.rb
@@ -33,6 +33,7 @@ Puppet::Type.newtype(:sensu_bonsai_asset) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 

--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -44,6 +44,7 @@ Puppet::Type.newtype(:sensu_check) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 * `sensu_handler` - Puppet will autorequie `sensu_handler` resources defined in `handlers` property.
 * `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.

--- a/lib/puppet/type/sensu_cluster_federation.rb
+++ b/lib/puppet/type/sensu_cluster_federation.rb
@@ -18,6 +18,7 @@ Puppet::Type.newtype(:sensu_cluster_federation) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_cluster_federation_member.rb
+++ b/lib/puppet/type/sensu_cluster_federation_member.rb
@@ -23,6 +23,7 @@ Puppet::Type.newtype(:sensu_cluster_federation_member) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_cluster_member.rb
+++ b/lib/puppet/type/sensu_cluster_member.rb
@@ -17,6 +17,7 @@ Puppet::Type.newtype(:sensu_cluster_member) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_cluster_role.rb
+++ b/lib/puppet/type/sensu_cluster_role.rb
@@ -18,6 +18,7 @@ Puppet::Type.newtype(:sensu_cluster_role) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_cluster_role_binding.rb
+++ b/lib/puppet/type/sensu_cluster_role_binding.rb
@@ -30,6 +30,7 @@ Puppet::Type.newtype(:sensu_cluster_role_binding) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_cluster_role` - Puppet will autorequire `sensu_cluster_role` resource defined in `role_ref` property.
 * `sensu_user` - Puppet will autorequire `sensu_user` resources based on users and groups defined for the `subjects` property.
 DESC
@@ -116,7 +117,7 @@ DESC
   end
 
   autorequire(:sensu_user) do
-    users = []
+    users = ['admin']
     groups = []
     (self[:subjects] || []).each do |subject|
       if subject['type'] == 'User'

--- a/lib/puppet/type/sensu_command.rb
+++ b/lib/puppet/type/sensu_command.rb
@@ -31,6 +31,7 @@ Puppet::Type.newtype(:sensu_command) do
 * `Service[sensu-backend]`
 * `Sensu_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_entity.rb
+++ b/lib/puppet/type/sensu_entity.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:sensu_entity) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 * `sensu_handler` - Puppet will autorequie `sensu_handler` resource defined in `deregistration.handler` property.
 DESC

--- a/lib/puppet/type/sensu_etcd_replicator.rb
+++ b/lib/puppet/type/sensu_etcd_replicator.rb
@@ -25,6 +25,7 @@ Puppet::Type.newtype(:sensu_etcd_replicator) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_filter.rb
+++ b/lib/puppet/type/sensu_filter.rb
@@ -26,6 +26,7 @@ Puppet::Type.newtype(:sensu_filter) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 * `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.
 DESC

--- a/lib/puppet/type/sensu_handler.rb
+++ b/lib/puppet/type/sensu_handler.rb
@@ -27,6 +27,7 @@ Puppet::Type.newtype(:sensu_handler) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 * `sensu_filter` - Puppet will autorequire `sensu_filter` resources defined in `filters` property.
 * `sensu_mutator` - Puppet will autorequire `sensu_mutator` resource defined for `mutator` property.

--- a/lib/puppet/type/sensu_hook.rb
+++ b/lib/puppet/type/sensu_hook.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:sensu_hook) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 * `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.
 DESC

--- a/lib/puppet/type/sensu_ldap_auth.rb
+++ b/lib/puppet/type/sensu_ldap_auth.rb
@@ -33,6 +33,7 @@ Puppet::Type.newtype(:sensu_ldap_auth) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_license.rb
+++ b/lib/puppet/type/sensu_license.rb
@@ -12,6 +12,7 @@ Puppet::Type.newtype(:sensu_license) do
 * `Package[sensu-go-cli]`
 * `Service[sensu-backend]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `file` - Puppet will autorequire `file` resources defined in `file` property.
 DESC
 

--- a/lib/puppet/type/sensu_mutator.rb
+++ b/lib/puppet/type/sensu_mutator.rb
@@ -25,6 +25,7 @@ Puppet::Type.newtype(:sensu_mutator) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 * `sensu_asset` - Puppet will autorequire `sensu_asset` resources defined in `runtime_assets` property.
 DESC

--- a/lib/puppet/type/sensu_namespace.rb
+++ b/lib/puppet/type/sensu_namespace.rb
@@ -16,6 +16,7 @@ Puppet::Type.newtype(:sensu_namespace) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_oidc_auth.rb
+++ b/lib/puppet/type/sensu_oidc_auth.rb
@@ -26,6 +26,7 @@ Puppet::Type.newtype(:sensu_oidc_auth) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_postgres_config.rb
+++ b/lib/puppet/type/sensu_postgres_config.rb
@@ -19,6 +19,7 @@ Puppet::Type.newtype(:sensu_postgres_config) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_role.rb
+++ b/lib/puppet/type/sensu_role.rb
@@ -24,6 +24,7 @@ Puppet::Type.newtype(:sensu_role) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 

--- a/lib/puppet/type/sensu_role_binding.rb
+++ b/lib/puppet/type/sensu_role_binding.rb
@@ -38,6 +38,7 @@ Puppet::Type.newtype(:sensu_role_binding) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_role` - Puppet will autorequire `sensu_role` resource defined in `role_ref` property.
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 * `sensu_user` - Puppet will autorequire `sensu_user` resources based on users and groups defined for the `subjects` property.
@@ -141,7 +142,7 @@ DESC
   end
 
   autorequire(:sensu_user) do
-    users = []
+    users = ['admin']
     groups = []
     (self[:subjects] || []).each do |subject|
       if subject['type'] == 'User'

--- a/lib/puppet/type/sensu_secret.rb
+++ b/lib/puppet/type/sensu_secret.rb
@@ -19,6 +19,7 @@ Puppet::Type.newtype(:sensu_secret) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `sensu_namespace` - Puppet will autorequire `sensu_namespace` resource defined in `namespace` property.
 DESC
 

--- a/lib/puppet/type/sensu_secrets_vault_provider.rb
+++ b/lib/puppet/type/sensu_secrets_vault_provider.rb
@@ -31,6 +31,7 @@ Puppet::Type.newtype(:sensu_secrets_vault_provider) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_tessen.rb
+++ b/lib/puppet/type/sensu_tessen.rb
@@ -13,6 +13,7 @@ Puppet::Type.newtype(:sensu_tessen) do
 * `Service[sensu-backend]`
 * `Sensu_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -15,10 +15,9 @@ Puppet::Type.newtype(:sensu_user) do
 
 @example Change a user's password
   sensu_user { 'test'
-    ensure       => 'present',
-    password     => 'newpassword',
-    old_password => 'supersecret',
-    groups       => ['users'],
+    ensure   => 'present',
+    password => 'newpassword',
+    groups   => ['users'],
   }
 
 **Autorequires**:
@@ -29,7 +28,7 @@ Puppet::Type.newtype(:sensu_user) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires(false)
+  add_autorequires(false, true, false)
 
   ensurable do
     desc "The basic property that the resource should be in."
@@ -53,6 +52,10 @@ DESC
 
   newproperty(:password) do
     desc "The user's password."
+
+    validate do |value|
+      raise ArgumentError, "password must be at least 8 characters long" unless value.size >= 8
+    end
 
     def insync?(is)
       if @resource[:disabled].to_sym == :true
@@ -78,7 +81,10 @@ DESC
   end
 
   newparam(:old_password) do
-    desc "The user's old password, needed in order to change a user's password"
+    desc "DEPRECATED - The user's old password, needed in order to change a user's password"
+    validate do |value|
+      Puppet.warning("Sensu_user[#{@resource[:name]}]: The old_password parameter is unnecessary and will be removed in a future release")
+    end
   end
 
   newproperty(:groups, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -25,6 +25,7 @@ Puppet::Type.newtype(:sensu_user) do
 * `Service[sensu-backend]`
 * `Sensuctl_configure[puppet]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 DESC
 
   extend PuppetX::Sensu::Type
@@ -111,6 +112,14 @@ DESC
   newparam(:configure_trusted_ca_file) do
     desc "Path to trusted CA to use with 'sensuctl configure'"
     defaultto('/etc/sensu/ssl/ca.crt')
+  end
+
+  autorequire(:sensu_user) do
+    if self[:name] == 'admin'
+      []
+    else
+      ['admin']
+    end
   end
 
   validate do

--- a/lib/puppet/type/sensuctl_configure.rb
+++ b/lib/puppet/type/sensuctl_configure.rb
@@ -12,11 +12,12 @@ Puppet::Type.newtype(:sensuctl_configure) do
 * `Package[sensu-go-cli]`
 * `Service[sensu-backend]`
 * `Sensu_api_validator[sensu]`
+* `Sensu_user[admin]`
 * `file` - Puppet will autorequire `file` resources defined in `trusted_ca_file` property.
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires(false, false, false)
+  add_autorequires(false, false)
 
   ensurable
 

--- a/lib/puppet/type/sensuctl_configure.rb
+++ b/lib/puppet/type/sensuctl_configure.rb
@@ -16,7 +16,7 @@ Puppet::Type.newtype(:sensuctl_configure) do
 DESC
 
   extend PuppetX::Sensu::Type
-  add_autorequires(false, false)
+  add_autorequires(false, false, false)
 
   ensurable
 
@@ -35,11 +35,6 @@ DESC
   newparam(:password) do
     desc "Password to use with sensuctl configure"
   end
-
-  newparam(:old_password) do
-    desc "The previous sensuctl password, needed in order to change passwords"
-  end
-
 
   newproperty(:trusted_ca_file) do
     desc "Path to trusted CA"

--- a/lib/puppet_x/sensu/type.rb
+++ b/lib/puppet_x/sensu/type.rb
@@ -6,7 +6,7 @@ module PuppetX
         %r{^[\w.\-:]+$}
       end
 
-      def add_autorequires(namespace=true, require_configure=true)
+      def add_autorequires(namespace=true, require_configure=true, require_admin=true)
         autorequire(:package) do
           ['sensu-go-cli']
         end
@@ -28,6 +28,12 @@ module PuppetX
         if namespace
           autorequire(:sensu_namespace) do
             [ self[:namespace] ]
+          end
+        end
+
+        if require_admin
+          autorequire(:sensu_user) do
+            ['admin']
           end
         end
       end

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -9,10 +9,9 @@ class sensu::api {
   include sensu
 
   sensu_api_config { 'sensu':
-    url          => $sensu::api_url,
-    username     => 'admin',
-    password     => $sensu::password,
-    old_password => $sensu::old_password,
+    url      => $sensu::api_url,
+    username => 'admin',
+    password => $sensu::password,
   }
 
   sensu_api_validator { 'sensu':

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -190,6 +190,8 @@ class sensu::backend (
     configure                 => true,
     configure_url             => $sensu::api_url,
     configure_trusted_ca_file => $sensu::trusted_ca_file,
+    provider                  => 'sensu_api',
+    before                    => Sensuctl_configure['puppet'],
   }
 
   if $manage_agent_user {
@@ -299,5 +301,21 @@ class sensu::backend (
     enable    => $service_enable,
     name      => $service_name,
     subscribe => $service_subscribe,
+  }
+
+  exec { 'sensu-backend init':
+    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+    refreshonly => true,
+    environment => [
+      'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=admin',
+      "SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=${sensu::password}",
+    ],
+    returns     => [0, 3],
+    subscribe   => Package['sensu-go-backend'],
+    require     => Sensu_api_validator['sensu'],
+    before      => [
+      Sensu_user['admin'],
+      Sensuctl_configure['puppet'],
+    ],
   }
 }

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -185,7 +185,6 @@ class sensu::backend (
   sensu_user { 'admin':
     ensure                    => 'present',
     password                  => $sensu::password,
-    old_password              => $sensu::old_password,
     groups                    => ['cluster-admins'],
     disabled                  => false,
     configure                 => true,
@@ -195,11 +194,10 @@ class sensu::backend (
 
   if $manage_agent_user {
     sensu_user { 'agent':
-      ensure       => 'present',
-      disabled     => $agent_user_disabled,
-      password     => $sensu::agent_password,
-      old_password => $sensu::agent_old_password,
-      groups       => ['system:agents'],
+      ensure   => 'present',
+      disabled => $agent_user_disabled,
+      password => $sensu::agent_password,
+      groups   => ['system:agents'],
     }
   }
 

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -90,7 +90,6 @@ class sensu::cli (
       url              => $sensu::api_url,
       username         => 'admin',
       password         => $sensu::password,
-      old_password     => $sensu::old_password,
       trusted_ca_file  => $sensu::trusted_ca_file,
       config_format    => $config_format,
       config_namespace => $config_namespace,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -54,11 +54,11 @@
 # @param password
 #   Sensu backend admin password used to confiure sensuctl.
 # @param old_password
-#   Sensu backend admin old password needed when changing password.
+#   DEPRECATED - Sensu backend admin old password needed when changing password.
 # @param agent_password
 #   The sensu agent password
 # @param agent_old_password
-#   The sensu agent old password needed when changing agent_password
+#   DEPRECATED - The sensu agent old password needed when changing agent_password
 class sensu (
   String $version = 'installed',
   Stdlib::Absolutepath $etc_dir = '/etc/sensu',
@@ -80,6 +80,13 @@ class sensu (
   String $agent_password = 'P@ssw0rd!',
   Optional[String] $agent_old_password = undef,
 ) {
+
+  if $old_password {
+    warning('Sensu: old_password parameter is unnecessary and will be removed in a future release')
+  }
+  if $agent_old_password {
+    warning('Sensu: agent_old_password parameter is unnecessary and will be removed in a future release')
+  }
 
   if $ssl_ca_content {
     $_ssl_ca_source = undef

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -6,8 +6,7 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu':
-        password     => 'supersecret',
-        old_password => 'P@ssw0rd!',
+        password => 'supersecret',
       }
       class { 'sensu::backend':
         include_default_resources => false,
@@ -40,8 +39,7 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu':
-        password     => 'supersecret',
-        old_password => 'P@ssw0rd!',
+        password => 'supersecret',
       }
       class { 'sensu::backend':
         include_default_resources => true,
@@ -65,8 +63,7 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu':
-        password     => 'supersecret',
-        old_password => 'P@ssw0rd!',
+        password => 'supersecret',
       }
       class { 'sensu::backend':
         service_env_vars => { 'SENSU_BACKEND_AGENT_PORT' => '9081' },
@@ -99,8 +96,7 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu':
-        password     => 'supersecret',
-        old_password => 'P@ssw0rd!',
+        password => 'supersecret',
       }
       class { 'sensu::backend': }
       class { 'sensu::agent':
@@ -135,8 +131,7 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu':
-        password     => 'supersecret',
-        old_password => 'P@ssw0rd!',
+        password => 'supersecret',
       }
       class { 'sensu::backend':
         agent_user_disabled => true,
@@ -161,8 +156,7 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu':
-        password      => 'P@ssw0rd!',
-        old_password  => 'supersecret',
+        password => 'P@ssw0rd!',
       }
       class { 'sensu::backend':
         tessen_ensure => 'absent',

--- a/spec/acceptance/02_backend_cluster_spec.rb
+++ b/spec/acceptance/02_backend_cluster_spec.rb
@@ -183,6 +183,7 @@ describe 'sensu::backend cluster class', if: RSpec.configuration.sensu_mode == '
       on hosts, 'systemctl stop sensu-backend'
       on hosts, 'rm -rf /var/lib/sensu/sensu-backend/etcd/*'
       on hosts, 'rm -rf /root/.config'
+      on hosts, 'puppet resource package sensu-go-backend ensure=absent'
 
       if RSpec.configuration.sensu_use_agent
         site_pp = <<-EOS

--- a/spec/acceptance/03_no_ssl_spec.rb
+++ b/spec/acceptance/03_no_ssl_spec.rb
@@ -7,9 +7,8 @@ describe 'sensu without SSL', if: ['base','full'].include?(RSpec.configuration.s
     it 'should work without errors' do
       pp = <<-EOS
       class { '::sensu':
-        use_ssl      => false,
-        password     => 'P@ssw0rd!',
-        old_password => 'supersecret',
+        use_ssl  => false,
+        password => 'P@ssw0rd!',
       }
       class { 'sensu::backend': }
       sensu_entity { 'sensu-agent':

--- a/spec/acceptance/04_plugins_spec.rb
+++ b/spec/acceptance/04_plugins_spec.rb
@@ -58,8 +58,7 @@ describe 'sensu::plugins class', if: ['base','full'].include?(RSpec.configuratio
     it 'should work without errors and be idempotent' do
       pp = <<-EOS
       class { '::sensu':
-        password     => 'P@ssw0rd!',
-        old_password => 'supersecret',
+        password => 'P@ssw0rd!',
       }
       class { 'sensu::backend': }
       class { 'sensu::plugins':

--- a/spec/acceptance/07_cli_spec.rb
+++ b/spec/acceptance/07_cli_spec.rb
@@ -14,8 +14,7 @@ describe 'sensu::cli class', if: ['base','full'].include?(RSpec.configuration.se
       EOS
       backend_pp = <<-EOS
       class { '::sensu':
-        password      => 'P@ssw0rd!',
-        old_password  => 'supersecret',
+        password => 'P@ssw0rd!',
       }
       class { 'sensu::backend': }
       EOS
@@ -58,8 +57,7 @@ describe 'sensu::cli class', if: ['base','full'].include?(RSpec.configuration.se
       EOS
       backend_pp = <<-EOS
       class { '::sensu':
-        password      => 'supersecret',
-        old_password  => 'P@ssw0rd!',
+        password => 'supersecret',
       }
       class { 'sensu::backend': }
       EOS
@@ -99,9 +97,8 @@ describe 'sensu::cli class', if: ['base','full'].include?(RSpec.configuration.se
       EOS
       backend_pp = <<-EOS
       class { '::sensu':
-        use_ssl       => false,
-        password      => 'P@ssw0rd!',
-        old_password  => 'supersecret',
+        use_ssl  => false,
+        password => 'P@ssw0rd!',
       }
       class { 'sensu::backend': }
       EOS

--- a/spec/acceptance/sensu_user_spec.rb
+++ b/spec/acceptance/sensu_user_spec.rb
@@ -68,9 +68,8 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
       pp = <<-EOS
       include sensu::backend
       sensu_user { 'test':
-        password     => 'password2',
-        old_password => 'password',
-        groups       => ['read-only'],
+        password => 'password2',
+        groups   => ['read-only'],
       }
       sensu_user { 'test2':
         password => 'password',
@@ -129,9 +128,8 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
       pp = <<-EOS
       include sensu::backend
       sensu_user { 'test':
-        password     => 'password3',
-        old_password => 'password2',
-        groups       => ['read-only'],
+        password => 'password3',
+        groups   => ['read-only'],
       }
       sensu_user { 'test-api':
         password => 'password3',
@@ -161,28 +159,6 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
     it 'should have valid password using API' do
       exit_code = on(node, 'sensuctl user test-creds test-api --password password3').exit_code
       expect(exit_code).to eq(0)
-    end
-  end
-
-  context 'invalid old_password' do
-    it 'should result in an error' do
-      pp = <<-EOS
-      include sensu::backend
-      sensu_user { 'test':
-        password     => 'password2',
-        old_password => 'password4',
-        groups       => ['read-only'],
-      }
-      EOS
-
-      if RSpec.configuration.sensu_use_agent
-        site_pp = "node 'sensu-backend' { #{pp} }"
-        puppetserver = hosts_as('puppetserver')[0]
-        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
-        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [1,4,6]
-      else
-        apply_manifest_on(node, pp, :expect_failures => true)
-      end
     end
   end
 

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -19,10 +19,9 @@ describe 'sensu::api', :type => :class do
 
         it {
           should contain_sensu_api_config('sensu').with({
-            'url'          => 'https://test.example.com:8080',
-            'username'     => 'admin',
-            'password'     => 'P@ssw0rd!',
-            'old_password' => nil,
+            'url'      => 'https://test.example.com:8080',
+            'username' => 'admin',
+            'password' => 'P@ssw0rd!',
           })
         }
 

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -34,7 +34,6 @@ describe 'sensu::backend', :type => :class do
           should contain_sensu_user('admin').with({
             'ensure'                    => 'present',
             'password'                  => 'P@ssw0rd!',
-            'old_password'              => nil,
             'groups'                    => ['cluster-admins'],
             'disabled'                  => 'false',
             'configure'                 => 'true',
@@ -47,7 +46,6 @@ describe 'sensu::backend', :type => :class do
             'ensure'       => 'present',
             'disabled'     => 'false',
             'password'     => 'P@ssw0rd!',
-            'old_password' => nil,
             'groups'       => ['system:agents'],
           })
         }
@@ -196,7 +194,6 @@ describe 'sensu::backend', :type => :class do
           should contain_sensu_user('admin').with({
             'ensure'                    => 'present',
             'password'                  => 'P@ssw0rd!',
-            'old_password'              => nil,
             'groups'                    => ['cluster-admins'],
             'disabled'                  => 'false',
             'configure'                 => 'true',

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -39,6 +39,8 @@ describe 'sensu::backend', :type => :class do
             'configure'                 => 'true',
             'configure_url'             => 'https://test.example.com:8080',
             'configure_trusted_ca_file' => '/etc/sensu/ssl/ca.crt',
+            'provider'                  => 'sensu_api',
+            'before'                    => 'Sensuctl_configure[puppet]',
           })
         }
         it {
@@ -199,6 +201,8 @@ describe 'sensu::backend', :type => :class do
             'configure'                 => 'true',
             'configure_url'             => 'http://test.example.com:8080',
             'configure_trusted_ca_file' => 'absent',
+            'provider'                  => 'sensu_api',
+            'before'                    => 'Sensuctl_configure[puppet]',
           })
         }
 
@@ -219,6 +223,24 @@ describe 'sensu::backend', :type => :class do
         }
 
         it { should contain_service('sensu-backend').without_notify }
+
+        it {
+          should contain_exec('sensu-backend init').with({
+            'path'        => '/usr/bin:/bin:/usr/sbin:/sbin',
+            'refreshonly' => 'true',
+            'environment' => [
+              'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=admin',
+              'SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=P@ssw0rd!',
+            ],
+            'returns'     => [0, 3],
+            'subscribe'   => 'Package[sensu-go-backend]',
+            'require'     => 'Sensu_api_validator[sensu]',
+            'before'      => [
+              'Sensu_user[admin]',
+              'Sensuctl_configure[puppet]',
+            ],
+          })
+        }
 
         context 'when puppet_hostcert undefined' do
           let(:facts) { facts.merge(puppet_hostcert: nil) }

--- a/spec/classes/resources_spec.rb
+++ b/spec/classes/resources_spec.rb
@@ -358,7 +358,7 @@ describe 'sensu::resources', :type => :class do
           <<-EOS
           class { 'sensu::resources':
             users => {
-              'test' => { 'password' => 'foobar' },
+              'test' => { 'password' => 'password' },
             }
           }
           EOS

--- a/spec/shared_examples/types.rb
+++ b/spec/shared_examples/types.rb
@@ -29,9 +29,10 @@ RSpec.shared_examples 'name_regex' do
   end
 end
 
-RSpec.shared_examples 'autorequires' do |namespace, configure|
+RSpec.shared_examples 'autorequires' do |namespace, configure, user|
   namespace = true if namespace.nil?
   configure = true if configure.nil?
+  user = true if user.nil?
 
   it 'should autorequire Package[sensu-go-cli]' do
     package = Puppet::Type.type(:package).new(:name => 'sensu-go-cli')
@@ -84,6 +85,18 @@ RSpec.shared_examples 'autorequires' do |namespace, configure|
       catalog.add_resource namespace
       rel = res.autorequire[0]
       expect(rel.source.ref).to eq(namespace.ref)
+      expect(rel.target.ref).to eq(res.ref)
+    end
+  end
+
+  if user
+    it 'should autorequire sensu_user' do
+      validator = Puppet::Type.type(:sensu_user).new(:name => 'admin', :password => 'password')
+      catalog = Puppet::Resource::Catalog.new
+      catalog.add_resource res
+      catalog.add_resource validator
+      rel = res.autorequire[0]
+      expect(rel.source.ref).to eq(validator.ref)
       expect(rel.target.ref).to eq(res.ref)
     end
   end

--- a/spec/unit/provider/sensu_user/sensu_api_spec.rb
+++ b/spec/unit/provider/sensu_user/sensu_api_spec.rb
@@ -14,12 +14,12 @@ describe Puppet::Type.type(:sensu_user).provider(:sensu_api) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(provider).to receive(:api_request).with('users').and_return(JSON.parse(my_fixture_read('user_list.json')))
+      allow(provider).to receive(:api_request).with('users', nil, {:failonfail => false}).and_return(JSON.parse(my_fixture_read('user_list.json')))
       expect(provider.instances.length).to eq(2)
     end
 
     it 'should return the resource for a user' do
-      allow(provider).to receive(:api_request).with('users').and_return(JSON.parse(my_fixture_read('user_list.json')))
+      allow(provider).to receive(:api_request).with('users', nil, {:failonfail => false}).and_return(JSON.parse(my_fixture_read('user_list.json')))
       property_hash = provider.instances.select {|i| i.name == 'admin'}[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('admin')
       expect(property_hash[:groups]).to eq(['cluster-admins'])

--- a/spec/unit/provider/sensuctl_configure/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_configure/sensuctl_spec.rb
@@ -25,67 +25,22 @@ describe Puppet::Type.type(:sensuctl_configure).provider(:sensuctl) do
     end
   end
 
-  describe 'backend_init' do
-    let(:custom_environment) do
-      {
-        'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME' => resource[:username],
-        'SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD' => resource[:password],
-      }
-    end
-
-    it 'should execute sensu-backend init' do
-      allow(resource.provider).to receive(:which).with('sensu-backend').and_return('/usr/sbin/sensu-backend')
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).with(resource[:url], resource[:username], 'foobar').and_return(false)
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).with(resource[:url], resource[:username], 'P@ssw0rd!').and_return(false)
-      expect(resource.provider).to receive(:execute).with(['/usr/sbin/sensu-backend','init'],{failonfail: false, custom_environment: custom_environment})
-      resource.provider.backend_init
-    end
-
-    it 'should skip if not sensu-backend' do
-      allow(resource.provider).to receive(:which).with('sensu-backend').and_return(nil)
-      expect(resource.provider).not_to receive(:execute)
-      resource.provider.backend_init
-    end
-
-    it 'should skip if password matches' do
-      allow(resource.provider).to receive(:which).with('sensu-backend').and_return('/usr/sbin/sensu-backend')
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).with(resource[:url], resource[:username], 'foobar').and_return(true)
-      expect(resource.provider).not_to receive(:execute)
-      resource.provider.backend_init
-    end
-
-    it 'should skip if bootstrap_password matches' do
-      allow(resource.provider).to receive(:which).with('sensu-backend').and_return('/usr/sbin/sensu-backend')
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).with(resource[:url], resource[:username], 'foobar').and_return(false)
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).with(resource[:url], resource[:username], 'P@ssw0rd!').and_return(true)
-      expect(resource.provider).not_to receive(:execute)
-      resource.provider.backend_init
-    end
-  end
-
   describe 'create' do
     before(:each) do
       allow(resource.provider).to receive(:exists?).and_return(false)
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).and_return(true)
     end
 
     it 'should run sensuctl configure' do
-      expect(resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
+      expect(resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       resource.provider.create
     end
     it 'should run sensuctl configure without SSL' do
       resource[:trusted_ca_file] = 'absent'
-      expect(resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','P@ssw0rd!'])
-      resource.provider.create
-    end
-    it 'should run sensuctl configure with password' do
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).and_return(false)
-      expect(resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
+      expect(resource.provider).to receive(:sensuctl).with(['configure','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       resource.provider.create
     end
     it 'should run sensuctl configure with namespace' do
       resource[:config_namespace] = 'qa'
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).and_return(false)
       expect(resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       expect(resource.provider).to receive(:sensuctl).with(['config','set-namespace','qa'])
       resource.provider.create
@@ -108,7 +63,6 @@ describe Puppet::Type.type(:sensuctl_configure).provider(:sensuctl) do
       resource.provider.flush
     end
     it 'should use update namespace' do
-      allow(Puppet::Provider::SensuAPI).to receive(:auth_test).and_return(true)
       expect(resource.provider).to receive(:sensuctl).with(['configure','--trusted-ca-file','/etc/sensu/ssl/ca.crt','--non-interactive','--url','http://localhost:8080','--username','admin','--password','foobar'])
       expect(resource.provider).to receive(:sensuctl).with(['config','set-namespace','qa'])
       resource.provider.config_namespace = 'qa'

--- a/spec/unit/sensu_cluster_role_binding_spec.rb
+++ b/spec/unit/sensu_cluster_role_binding_spec.rb
@@ -190,7 +190,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
 
   it 'should autorequire sensu_user by user' do
     config[:subjects] = [{'type' => 'User', 'name' => 'test'}]
-    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'password')
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource binding
     catalog.add_resource user
@@ -201,7 +201,7 @@ describe Puppet::Type.type(:sensu_cluster_role_binding) do
 
   it 'should autorequire sensu_user by group' do
     config[:subjects] = [{'type' => 'Group', 'name' => 'group'}]
-    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'password')
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource binding
     catalog.add_resource user

--- a/spec/unit/sensu_role_binding_spec.rb
+++ b/spec/unit/sensu_role_binding_spec.rb
@@ -219,7 +219,7 @@ describe Puppet::Type.type(:sensu_role_binding) do
 
   it 'should autorequire sensu_user by user' do
     config[:subjects] = [{'type' => 'User', 'name' => 'test'}]
-    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'password')
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource binding
     catalog.add_resource user
@@ -230,7 +230,7 @@ describe Puppet::Type.type(:sensu_role_binding) do
 
   it 'should autorequire sensu_user by group' do
     config[:subjects] = [{'type' => 'Group', 'name' => 'group'}]
-    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'foobar')
+    user = Puppet::Type.type(:sensu_user).new(:name => 'test', :groups => ['group'], :password => 'password')
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource binding
     catalog.add_resource user

--- a/spec/unit/sensu_user_spec.rb
+++ b/spec/unit/sensu_user_spec.rb
@@ -5,7 +5,7 @@ describe Puppet::Type.type(:sensu_user) do
   let(:default_config) do
     {
       name: 'test',
-      password: 'foobar',
+      password: 'password',
     }
   end
   let(:config) do
@@ -67,8 +67,6 @@ describe Puppet::Type.type(:sensu_user) do
 
   # String properties
   [
-    :password,
-    :old_password,
     :configure_url,
     :configure_trusted_ca_file,
   ].each do |property|
@@ -199,7 +197,17 @@ describe Puppet::Type.type(:sensu_user) do
     end
   end
 
-  include_examples 'autorequires', false do
+  describe 'password' do
+    it 'accepts value' do
+      expect(user[:password]).to eq('password')
+    end
+    it 'has minimum length' do
+      config[:password] = 'foo'
+      expect { user }.to raise_error(Puppet::Error, /8 characters long/)
+    end
+  end
+
+  include_examples 'autorequires', false, true, false do
     let(:res) { user }
   end
 

--- a/spec/unit/sensu_user_spec.rb
+++ b/spec/unit/sensu_user_spec.rb
@@ -207,6 +207,16 @@ describe Puppet::Type.type(:sensu_user) do
     end
   end
 
+  it 'should autorequire sensu_user' do
+    validator = Puppet::Type.type(:sensu_user).new(:name => 'admin', :password => 'password')
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource user
+    catalog.add_resource validator
+    rel = user.autorequire[0]
+    expect(rel.source.ref).to eq(validator.ref)
+    expect(rel.target.ref).to eq(user.ref)
+  end
+
   include_examples 'autorequires', false, true, false do
     let(:res) { user }
   end

--- a/spec/unit/sensuctl_configure_spec.rb
+++ b/spec/unit/sensuctl_configure_spec.rb
@@ -155,7 +155,7 @@ describe Puppet::Type.type(:sensuctl_configure) do
     expect(rel.target.ref).to eq(configure.ref)
   end
 
-  include_examples 'autorequires', false, false, false do
+  include_examples 'autorequires', false, false do
     let(:res) { configure }
   end
 

--- a/spec/unit/sensuctl_configure_spec.rb
+++ b/spec/unit/sensuctl_configure_spec.rb
@@ -155,7 +155,7 @@ describe Puppet::Type.type(:sensuctl_configure) do
     expect(rel.target.ref).to eq(configure.ref)
   end
 
-  include_examples 'autorequires', false, false do
+  include_examples 'autorequires', false, false, false do
     let(:res) { configure }
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

* Deprecate `sensu::old_password` and `sensu::agent_old_password`, no longer used or necessary
* Validate `sensu_user` passwords are at least 8 characters long
* All resources except now auto-require `Sensu_user[admin]`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go now makes it easier to manage passwords in such a way that using the old password is no longer necessary.  This deprecates the unnecessary password so that catalogs don't produce errors if people have provided the `old_password` parameters.

The changes to support this should be released in Sensu Go 5.21 but this should still work before 5.21 by passing the plain text password when managing users if the command to generate the hash fails.

There will be deprecation warnings for public resources with `old_password`. All private resources had `old_password` removed.

I've added hopefully catchy bold to pull request title to grab people's attention in CHANGELOG.