### PR TITLE
Fix Windows acceptance tests and update Postgresql dependency range

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -35,7 +35,7 @@ fixtures:
       ref: v6.0.0
     postgresql:
       repo: git://github.com/puppetlabs/puppetlabs-postgresql.git
-      ref: v6.0.0
+      ref: v6.4.0
     archive:
       repo: git://github.com/voxpupuli/puppet-archive.git
       ref: 'v3.0.0'

--- a/README.md
+++ b/README.md
@@ -172,10 +172,7 @@ For systems using `yum` and Puppet >= 6.0.0:
 For Windows:
   * [puppetlabs/chocolatey](https://forge.puppet.com/puppetlabs/chocolatey) module (`>= 3.0.0 < 5.0.0`)
   * [puppet/windows_env](https://forge.puppet.com/puppet/windows_env) module (`>= 3.0.0 < 4.0.0`)
-  * [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.    0 < 5.0.0`)
-
-For PostgreSQL datastore support:
-* [puppetlabs/postgresql](https://forge.puppet.com/puppetlabs/postgresql) module (`>= 6.0.0 < 7.0.0`)
+  * [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.0 < 5.0.0`)
 
 ### Beginning with Sensu
 

--- a/manifests/backend/datastore/postgresql.pp
+++ b/manifests/backend/datastore/postgresql.pp
@@ -21,7 +21,7 @@ class sensu::backend::datastore::postgresql {
   if $sensu::backend::manage_postgresql_db and $sensu::backend::datastore_ensure == 'present' {
     postgresql::server::db { $dbname:
       user     => $user,
-      password => postgresql_password($user, $password),
+      password => postgresql::postgresql_password($user, $password),
       before   => Sensu_postgres_config[$sensu::backend::postgresql_name],
     }
   }

--- a/metadata.json
+++ b/metadata.json
@@ -15,6 +15,10 @@
     {
       "name": "richardc/datacat",
       "version_requirement": ">= 0.6.0 < 2.0.0"
+    },
+    {
+      "name": "puppetlabs/postgresql",
+      "version_requirement": ">= 6.4.0 < 7.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -8,7 +8,7 @@ describe 'sensu::cli class', if: Gem.win_platform? do
       api_host => 'localhost',
     }
     class { 'sensu::cli':
-      install_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.1/sensu-go_5.14.1_windows_amd64.zip',
+      install_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.1/sensu-go_5.20.1_windows_amd64.zip',
       # Not yet able to run backend in appveyor so configure will not work
       configure      => false,
     }
@@ -21,8 +21,11 @@ describe 'sensu::cli class', if: Gem.win_platform? do
         puts File.read('C:\manifest-cli.pp')
       end
 
-      describe command('puppet apply --debug C:\manifest-cli.pp') do
-        its(:exit_status) { is_expected.to eq 0 }
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-cli.pp ; Write-Output "EXITCODE=$LastExitCode"') do
+        its(:stdout) { is_expected.to match /EXITCODE=2/ }
+      end
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-cli.pp ; Write-Output "EXITCODE=$LastExitCode"') do
+        its(:stdout) { is_expected.to match /EXITCODE=0/ }
       end
 
       describe file('C:/Program Files/Sensu/sensuctl.exe') do
@@ -32,7 +35,7 @@ describe 'sensu::cli class', if: Gem.win_platform? do
         it 'has version fact' do
           output = `facter --json -p sensuctl`
           data = JSON.parse(output.strip)
-          expect(data['sensuctl']['version']).to match(/^[0-9\.]+$/)
+          expect(data['sensuctl']['version']).to match(/^[0-9\.]+/)
         end
       end
     end
@@ -62,8 +65,11 @@ describe 'sensu::agent class', if: Gem.win_platform? do
         puts File.read('C:\manifest-agent.pp')
       end
 
-      describe command('puppet apply --debug C:\manifest-agent.pp') do
-        its(:exit_status) { is_expected.to eq 0 }
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp ; Write-Output "EXITCODE=$LastExitCode"') do
+        its(:stdout) { is_expected.to match /EXITCODE=2/ }
+      end
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp ; Write-Output "EXITCODE=$LastExitCode"') do
+        its(:stdout) { is_expected.to match /EXITCODE=0/ }
       end
 
       describe file('C:\ProgramData\Sensu\config\agent.yml') do
@@ -87,7 +93,7 @@ describe 'sensu::agent class', if: Gem.win_platform? do
       it 'has version fact' do
         output = `facter --json -p sensu_agent`
         data = JSON.parse(output.strip)
-        expect(data['sensu_agent']['version']).to match(/^[0-9\.]+$/)
+        expect(data['sensu_agent']['version']).to match(/^[0-9\.]+/)
       end
     end
   end
@@ -97,7 +103,7 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     class { '::sensu': }
     class { 'sensu::agent':
       package_name   => 'Sensu Agent',
-      package_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.13.1/sensu-go-agent_5.13.1.5957_en-US.x64.msi',
+      package_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.1/sensu-go-agent_5.20.1.12427_en-US.x64.msi',
       backends       => ['sensu-backend:8081'],
       entity_name    => 'sensu-agent',
       config_hash    => {
@@ -117,8 +123,11 @@ describe 'sensu::agent class', if: Gem.win_platform? do
         its(:exit_status) { is_expected.to eq 0 }
       end
 
-      describe command('puppet apply --debug C:\manifest-agent.pp') do
-        its(:exit_status) { is_expected.to eq 0 }
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp ; Write-Output "EXITCODE=$LastExitCode"') do
+        its(:stdout) { is_expected.to match /EXITCODE=2/ }
+      end
+      describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp ; Write-Output "EXITCODE=$LastExitCode"') do
+        its(:stdout) { is_expected.to match /EXITCODE=0/ }
       end
     end
 
@@ -133,7 +142,7 @@ describe 'sensu::agent class', if: Gem.win_platform? do
       it 'has version fact' do
         output = `facter --json -p sensu_agent`
         data = JSON.parse(output.strip)
-        expect(data['sensu_agent']['version']).to match(/^[0-9\.]+$/)
+        expect(data['sensu_agent']['version']).to match(/^[0-9\.]+/)
       end
     end
   end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -65,9 +65,6 @@ RSpec.configure do |c|
     if collection == 'puppet6'
       on setup_nodes, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
     end
-    if ['full','examples'].include?(RSpec.configuration.sensu_mode)
-      on setup_nodes, puppet('module', 'install', 'puppetlabs-postgresql', '--version', '">= 6.0.0 < 7.0.0"'), { :acceptable_exit_codes => [0,1] }
-    end
     # Dependencies only needed to test some examples
     if RSpec.configuration.sensu_mode == 'examples'
       on setup_nodes, puppet('module', 'install', 'puppet-logrotate', '--version', '4.0.0')

--- a/tests/sensu-cli.pp
+++ b/tests/sensu-cli.pp
@@ -1,5 +1,5 @@
 if $facts['os']['family'] == 'windows' {
-  $install_source = 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.1/sensu-go_5.14.1_windows_amd64.zip'
+  $install_source = 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.20.1/sensu-go_5.20.1_windows_amd64.zip'
 } else {
   $install_source = undef
 }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use latest Sensu Go for testing which is what happens when chocolatey tests run. This should resolve failures with appveyor as I ran the tests locally in Vagrant and had no issues.  Also fix version test because now the version is more than just `5.20.0` it's like `5.20.0+ee` which we fixed for Travis tests but missed Windows.