### PR TITLE
Improved PostgreSQL SSL support

### DIFF
--- a/examples/postgresql-replication/postgresql.pp
+++ b/examples/postgresql-replication/postgresql.pp
@@ -24,7 +24,7 @@ class { 'postgresql::server':
 
 postgresql::server::db { 'sensu':
   user     => 'sensu',
-  password => postgresql_password('sensu', $password),
+  password => postgresql::postgresql_password('sensu', $password),
 }
 
 postgresql::server::pg_hba_rule { 'allow access to sensu database':

--- a/examples/postgresql-replication/sensu-backend.pp
+++ b/examples/postgresql-replication/sensu-backend.pp
@@ -6,54 +6,12 @@ class { 'sensu::agent':
   backends => ['sensu-backend:8081'],
 }
 class { 'sensu::backend':
-  datastore            => 'postgresql',
-  manage_postgresql_db => false,
-  postgresql_host      => $master_ip,
-  postgresql_password  => $password,
-}
-
-# Use Puppet certs when connecting to Sensu DB's Postgresql service
-file { '/var/lib/sensu/.postgresql':
-  ensure  => 'directory',
-  owner   => 'sensu',
-  group   => 'sensu',
-  mode    => '0755',
-  require => Package['sensu-go-backend'],
-  notify  => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/root.crl':
-  ensure => 'file',
-  source => '/etc/puppetlabs/puppet/ssl/crl.pem',
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0644',
-  notify => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/root.crt':
-  ensure => 'file',
-  source => $sensu::ssl_ca_source,
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0644',
-  notify => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/postgresql.crt':
-  ensure => 'file',
-  source => $sensu::backend::ssl_cert_source,
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0644',
-  notify => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/postgresql.key':
-  ensure => 'file',
-  source => $sensu::backend::ssl_key_source,
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0600',
-  notify => Service['sensu-backend'],
+  datastore                  => 'postgresql',
+  manage_postgresql_db       => false,
+  postgresql_host            => $master_ip,
+  postgresql_password        => $password,
+  postgresql_ssl_ca_source   => $sensu::ssl_ca_source,
+  postgresql_ssl_crl_source  => $facts['puppet_hostcrl'],
+  postgresql_ssl_cert_source => $facts['puppet_hostcert'],
+  postgresql_ssl_key_source  => $facts['puppet_hostprivkey'],
 }

--- a/examples/postgresql-ssl/postgresql.pp
+++ b/examples/postgresql-ssl/postgresql.pp
@@ -24,7 +24,7 @@ file { 'postgresql_ssl_key_file':
 
 postgresql::server::db { 'sensu':
   user     => 'sensu',
-  password => postgresql_password('sensu', $password),
+  password => postgresql::postgresql_password('sensu', $password),
 }
 
 postgresql::server::pg_hba_rule { 'allow access to sensu database':

--- a/examples/postgresql-ssl/sensu-backend.pp
+++ b/examples/postgresql-ssl/sensu-backend.pp
@@ -5,54 +5,12 @@ class { 'sensu::agent':
   backends => ['sensu-backend:8081'],
 }
 class { 'sensu::backend':
-  datastore            => 'postgresql',
-  manage_postgresql_db => false,
-  postgresql_host      => 'sensu-agent',
-  postgresql_password  => $password,
-}
-
-# Use Puppet certs when connecting to Sensu DB's Postgresql service
-file { '/var/lib/sensu/.postgresql':
-  ensure  => 'directory',
-  owner   => 'sensu',
-  group   => 'sensu',
-  mode    => '0755',
-  require => Package['sensu-go-backend'],
-  notify  => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/root.crl':
-  ensure => 'file',
-  source => '/etc/puppetlabs/puppet/ssl/crl.pem',
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0644',
-  notify => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/root.crt':
-  ensure => 'file',
-  source => $sensu::ssl_ca_source,
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0644',
-  notify => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/postgresql.crt':
-  ensure => 'file',
-  source => $sensu::backend::ssl_cert_source,
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0644',
-  notify => Service['sensu-backend'],
-}
-
-file { '/var/lib/sensu/.postgresql/postgresql.key':
-  ensure => 'file',
-  source => $sensu::backend::ssl_key_source,
-  owner  => 'sensu',
-  group  => 'sensu',
-  mode   => '0600',
-  notify => Service['sensu-backend'],
+  datastore                  => 'postgresql',
+  manage_postgresql_db       => false,
+  postgresql_host            => 'sensu-agent',
+  postgresql_password        => $password,
+  postgresql_ssl_ca_source   => $sensu::ssl_ca_source,
+  postgresql_ssl_crl_source  => $facts['puppet_hostcrl'],
+  postgresql_ssl_cert_source => $facts['puppet_hostcert'],
+  postgresql_ssl_key_source  => $facts['puppet_hostprivkey'],
 }

--- a/lib/facter/sensu_puppet_facts.rb
+++ b/lib/facter/sensu_puppet_facts.rb
@@ -20,6 +20,12 @@ module SensuPuppetFacts
         ::Puppet[:localcacert].to_s
       end
     end
+
+    Facter.add(:puppet_hostcrl) do
+      setcode do
+        ::Puppet[:hostcrl].to_s
+      end
+    end
   end
 
   def self.init_settings

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -79,6 +79,34 @@
 #   The PostgreSQL port
 # @param postgresql_dbname
 #   The name of the PostgreSQL database
+# @param postgresql_sslmode
+#   The PostgreSQL sslmode value
+# @param postgresql_ssl_dir
+#   The path to store SSL related files for PostgreSQL connections
+# @param postgresql_ssl_ca_source
+#   The source of PostgreSQL SSL CA
+#   Do not define with postgresql_ssl_ca_content
+# @param postgresql_ssl_ca_content
+#   The content of PostgreSQL SSL CA
+#   Do not define with postgresql_ssl_ca_source
+# @param postgresql_ssl_crl_source
+#   The source of PostgreSQL SSL CRL
+#   Do not define with postgresql_ssl_crl_content
+# @param postgresql_ssl_crl_content
+#   The content of PostgreSQL SSL CRL
+#   Do not define with postgresql_ssl_crl_source
+# @param postgresql_ssl_cert_source
+#   The source of PostgreSQL SSL certificate
+#   Do not define with postgresql_ssl_cert_content
+# @param postgresql_ssl_cert_content
+#   The content of PostgreSQL SSL certificate
+#   Do not define with postgresql_ssl_cert_source
+# @param postgresql_ssl_key_source
+#   The source of PostgreSQL SSL private key
+#   Do not define with postgresql_ssl_key_content
+# @param postgresql_ssl_key_content
+#   The content of PostgreSQL SSL private key
+#   Do not define with postgresql_ssl_key_source
 # @param postgresql_pool_size
 #   The PostgreSQL pool size
 #
@@ -113,6 +141,16 @@ class sensu::backend (
   Stdlib::Host $postgresql_host = 'localhost',
   Stdlib::Port $postgresql_port = 5432,
   String $postgresql_dbname = 'sensu',
+  Enum['disable','require','verify-ca','verify-full'] $postgresql_sslmode = 'require',
+  Stdlib::Absolutepath $postgresql_ssl_dir = '/var/lib/sensu/.postgresql',
+  Optional[String] $postgresql_ssl_ca_source = undef,
+  Optional[String] $postgresql_ssl_ca_content = undef,
+  Optional[String] $postgresql_ssl_crl_source = undef,
+  Optional[String] $postgresql_ssl_crl_content = undef,
+  Optional[String] $postgresql_ssl_cert_source = undef,
+  Optional[String] $postgresql_ssl_cert_content = undef,
+  Optional[String] $postgresql_ssl_key_source = undef,
+  Optional[String] $postgresql_ssl_key_content = undef,
   Integer $postgresql_pool_size = 20,
 ) {
 

--- a/manifests/backend/datastore/postgresql.pp
+++ b/manifests/backend/datastore/postgresql.pp
@@ -10,7 +10,8 @@ class sensu::backend::datastore::postgresql {
   $host = $sensu::backend::postgresql_host
   $port = $sensu::backend::postgresql_port
   $dbname = $sensu::backend::postgresql_dbname
-  $dsn = "postgresql://${user}:${password}@${host}:${port}/${dbname}"
+  $sslmode = $sensu::backend::postgresql_sslmode
+  $dsn = "postgresql://${user}:${password}@${host}:${port}/${dbname}?sslmode=${sslmode}"
 
   sensu_postgres_config { $sensu::backend::postgresql_name:
     ensure    => $sensu::backend::datastore_ensure,
@@ -23,6 +24,74 @@ class sensu::backend::datastore::postgresql {
       user     => $user,
       password => postgresql::postgresql_password($user, $password),
       before   => Sensu_postgres_config[$sensu::backend::postgresql_name],
+    }
+  }
+
+  $ssl_dir = $sensu::backend::postgresql_ssl_dir
+  $ssl_ca_source = $sensu::backend::postgresql_ssl_ca_source
+  $ssl_ca_content = $sensu::backend::postgresql_ssl_ca_content
+  $ssl_crl_source = $sensu::backend::postgresql_ssl_crl_source
+  $ssl_crl_content = $sensu::backend::postgresql_ssl_crl_content
+  $ssl_cert_source = $sensu::backend::postgresql_ssl_cert_source
+  $ssl_cert_content = $sensu::backend::postgresql_ssl_cert_content
+  $ssl_key_source = $sensu::backend::postgresql_ssl_key_source
+  $ssl_key_content = $sensu::backend::postgresql_ssl_key_content
+
+  file { 'sensu-backend postgresql_ssl_dir':
+    ensure  => 'directory',
+    path    => $ssl_dir,
+    owner   => $sensu::sensu_user,
+    group   => $sensu::sensu_group,
+    mode    => '0755',
+    require => Package['sensu-go-backend'],
+    notify  => Service['sensu-backend'],
+  }
+  if $ssl_ca_source or $ssl_ca_content {
+    file { 'sensu-backend postgresql_ca':
+      ensure  => 'file',
+      path    => "${ssl_dir}/root.crt",
+      source  => $ssl_ca_source,
+      content => $ssl_ca_content,
+      owner   => $sensu::sensu_user,
+      group   => $sensu::sensu_group,
+      mode    => '0644',
+      notify  => Service['sensu-backend'],
+    }
+  }
+  if $ssl_crl_source or $ssl_crl_content {
+    file { 'sensu-backend postgresql_crl':
+      ensure  => 'file',
+      path    => "${ssl_dir}/root.crl",
+      source  => $ssl_crl_source,
+      content => $ssl_crl_content,
+      owner   => $sensu::sensu_user,
+      group   => $sensu::sensu_group,
+      mode    => '0644',
+      notify  => Service['sensu-backend'],
+    }
+  }
+  if $ssl_cert_source or $ssl_cert_content {
+    file { 'sensu-backend postgresql_cert':
+      ensure  => 'file',
+      path    => "${ssl_dir}/postgresql.crt",
+      source  => $ssl_cert_source,
+      content => $ssl_cert_content,
+      owner   => $sensu::sensu_user,
+      group   => $sensu::sensu_group,
+      mode    => '0644',
+      notify  => Service['sensu-backend'],
+    }
+  }
+  if $ssl_key_source or $ssl_key_content {
+    file { 'sensu-backend postgresql_key':
+      ensure  => 'file',
+      path    => "${ssl_dir}/postgresql.key",
+      source  => $ssl_key_source,
+      content => $ssl_key_content,
+      owner   => $sensu::sensu_user,
+      group   => $sensu::sensu_group,
+      mode    => '0600',
+      notify  => Service['sensu-backend'],
     }
   }
 }

--- a/spec/acceptance/06_postgresql_spec.rb
+++ b/spec/acceptance/06_postgresql_spec.rb
@@ -42,7 +42,7 @@ describe 'postgresql datastore', if: RSpec.configuration.sensu_mode == 'full' do
       # https://github.com/sensu/sensu-go/issues/3424
       on node, 'sensuctl dump store/v1.PostgresConfig --format yaml --all-namespaces' do
         data = YAML.load(stdout)
-        expect(data['spec']['dsn']).to eq('postgresql://sensu:changeme@localhost:5432/sensu')
+        expect(data['spec']['dsn']).to eq('postgresql://sensu:changeme@localhost:5432/sensu?sslmode=require')
         expect(data['spec']['pool_size']).to eq(20)
       end
     end

--- a/spec/unit/facter/sensu_puppet_facts_spec.rb
+++ b/spec/unit/facter/sensu_puppet_facts_spec.rb
@@ -29,4 +29,9 @@ describe SensuPuppetFacts do
     Puppet[:localcacert] = '/dne/ca.pem'
     expect(Facter.value(:puppet_localcacert)).to eq('/dne/ca.pem')
   end
+
+  it 'should have puppet_hostcrl defined' do
+    Puppet[:hostcrl] = '/dne/crl.pem'
+    expect(Facter.value(:puppet_hostcrl)).to eq('/dne/crl.pem')
+  end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds better support for PostgreSQL SSL with sensu-backend.

* Add parameter postgresql_sslmode
* Add parameter postgresql_ssl_dir
* Add parameter postgresql_ssl_ca_source and postgresql_ssl_ca_content
* Add parameter postgresql_ssl_crl_source and postgresql_ssl_crl_content
* Add parameter postgresql_ssl_cert_source and postgresql_ssl_cert_content
* Add parameter postgresql_ssl_key_source and postgresql_ssl_key_content


## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1258 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
By default sensu-backend has `sslmode=require` which means by default SSL needs to be configured. Because this Puppet module does not directly manage the Postgres server I am not providing defaults for CA, cert, key, etc because it's not safe to assume any defaults based on knowledge this module has.

I based values for `sslmode` on this log message when I initially tried to use Postgres default of `prefer`:

```
Aug 08 14:46:27 sensu-backend sensu-backend[9656]: {"component":"ent-store","error":"Could not get DB version: pq: unsupported sslmode \"pref
er\"; only \"require\" (default), \"verify-full\", \"verify-ca\", and \"disable\" supported","level":"error","msg":"error opening postgres st
ore, retrying...","time":"2020-08-08T14:46:27Z"}
```
