### PR TITLE
Make sensu_ad_auth group_search optional

### DIFF
--- a/lib/puppet/type/sensu_ad_auth.rb
+++ b/lib/puppet/type/sensu_ad_auth.rb
@@ -28,6 +28,25 @@ Puppet::Type.newtype(:sensu_ad_auth) do
     ],
   }
 
+@example Add an AD auth that uses memberOf attribute by omitting group_search
+  sensu_ldap_auth { 'ad':
+    ensure              => 'present',
+    servers             => [
+      {
+        'host' => '127.0.0.1',
+        'port' => 389,
+        'binding' => {
+          'user_dn' => 'cn=binder,dc=acme,dc=org',
+          'password' => 'P@ssw0rd!'
+        },
+        'user_search'  => {
+          'base_dn' => 'dc=acme,dc=org',
+        },
+      },
+    ],
+  }
+
+
 **Autorequires**:
 * `Package[sensu-go-cli]`
 * `Service[sensu-backend]`
@@ -57,7 +76,7 @@ DESC
     Keys:
     * host: required
     * port: required
-    * group_search: required
+    * group_search: required for Sensu 5, optional for Sensu 6 (omit to use memberOf with Sensu 6)
     * user_search: required
     * binding: optional Hash
     * insecure: default is `false`
@@ -88,7 +107,7 @@ DESC
       if ! server.is_a?(Hash)
         raise ArgumentError, "Each server must be a Hash not #{server.class}"
       end
-      required_keys = ['host','port','group_search','user_search']
+      required_keys = ['host','port','user_search']
       server_keys = server.keys.map { |k| k.to_s }
       required_keys.each do |k|
         if ! server_keys.include?(k)
@@ -115,16 +134,18 @@ DESC
           raise ArgumentError, "server binding must contain keys 'password' and 'user_dn'"
         end
       end
-      if ! server['group_search'].is_a?(Hash)
-        raise ArgumentError, "group_search must be a Hash not #{server['group_search'].class}"
-      end
-      if ! server['group_search'].key?('base_dn')
-        raise ArgumentError, "group_search requires base_dn"
-      end
-      group_search_valid_keys = ['base_dn','attribute','name_attribute','object_class']
-      server['group_search'].keys.each do |key|
-        if ! group_search_valid_keys.include?(key)
-          raise ArgumentError, "#{key} is not a valid key for group_search"
+      if server.key?('group_search')
+        if ! server['group_search'].is_a?(Hash)
+          raise ArgumentError, "group_search must be a Hash not #{server['group_search'].class}"
+        end
+        if ! server['group_search'].key?('base_dn')
+          raise ArgumentError, "group_search requires base_dn"
+        end
+        group_search_valid_keys = ['base_dn','attribute','name_attribute','object_class']
+        server['group_search'].keys.each do |key|
+          if ! group_search_valid_keys.include?(key)
+            raise ArgumentError, "#{key} is not a valid key for group_search"
+          end
         end
       end
       if ! server['user_search'].is_a?(Hash)
@@ -160,15 +181,24 @@ DESC
           server[k] = ''
         end
       end
-      group_search_defaults = {
-        'attribute' => 'member',
-        'name_attribute' => 'cn',
-        'object_class' => 'group',
-      }
-      group_search_defaults.each_pair do |k,v|
-        if ! server['group_search'].key?(k)
-          server['group_search'][k] = v
+      if server.key?('group_search')
+        group_search_defaults = {
+          'attribute' => 'member',
+          'name_attribute' => 'cn',
+          'object_class' => 'group',
+        }
+        group_search_defaults.each_pair do |k,v|
+          if ! server['group_search'].key?(k)
+            server['group_search'][k] = v
+          end
         end
+      else
+        server['group_search'] = {
+          'base_dn' => '',
+          'attribute' => '',
+          'name_attribute'  => '',
+          'object_class'    => '',
+        }
       end
       user_search_defaults = {
         'attribute' => 'sAMAccountName',

--- a/spec/acceptance/sensu_ad_auth_spec.rb
+++ b/spec/acceptance/sensu_ad_auth_spec.rb
@@ -16,9 +16,6 @@ describe 'sensu_ad_auth', if: RSpec.configuration.sensu_mode == 'types' do
               'user_dn' => 'cn=binder,dc=acme,dc=org',
               'password' => 'P@ssw0rd!'
             },
-            'group_search' => {
-              'base_dn' => 'dc=acme,dc=org',
-            },
             'user_search'  => {
               'base_dn' => 'dc=acme,dc=org',
             },
@@ -34,9 +31,6 @@ describe 'sensu_ad_auth', if: RSpec.configuration.sensu_mode == 'types' do
             'binding'      => {
               'user_dn' => 'cn=binder,dc=acme,dc=org',
               'password' => 'P@ssw0rd!'
-            },
-            'group_search' => {
-              'base_dn' => 'dc=acme,dc=org',
             },
             'user_search'  => {
               'base_dn' => 'dc=acme,dc=org',
@@ -71,7 +65,7 @@ describe 'sensu_ad_auth', if: RSpec.configuration.sensu_mode == 'types' do
         expect(data['servers'][0]['default_upn_domain']).to eq('')
         expect(data['servers'][0]['include_nested_groups']).to be_nil
         expect(data['servers'][0]['binding']).to eq({'user_dn' => 'cn=binder,dc=acme,dc=org', 'password' => 'P@ssw0rd!'})
-        expect(data['servers'][0]['group_search']).to eq({'base_dn' => 'dc=acme,dc=org','attribute' => 'member','name_attribute' => 'cn','object_class' => 'group'})
+        expect(data['servers'][0]['group_search']).to eq({'base_dn' => '','attribute' => '','name_attribute' => '','object_class' => ''})
         expect(data['servers'][0]['user_search']).to eq({'base_dn' => 'dc=acme,dc=org','attribute' => 'sAMAccountName','name_attribute' => 'displayName','object_class' => 'person'})
       end
     end
@@ -87,7 +81,7 @@ describe 'sensu_ad_auth', if: RSpec.configuration.sensu_mode == 'types' do
         expect(data['servers'][0]['default_upn_domain']).to eq('')
         expect(data['servers'][0]['include_nested_groups']).to be_nil
         expect(data['servers'][0]['binding']).to eq({'user_dn' => 'cn=binder,dc=acme,dc=org', 'password' => 'P@ssw0rd!'})
-        expect(data['servers'][0]['group_search']).to eq({'base_dn' => 'dc=acme,dc=org','attribute' => 'member','name_attribute' => 'cn','object_class' => 'group'})
+        expect(data['servers'][0]['group_search']).to eq({'base_dn' => '','attribute' => '','name_attribute' => '','object_class' => ''})
         expect(data['servers'][0]['user_search']).to eq({'base_dn' => 'dc=acme,dc=org','attribute' => 'sAMAccountName','name_attribute' => 'displayName','object_class' => 'person'})
       end
     end

--- a/spec/unit/sensu_ad_auth_spec.rb
+++ b/spec/unit/sensu_ad_auth_spec.rb
@@ -241,9 +241,9 @@ describe Puppet::Type.type(:sensu_ad_auth) do
       config[:servers][0]['group_search'] = {'base_dn' => 'foo', 'foo' => 'bar'}
       expect { auth }.to raise_error(Puppet::Error, /is not a valid key for group_search/)
     end
-    it 'should fail if group_search not defined' do
+    it 'should not fail if group_search not defined' do
       config[:servers][0].delete('group_search')
-      expect { auth }.to raise_error(Puppet::Error, /requires key group_search/)
+      expect { auth }.not_to raise_error
     end
     it 'should require a hash for user_search' do
       config[:servers][0]['user_search'] = 'foo'


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The `group_search` when configuring `sensu_ad_auth` is now optional.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Sensu Go 6 added a feature to support AD memberOf attribute for group lookups on users rather than searching groups.  To do this you must not define `group_search` when configuring AD auth.