### PR TITLE
Allow disabling namespace validation for large environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -975,6 +975,17 @@ class { 'sensu::backend':
 }
 ```
 
+If many thousands of resources such as `sensu_check` are defined there will be an execution of `sensuctl namespace list` for each check to validate
+the namespace exists. A similar validation is performed with `sensu_api` provider.  To avoid this extra overhead it may be necessary to disable this validation.
+
+**NOTE**: If namespace validation is disabled it's necessary to ensure a namespace is defined in Puppet in order to assign resources to that namespace.
+
+```puppet
+class { 'sensu':
+  validate_namespaces => false,
+}
+```
+
 ### Composite Names for Namespaces
 
 All resources that support having a `namespace` also support a composite name to define the namespace.

--- a/README.md
+++ b/README.md
@@ -976,7 +976,9 @@ class { 'sensu::backend':
 ```
 
 If many thousands of resources such as `sensu_check` are defined there will be an execution of `sensuctl namespace list` for each check to validate
-the namespace exists. A similar validation is performed with `sensu_api` provider.  To avoid this extra overhead it may be necessary to disable this validation.
+the namespace exists if the namespace is not defined in Puppet.
+A similar validation is performed with `sensu_api` provider.  To avoid this extra overhead it may be necessary to disable this validation if you
+are defining namespaces outside of Puppet.
 
 **NOTE**: If namespace validation is disabled it's necessary to ensure a namespace is defined in Puppet in order to assign resources to that namespace.
 

--- a/lib/puppet/provider/sensu_api.rb
+++ b/lib/puppet/provider/sensu_api.rb
@@ -11,6 +11,11 @@ class Puppet::Provider::SensuAPI < Puppet::Provider
     attr_accessor :password
     attr_accessor :access_token
     attr_accessor :refresh_token
+    attr_accessor :validate_namespaces
+  end
+
+  def validate_namespaces
+    self.class.validate_namespaces
   end
 
   def self.update_access_token

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -10,6 +10,11 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
   class << self
     attr_accessor :chunk_size
     attr_accessor :path
+    attr_accessor :validate_namespaces
+  end
+
+  def validate_namespaces
+    self.class.validate_namespaces
   end
 
   def self.config_path

--- a/lib/puppet/type/sensu_api_config.rb
+++ b/lib/puppet/type/sensu_api_config.rb
@@ -25,6 +25,12 @@ DESC
     desc "Sensu API password"
   end
 
+  newparam(:validate_namespaces, :boolean => true) do
+    desc "Determines of namespaces should be validated with Sensu API"
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
+
   # First collect all types with sensu_api provider that come from this module
   # For each sensu_api type, set the class variable 'chunk_size' used by
   # each provider to list resources
@@ -40,6 +46,7 @@ DESC
       provider_class.url = self[:url]
       provider_class.username = self[:username]
       provider_class.password = self[:password]
+      provider_class.validate_namespaces = self[:validate_namespaces]
     end
     []
   end

--- a/lib/puppet/type/sensuctl_config.rb
+++ b/lib/puppet/type/sensuctl_config.rb
@@ -17,6 +17,12 @@ DESC
     desc "sensuctl chunk-size"
   end
 
+  newparam(:validate_namespaces, :boolean => true) do
+    desc "Determines of namespaces should be validated with sensuctl"
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
+
   newparam(:path) do
     desc "path to sensuctl"
   end
@@ -34,6 +40,7 @@ DESC
     sensuctl_types.each do |type|
       provider_class = Puppet::Type.type(type).provider(:sensuctl)
       provider_class.chunk_size = self[:chunk_size]
+      provider_class.validate_namespaces = self[:validate_namespaces]
       provider_class.path = self[:path]
     end
     []

--- a/lib/puppet_x/sensu/type.rb
+++ b/lib/puppet_x/sensu/type.rb
@@ -50,12 +50,17 @@ module PuppetX
           end
           @catalog_namespaces = catalog_namespaces
         end
+        # Check if namespace is in catalog
+        if (resource[:ensure] && resource[:ensure].to_sym != :absent) && catalog_namespaces.include?(resource[:namespace])
+          return true
+        end
         if ! resource.provider.validate_namespaces.nil? && resource.provider.validate_namespaces.to_s.to_sym == :false
           namespaces = catalog_namespaces
         else
           namespaces = resource.provider.namespaces()
         end
-        if (resource[:ensure] && resource[:ensure].to_sym != :absent) && !( catalog_namespaces.include?(resource[:namespace]) || namespaces.include?(resource[:namespace]) )
+        # Check if namespace exists on system (not defined in catalog)
+        if (resource[:ensure] && resource[:ensure].to_sym != :absent) && ! namespaces.include?(resource[:namespace])
           raise Puppet::Error, "Sensu namespace '#{resource[:namespace]}' must be defined or exist"
         end
       end

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -9,9 +9,10 @@ class sensu::api {
   include sensu
 
   sensu_api_config { 'sensu':
-    url      => $sensu::api_url,
-    username => 'admin',
-    password => $sensu::password,
+    url                 => $sensu::api_url,
+    username            => 'admin',
+    password            => $sensu::password,
+    validate_namespaces => $sensu::validate_namespaces,
   }
 
   sensu_api_validator { 'sensu':

--- a/manifests/cli.pp
+++ b/manifests/cli.pp
@@ -82,8 +82,9 @@ class sensu::cli (
 
   if $configure {
     sensuctl_config { 'sensu':
-      chunk_size => $sensuctl_chunk_size,
-      path       => $sensuctl_path,
+      chunk_size          => $sensuctl_chunk_size,
+      path                => $sensuctl_path,
+      validate_namespaces => $sensu::validate_namespaces,
     }
 
     sensuctl_configure { 'puppet':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,8 @@
 #   The sensu agent password
 # @param agent_old_password
 #   DEPRECATED - The sensu agent old password needed when changing agent_password
+# @param validate_namespaces
+#   Determines if sensuctl and sensu_api types will validate their namespace exists
 class sensu (
   String $version = 'installed',
   Stdlib::Absolutepath $etc_dir = '/etc/sensu',
@@ -79,6 +81,7 @@ class sensu (
   Optional[String] $old_password = undef,
   String $agent_password = 'P@ssw0rd!',
   Optional[String] $agent_old_password = undef,
+  Boolean $validate_namespaces = true,
 ) {
 
   if $old_password {

--- a/spec/classes/api_spec.rb
+++ b/spec/classes/api_spec.rb
@@ -19,9 +19,10 @@ describe 'sensu::api', :type => :class do
 
         it {
           should contain_sensu_api_config('sensu').with({
-            'url'      => 'https://test.example.com:8080',
-            'username' => 'admin',
-            'password' => 'P@ssw0rd!',
+            'url'                 => 'https://test.example.com:8080',
+            'username'            => 'admin',
+            'password'            => 'P@ssw0rd!',
+            'validate_namespaces' => 'true',
           })
         }
 

--- a/spec/classes/cli_spec.rb
+++ b/spec/classes/cli_spec.rb
@@ -66,6 +66,7 @@ describe 'sensu::cli', :type => :class do
         end
 
         it { should contain_sensuctl_config('sensu').without_chunk_size }
+        it { should contain_sensuctl_config('sensu').with_validate_namespaces('true') }
 
         it {
           should contain_sensuctl_configure('puppet').with({
@@ -97,6 +98,13 @@ describe 'sensu::cli', :type => :class do
         else
           it { should compile.with_all_deps }
         end
+      end
+
+      context 'with validate_namespaces => false' do
+        let(:pre_condition) do
+          "class { 'sensu': validate_namespaces => false }"
+        end
+        it { should contain_sensuctl_config('sensu').with_validate_namespaces('false') }
       end
 
       context 'with use_ssl => false' do

--- a/spec/shared_examples/namespace.rb
+++ b/spec/shared_examples/namespace.rb
@@ -2,8 +2,8 @@ require 'spec_helper'
 
 RSpec.shared_examples 'namespace' do
   it 'should not fail if namespace defined' do
-    config[:namespace] = 'devs'
-    namespace = Puppet::Type.type(:sensu_namespace).new(:name => 'devs')
+    config[:namespace] = 'default'
+    namespace = Puppet::Type.type(:sensu_namespace).new(:name => 'default')
     catalog = Puppet::Resource::Catalog.new
     catalog.add_resource res
     catalog.add_resource namespace
@@ -11,6 +11,7 @@ RSpec.shared_examples 'namespace' do
   end
 
   it 'should not fail if namespace exists' do
+    allow(res.provider).to receive(:validate_namespaces).and_return(true)
     allow(res.provider).to receive(:namespaces).and_return(['devs','default'])
     config[:namespace] = 'devs'
     catalog = Puppet::Resource::Catalog.new


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds `validate_namespaces` parameter to `sensu` class that is passed to `sensuctl_config` and `sensu_api_config` that can disable namespace validation. The namespace will need to exist in the catalog to pass validations.  There is also a change to catalog namespace checking to only iterate over the catalog once and cache the catalog namespaces to ensure namespaces are defined in catalog.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1253 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In large environments with thousands of resources for Sensu there would be thousands of `sensuctl namespace list` executions and this slows down catalog applications.