### PR TITLE
Installation of sensu-plugins-ruby fails on CentOS8

### DIFF
--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -39,6 +39,7 @@ class sensu::plugins (
   Optional[Boolean] $manage_repo = undef,
   String $package_ensure = 'installed',
   String $package_name = 'sensu-plugins-ruby',
+  String $package_url = "https://packagecloud.io/sensu/community/packages/el/7/sensu-plugins-ruby-0.2.0-1.el7.x86_64.rpm/download.rpm",
   Array $dependencies = [],
   Array $gem_dependencies = [],
   Variant[Array, Hash] $plugins = [],
@@ -61,10 +62,25 @@ class sensu::plugins (
     $package_require = undef
   }
 
-  package { 'sensu-plugins-ruby':
-    ensure  => $package_ensure,
-    name    => $package_name,
-    require => $package_require,
+  if "${facts['os']['family']}${facts['os']['release']['major']}" == "RedHat8" {
+    exec { 'fetch sensu-plugins-ruby rpm':
+      command => "/usr/bin/curl -L ${package_url} --output /opt/${package_name}.rpm",
+      creates => "/opt/${package_name}.rpm",
+      user    => 'root',
+    }
+    package { 'sensu-plugins-ruby':
+      ensure  => $package_ensure,
+      name    => $package_name,
+      require => Exec['fetch sensu-plugins-ruby rpm'],
+      source => "/opt/${package_name}.rpm",
+    }
+  }
+  else {
+    package { 'sensu-plugins-ruby':
+      ensure  => $package_ensure,
+      name    => $package_name,
+      require => $package_require,
+    }
   }
 
   ensure_packages($dependencies)


### PR DESCRIPTION
Installation of sensu-plugins-ruby fails on CentOS8 since it is not present in the installed repository. This 'fix' fetches and installs the el7-package from a given URL-source

This PR provides the option to install sensu-plugins-ruby on RedHat/CentOS8 from a given URL source. 

## Description

This PR only affects systems within the RedHat family on major version 8 where the gem "sensu-plugins-ruby" is fetched and installed "manually". 

## Motivation and Context

I did this fix in a module created in-house, but ran quickly into duplicate declaration issues since we use this module for both CentOS 7 and CentOS 8. Thought it would be best to add the fix here.

## How Has This Been Tested?
Tok a CentOS 8 system without the gem. Added the fix. Ran puppet -  success. Tried several runs, everything works as expected. Also tried removing the package and the run another puppet run with success.
