### PR TITLE
Do not expose PostgreSQL DSN

### DIFF
--- a/lib/puppet/type/sensu_postgres_config.rb
+++ b/lib/puppet/type/sensu_postgres_config.rb
@@ -33,6 +33,16 @@ DESC
 
   newproperty(:dsn) do
     desc "Use the dsn attribute to specify the data source names as a URL or PostgreSQL connection string"
+
+    def change_to_s(currentvalue, newvalue)
+      return "changed dsn"
+    end
+    def is_to_s(currentvalue)
+      return '[old dsn redacted]'
+    end
+    def should_to_s(newvalue)
+      return '[new dsn redacted]'
+    end
   end
 
   newproperty(:pool_size, :parent => PuppetX::Sensu::IntegerProperty) do

--- a/spec/acceptance/sensu_oidc_auth_spec.rb
+++ b/spec/acceptance/sensu_oidc_auth_spec.rb
@@ -10,7 +10,7 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
         ensure            => 'present',
         additional_scopes => ['email','groups'],
         client_id         => '0oa13ry4ypeDDBpxF357',
-        client_secret     => 'DlArQRfND4BKBUyO0mE-TL2PWOVwyGjIO1fdk9gX',
+        client_secret     => 'supersecret',
         groups_claim      => 'groups',
         groups_prefix     => 'oidc:',
         redirect_uri      => 'https://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback',
@@ -22,7 +22,7 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
         ensure            => 'present',
         additional_scopes => ['email','groups'],
         client_id         => '0oa13ry4ypeDDBpxF357',
-        client_secret     => 'DlArQRfND4BKBUyO0mE-TL2PWOVwyGjIO1fdk9gX',
+        client_secret     => 'supersecret',
         groups_claim      => 'groups',
         groups_prefix     => 'oidc:',
         redirect_uri      => 'https://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback',
@@ -50,7 +50,7 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
       on node, 'sensuctl auth info oidc --format json' do
         data = JSON.parse(stdout)
         expect(data['client_id']).to eq('0oa13ry4ypeDDBpxF357')
-        expect(data['client_secret']).to eq('DlArQRfND4BKBUyO0mE-TL2PWOVwyGjIO1fdk9gX')
+        expect(data['client_secret']).to eq('supersecret')
         expect(data['server']).to eq('https://idp.example.com')
         expect(data['groups_claim']).to eq('groups')
         expect(data['groups_prefix']).to eq('oidc:')
@@ -65,7 +65,7 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
       on node, 'sensuctl auth info oidc-api --format json' do
         data = JSON.parse(stdout)
         expect(data['client_id']).to eq('0oa13ry4ypeDDBpxF357')
-        expect(data['client_secret']).to eq('DlArQRfND4BKBUyO0mE-TL2PWOVwyGjIO1fdk9gX')
+        expect(data['client_secret']).to eq('supersecret')
         expect(data['server']).to eq('https://idp.example.com')
         expect(data['groups_claim']).to eq('groups')
         expect(data['groups_prefix']).to eq('oidc:')
@@ -85,7 +85,7 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
         ensure            => 'present',
         additional_scopes => ['email','groups','openid'],
         client_id         => '0oa13ry4ypeDDBpxF357',
-        client_secret     => 'secret',
+        client_secret     => 'foobar',
         groups_claim      => 'roles',
         groups_prefix     => 'oidc:',
         redirect_uri      => 'https://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback',
@@ -97,7 +97,7 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
         ensure            => 'present',
         additional_scopes => ['email','groups','openid'],
         client_id         => '0oa13ry4ypeDDBpxF357',
-        client_secret     => 'secret',
+        client_secret     => 'foobar',
         groups_claim      => 'roles',
         groups_prefix     => 'oidc:',
         redirect_uri      => 'https://sensu-backend.example.com:8080/api/enterprise/authentication/v2/oidc/callback',
@@ -112,20 +112,24 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
         site_pp = "node 'sensu-backend' { #{pp} }"
         puppetserver = hosts_as('puppetserver')[0]
         create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
-        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        result = on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
         on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
       else
         # Run it twice and test for idempotency
-        apply_manifest_on(node, pp, :catch_failures => true)
+        result = apply_manifest_on(node, pp, :catch_failures => true)
         apply_manifest_on(node, pp, :catch_changes  => true)
       end
+      expect(result.stdout).not_to include('supersecret')
+      expect(result.stderr).not_to include('supersecret')
+      expect(result.stdout).not_to include('foobar')
+      expect(result.stderr).not_to include('foobar')
     end
 
     it 'should have a valid OIDC auth' do
       on node, 'sensuctl auth info oidc --format json' do
         data = JSON.parse(stdout)
         expect(data['client_id']).to eq('0oa13ry4ypeDDBpxF357')
-        expect(data['client_secret']).to eq('secret')
+        expect(data['client_secret']).to eq('foobar')
         expect(data['server']).to eq('https://idp.example.com')
         expect(data['groups_claim']).to eq('roles')
         expect(data['groups_prefix']).to eq('oidc:')
@@ -140,7 +144,7 @@ describe 'sensu_oidc_auth', if: RSpec.configuration.sensu_mode == 'types' do
       on node, 'sensuctl auth info oidc-api --format json' do
         data = JSON.parse(stdout)
         expect(data['client_id']).to eq('0oa13ry4ypeDDBpxF357')
-        expect(data['client_secret']).to eq('secret')
+        expect(data['client_secret']).to eq('foobar')
         expect(data['server']).to eq('https://idp.example.com')
         expect(data['groups_claim']).to eq('roles')
         expect(data['groups_prefix']).to eq('oidc:')

--- a/spec/acceptance/sensu_secrets_spec.rb
+++ b/spec/acceptance/sensu_secrets_spec.rb
@@ -165,13 +165,15 @@ describe 'sensu_secrets_vault_provider', if: RSpec.configuration.sensu_mode == '
         site_pp = "node 'sensu-backend' { #{pp} }"
         puppetserver = hosts_as('puppetserver')[0]
         create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
-        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        result = on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
         on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
       else
         # Run it twice and test for idempotency
-        apply_manifest_on(node, pp, :catch_failures => true)
+        result = apply_manifest_on(node, pp, :catch_failures => true)
         apply_manifest_on(node, pp, :catch_changes  => true)
       end
+      expect(result.stdout).not_to include('VAULT_TOKEN')
+      expect(result.stderr).not_to include('VAULT_TOKEN')
     end
 
     it 'should have a valid VaultProvider' do

--- a/spec/acceptance/sensu_user_spec.rb
+++ b/spec/acceptance/sensu_user_spec.rb
@@ -7,15 +7,15 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
       pp = <<-EOS
       include sensu::backend
       sensu_user { 'test':
-        password => 'password',
+        password => 'supersecret',
         groups   => ['read-only'],
       }
       sensu_user { 'test2':
-        password => 'password',
+        password => 'supersecret',
         groups   => ['read-only'],
       }
       sensu_user { 'test-api':
-        password => 'password',
+        password => 'supersecret',
         groups   => ['read-only'],
         provider => 'sensu_api',
       }
@@ -44,7 +44,7 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
     end
 
     it 'should have valid password' do
-      exit_code = on(node, 'sensuctl user test-creds test --password password').exit_code
+      exit_code = on(node, 'sensuctl user test-creds test --password supersecret').exit_code
       expect(exit_code).to eq(0)
     end
 
@@ -58,7 +58,7 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
     end
 
     it 'should have valid password using API' do
-      exit_code = on(node, 'sensuctl user test-creds test-api --password password').exit_code
+      exit_code = on(node, 'sensuctl user test-creds test-api --password supersecret').exit_code
       expect(exit_code).to eq(0)
     end
   end
@@ -68,16 +68,16 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
       pp = <<-EOS
       include sensu::backend
       sensu_user { 'test':
-        password => 'password2',
+        password => 'supersecret2',
         groups   => ['read-only'],
       }
       sensu_user { 'test2':
-        password => 'password',
+        password => 'supersecret',
         groups   => ['read-only','admin'],
         disabled => true,
       }
       sensu_user { 'test-api':
-        password => 'password2',
+        password => 'supersecret2',
         groups   => ['read-only','admin'],
         provider => 'sensu_api',
       }
@@ -87,13 +87,15 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
         site_pp = "node 'sensu-backend' { #{pp} }"
         puppetserver = hosts_as('puppetserver')[0]
         create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
-        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        result = on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
         on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
       else
         # Run it twice and test for idempotency
-        apply_manifest_on(node, pp, :catch_failures => true)
+        result = apply_manifest_on(node, pp, :catch_failures => true)
         apply_manifest_on(node, pp, :catch_changes  => true)
       end
+      expect(result.stdout).not_to include('supersecret')
+      expect(result.stderr).not_to include('supersecret')
     end
 
     it 'should have an updated user' do
@@ -105,7 +107,7 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
       end
     end
     it 'should have valid password' do
-      exit_code = on(node, 'sensuctl user test-creds test --password password2').exit_code
+      exit_code = on(node, 'sensuctl user test-creds test --password supersecret2').exit_code
       expect(exit_code).to eq(0)
     end
 
@@ -118,7 +120,7 @@ describe 'sensu_user', if: RSpec.configuration.sensu_mode == 'types' do
       end
     end
     it 'should have valid password using API' do
-      exit_code = on(node, 'sensuctl user test-creds test-api --password password2').exit_code
+      exit_code = on(node, 'sensuctl user test-creds test-api --password supersecret2').exit_code
       expect(exit_code).to eq(0)
     end
   end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Ensure the `sensu_postgres_config` DSN does not get exposed in logs or Puppet reports as it will contain a password.