### PR TITLE
Improve sensu-backend init

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -343,13 +343,15 @@ class sensu::backend (
 
   exec { 'sensu-backend init':
     path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-    refreshonly => true,
     environment => [
       'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=admin',
       "SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=${sensu::password}",
     ],
     returns     => [0, 3],
-    subscribe   => Package['sensu-go-backend'],
+    # sensu-backend init will exit with code 3 if already run
+    # If exit code is 3, do not need to run sensu-backend init again
+    # If exit is not 3, run sensu-backend init
+    unless      => 'sensu-backend init ; [ $? -eq 3 ] && exit 0 || exit 1',
     require     => Sensu_api_validator['sensu'],
     before      => [
       Sensu_user['admin'],

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -227,13 +227,12 @@ describe 'sensu::backend', :type => :class do
         it {
           should contain_exec('sensu-backend init').with({
             'path'        => '/usr/bin:/bin:/usr/sbin:/sbin',
-            'refreshonly' => 'true',
             'environment' => [
               'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=admin',
               'SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=P@ssw0rd!',
             ],
             'returns'     => [0, 3],
-            'subscribe'   => 'Package[sensu-go-backend]',
+            'unless'      => 'sensu-backend init ; [ $? -eq 3 ] && exit 0 || exit 1',
             'require'     => 'Sensu_api_validator[sensu]',
             'before'      => [
               'Sensu_user[admin]',


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Rather than only running `sensu-backend init` on refresh of Package, run it if the exit code is not 3. 

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1261
