### PR TITLE
Add sensu::backend_upgrade task

### DIFF
--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,10 @@ sensu_bonsai_asset { 'sensu/sensu-pagerduty-handler':
 
 The following Bolt tasks are provided by this Module:
 
+**sensu::backend\_upgrade**: Perform backend upgrade via `sensu-backend upgrade` command.
+
+Example: `bolt task run sensu::backend_upgrade --targets sensu_backend`
+
 **sensu::agent\_event**: Create a Sensu Go agent event via the agent API
 
 Example: `bolt task run sensu::agent_event name=bolttest status=1 output=test --targets sensu_agent`

--- a/spec/fixtures/tasks/backend_upgrade/logs.out
+++ b/spec/fixtures/tasks/backend_upgrade/logs.out
@@ -1,0 +1,3 @@
+{"component":"store","level":"warning","msg":"migrating etcd database to a new version","time":"2020-07-11T15:07:50Z"}
+{"component":"store","database_version":1,"level":"info","msg":"successfully upgraded database","time":"2020-07-11T15:07:50Z"}
+{"component":"store","database_version":2,"level":"info","msg":"successfully upgraded database","time":"2020-07-11T15:07:50Z"}

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -13,6 +13,7 @@ RSpec.configure do |c|
   c.add_setting :sensu_mode, default: 'base'
   c.add_setting :sensu_enterprise_file, default: nil
   c.add_setting :sensu_test_enterprise, default: false
+  c.add_setting :add_ci_repo, default: false
   c.add_setting :sensu_manage_repo, default: true
   c.add_setting :sensu_use_agent, default: false
   c.add_setting :examples_dir, default: nil
@@ -37,10 +38,7 @@ RSpec.configure do |c|
   secrets = File.join(project_dir, 'tests/secrets')
   if File.exists?(secrets) && (ENV['BEAKER_sensu_ci_build'] == 'yes' || ENV['BEAKER_sensu_ci_build'] == 'true')
     c.sensu_manage_repo = false
-    add_ci_repo = true
-  else
-    c.sensu_manage_repo = true
-    add_ci_repo = false
+    c.add_ci_repo = true
   end
 
   c.examples_dir = File.join(project_dir, 'examples')
@@ -80,7 +78,7 @@ RSpec.configure do |c|
       on host, "puppet config set --section main certname #{host.name}"
     end
 
-    if add_ci_repo
+    if c.add_ci_repo
       scp_to(hosts, ci_build, '/tmp/ci_build.sh')
       scp_to(hosts, secrets, '/tmp/secrets')
       on hosts, '/tmp/ci_build.sh'

--- a/spec/tasks/backend_upgrade_spec.rb
+++ b/spec/tasks/backend_upgrade_spec.rb
@@ -1,0 +1,32 @@
+require 'spec_helper'
+require_relative '../../tasks/backend_upgrade.rb'
+
+describe SensuBackendUpgrade do
+  let(:output) { my_fixture_read('logs.out') }
+  let(:logs) do
+    [
+      {"component" => "store","level" => "warning","msg" => "migrating etcd database to a new version","time" => "2020-07-11T15:07:50Z"},
+      {"component" => "store","database_version" => 1,"level" => "info","msg" => "successfully upgraded database","time" => "2020-07-11T15:07:50Z"},
+      {"component" => "store","database_version" => 2,"level" => "info","msg" => "successfully upgraded database","time" => "2020-07-11T15:07:50Z"},
+    ]
+  end
+
+  it 'executes upgrade with no arguments' do
+    expect(Open3).to receive(:capture3).with('sensu-backend upgrade --skip-confirm').and_return(["", output, 0])
+    ret = described_class.upgrade({})
+    expect(ret).to eq(logs)
+  end
+
+  it 'handles arguments' do
+    expected_cmd = 'sensu-backend upgrade --skip-confirm --config-file /etc/foo.yml --timeout 10 --etcd-client-cert-auth --etcd-cipher-suites foo bar'
+    params = {
+      '_task': 'sensu::backend_upgrade',
+      'config_file': '/etc/foo.yml',
+      'timeout': 10,
+      'etcd_client_cert_auth': true,
+      'etcd_cipher_suites': ['foo','bar'],
+    }
+    expect(Open3).to receive(:capture3).with(expected_cmd).and_return(["", output, 0])
+    described_class.upgrade(params)
+  end
+end

--- a/tasks/backend_upgrade.json
+++ b/tasks/backend_upgrade.json
@@ -1,0 +1,46 @@
+{
+  "description": "Execute Sensu Go backend upgrade",
+  "input_method": "stdin",
+  "parameters": {
+    "config_file": {
+      "description": "Path to backend.yml",
+      "type": "Optional[String[1]]"
+    },
+    "timeout": {
+      "description": "Timeout for connecting to etcd",
+      "type": "Optional[Integer]"
+    },
+    "etcd_advertise_client_urls": {
+      "description": "list of this member's client URLs to advertise to clients",
+      "type": "Optional[Array]"
+    },
+    "etcd_cert_file": {
+      "description": "path to the client server TLS cert file",
+      "type": "Optional[String[1]]"
+    },
+    "etcd_cipher_suites": {
+      "description": "list of ciphers to use for etcd TLS configuration",
+      "type": "Optional[Array]"
+    },
+    "etcd_client_cert_auth": {
+      "description": "enable client cert authentication",
+      "type": "Optional[Boolean]"
+    },
+    "etcd_client_urls": {
+      "description": "client URLs to use when operating as an etcd client",
+      "type": "Optional[Array]"
+    },
+    "etcd_key_file": {
+      "description": "path to the client server TLS key file",
+      "type": "Optional[String[1]]"
+    },
+    "etcd_max_request_bytes": {
+      "description": "maximum etcd request size in bytes (use with caution)",
+      "type": "Optional[Integer]"
+    },
+    "etcd_trusted_ca_file": {
+      "description": "path to the client server TLS trusted CA cert file",
+      "type": "Optional[String[1]]"
+    }
+  }
+}

--- a/tasks/backend_upgrade.rb
+++ b/tasks/backend_upgrade.rb
@@ -1,0 +1,48 @@
+#!/opt/puppetlabs/puppet/bin/ruby
+require 'resolv'
+require 'json'
+require 'open3'
+
+class SensuBackendUpgrade
+  def self.upgrade(params)
+    cmd = ['sensu-backend', 'upgrade', '--skip-confirm']
+    valid_params = [
+      'config_file', 'timeout', 'etcd_advertise_client_urls', 'etcd_cert_file',
+      'etcd_cipher_suites', 'etcd_client_cert_auth', 'etcd_client_urls',
+      'etcd_key_file', 'etcd_max_request_bytes', 'etcd_trusted_ca_file',
+    ]
+    params.each_pair do |key, value|
+      next unless valid_params.include?(key.to_s)
+      cmd << "--#{key.to_s.gsub('_', '-')}"
+      if [TrueClass, FalseClass].include?(value.class)
+        next
+      elsif value.is_a?(Array)
+        cmd << value.join(' ')
+      else
+        cmd << value
+      end
+    end
+    stdout, stderr, status = Open3.capture3(cmd.join(' '))
+    if status != 0
+      raise Exception, "Failed to execute #{cmd.join(' ')}: #{stderr}"
+    end
+    logs = []
+    stderr.each_line do |line|
+      log = JSON.parse(line)
+      logs << log
+    end
+    logs
+  end
+
+  def self.run
+    params = JSON.parse(STDIN.read)
+    logs = upgrade(params)
+    puts({ logs: logs}.to_json)
+  rescue Exception => e
+    puts({ _error: e.message }.to_json)
+    exit 1
+  end
+end
+
+SensuBackendUpgrade.run if $PROGRAM_NAME == __FILE__
+


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the `sensu::backend_upgrade` bolt task that can run `sensu-backend upgrade` during Sensu Go 6 upgrade.

This was pulled out of #1255 