### PR TITLE
Add support for Sensu Go Web

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -30,5 +30,15 @@ fixtures:
       repo: git://github.com/voxpupuli/puppet-archive.git
     windows_env:
       repo: git://github.com/voxpupuli/puppet-windows_env.git
+    git:
+      repo: git://github.com/rehanone/puppet-git.git
+    vcsrepo:
+      repo: git://github.com/puppetlabs/puppetlabs-vcsrepo.git
+    nodejs:
+      repo: git://github.com/voxpupuli/puppet-nodejs.git
+    yarn:
+      repo: git://github.com/initforthe/puppet-yarn.git
+    systemd:
+      repo: git://github.com/camptocamp/puppet-systemd.git
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -42,5 +42,20 @@ fixtures:
     windows_env:
       repo: git://github.com/voxpupuli/puppet-windows_env.git
       ref: 'v3.0.0'
+    git:
+      repo: git://github.com/rehanone/puppet-git.git
+      ref: '1.4.1'
+    vcsrepo:
+      repo: git://github.com/puppetlabs/puppetlabs-vcsrepo.git
+      ref: 'v3.1.1'
+    nodejs:
+      repo: git://github.com/voxpupuli/puppet-nodejs.git
+      ref: v8.0.0
+    yarn:
+      repo: git://github.com/initforthe/puppet-yarn.git
+      ref: v1.1.0
+    systemd:
+      repo: git://github.com/camptocamp/puppet-systemd.git
+      ref: '2.9.0'
   symlinks:
     sensu: "#{source_dir}"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
     * [Basic Sensu backend](#basic-sensu-backend)
     * [Basic Sensu agent](#basic-sensu-agent)
     * [Basic Sensu CLI](#basic-sensu-cli)
+    * [Sensu Go Web](#sensu-go-web)
     * [API Providers](#api-providers)
     * [Manage Windows Agent](#manage-windows-agent)
     * [Advanced agent](#advanced-agent)
@@ -174,6 +175,13 @@ For Windows:
   * [puppet/windows_env](https://forge.puppet.com/puppet/windows_env) module (`>= 3.0.0 < 4.0.0`)
   * [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.0 < 5.0.0`)
 
+For sensu::web class:
+  * [rehan/git](https://forge.puppet.com/rehan/git) module (`>= 1.4.1 <2.0.0`) **NOTE** Or any other git module with `git` class.
+  * [puppetlabs/vcsrepo](https://forge.puppet.com/puppetlabs/vcsrepo) module (`>= 3.1.1 <4.0.0`)
+  * [puppet/nodejs](https://forge.puppet.com/puppet/nodejs) module (`>= 8.0.0 <9.0.0`)
+  * [initforthe/yarn](https;//forge.puppet.com/initforthe/yarn) module (`>= 1.1.0 <2.0.0`)
+  * [camptocamp/systemd](https://forge.puppet.com/camptocamp/systemd) module (`>= 2.8.0 <3.0.0`)
+
 ### Beginning with Sensu
 
 This module provides Vagrant definitions that can be used to get started with Sensu.
@@ -269,6 +277,34 @@ class { '::sensu':
 }
 class { 'sensu::cli':
   install_source => 'https://s3-us-west-2.amazonaws.com/sensu.io/sensu-go/5.14.1/sensu-go_5.14.1_windows_amd64.zip',
+}
+```
+
+### Sensu Go Web
+
+Be sure all necessary soft dependencies are installed, see [Soft module dependencies](#soft-module-dependencies).
+
+To install Sensu Go Web include the necessary class and ensure the API host is defined.
+The example below uses defaults for both version and port.
+
+```puppet
+class { 'sensu':
+  use_ssl  => true,
+  api_host => 'backend.example.com',
+}
+class { 'sensu::web':
+  version => '1.0.1',
+  port    => '9080',
+}
+```
+
+If you wish to run a port below 1024 you must run sensu-web service as root:
+
+```
+class { 'sensu::web':
+  port          => 80,
+  service_user  => 'root',
+  service_group => 'root',
 }
 ```
 

--- a/manifests/common.pp
+++ b/manifests/common.pp
@@ -3,6 +3,7 @@
 #
 class sensu::common {
   include sensu
+  contain sensu::common::user
 
   if $sensu::etc_parent_dir {
     file { 'sensu_dir':
@@ -27,29 +28,6 @@ class sensu::common {
 
   if $sensu::use_ssl {
     contain sensu::ssl
-  }
-
-  if $sensu::manage_user and $sensu::sensu_user {
-    user { 'sensu':
-      ensure     => 'present',
-      name       => $sensu::sensu_user,
-      forcelocal => true,
-      shell      => '/bin/false',
-      gid        => $sensu::sensu_group,
-      uid        => undef,
-      home       => '/var/lib/sensu',
-      managehome => false,
-      system     => true,
-    }
-  }
-  if $sensu::manage_group and $sensu::sensu_group {
-    group { 'sensu':
-      ensure     => 'present',
-      name       => $sensu::sensu_group,
-      forcelocal => true,
-      gid        => undef,
-      system     => true,
-    }
   }
 
   if $sensu::manage_repo {

--- a/manifests/common/user.pp
+++ b/manifests/common/user.pp
@@ -1,0 +1,29 @@
+# @summary Sensu class for common user resources
+# @api private
+#
+class sensu::common::user {
+  include sensu
+
+  if $sensu::manage_user and $sensu::sensu_user {
+    user { 'sensu':
+      ensure     => 'present',
+      name       => $sensu::sensu_user,
+      forcelocal => true,
+      shell      => '/bin/false',
+      gid        => $sensu::sensu_group,
+      uid        => undef,
+      home       => '/var/lib/sensu',
+      managehome => false,
+      system     => true,
+    }
+  }
+  if $sensu::manage_group and $sensu::sensu_group {
+    group { 'sensu':
+      ensure     => 'present',
+      name       => $sensu::sensu_group,
+      forcelocal => true,
+      gid        => undef,
+      system     => true,
+    }
+  }
+}

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -42,6 +42,8 @@ class sensu::web (
   include nodejs
   include yarn
 
+  Package['nodejs'] -> Package['yarn']
+
   $user = $sensu::sensu_user
   $group = $sensu::sensu_group
   $_service_user = pick($service_user, $user)
@@ -81,6 +83,7 @@ class sensu::web (
     onlyif  => "test -f ${install_dir}/.install",
     timeout => 0,
     user    => $user,
+    require => Package['yarn'],
   }
 
   systemd::unit_file { 'sensu-web.service':

--- a/manifests/web.pp
+++ b/manifests/web.pp
@@ -1,0 +1,102 @@
+# @summary Manage Sensu Go Web
+#
+# Class to manage the Sensu Go Web.
+#
+# @example
+#   include sensu::web
+#
+# @param revision
+#   Git revision of Sensu Go Web to download with git
+#   This can be a git tag, branch of commit SHA
+# @param source
+#   Sensu Go Web git repo source URL
+# @param install_dir
+#   Path of where to install Sensu web
+# @param port
+#   Port to use for Sensu Web
+#   Default is 9080
+#   Changing the value below 1024 requires setting service_user=root and service_group=root
+# @param service_user
+#   The user to run sensu-web service as
+#   Defaults to value defined for sensu::user parameter
+# @param service_group
+#   The group to run sensu-web service as
+#   Defaults to value defined for sensu::group parameter
+#
+class sensu::web (
+  Optional[String] $revision = 'v1.0.1',
+  String $source = 'https://github.com/sensu/web.git',
+  Stdlib::Absolutepath $install_dir = '/opt/sensu-web',
+  Stdlib::Port $port = 9080,
+  Optional[String] $service_user = undef,
+  Optional[String] $service_group = undef,
+) {
+
+  if $facts['service_provider'] != 'systemd' {
+    fail('Class sensu::web is only supported on systems that support systemd')
+  }
+
+  include sensu
+  include sensu::common::user
+  include git
+  include nodejs
+  include yarn
+
+  $user = $sensu::sensu_user
+  $group = $sensu::sensu_group
+  $_service_user = pick($service_user, $user)
+  $_service_group = pick($service_group, $group)
+  $api_url = $sensu::api_url
+
+  file { 'sensu-web-dir':
+    ensure => 'directory',
+    path   => $install_dir,
+    owner  => $user,
+    group  => $group,
+    mode   => '0755',
+    before => Vcsrepo['sensu-web'],
+  }
+
+  vcsrepo { 'sensu-web':
+    ensure   => 'latest',
+    path     => $install_dir,
+    provider => 'git',
+    revision => $revision,
+    source   => $source,
+    user     => $user,
+    notify   => Exec['sensu-web-touch-install'],
+  }
+
+  exec { 'sensu-web-touch-install':
+    path        => '/usr/bin:/bin',
+    command     => "touch ${install_dir}/.install",
+    refreshonly => true,
+    user        => $user,
+    before      => Exec['sensu-web-install'],
+  }
+  exec { 'sensu-web-install':
+    path    => '/usr/bin:/bin:/usr/sbin:/sbin',
+    command => "yarn install && rm -f ${install_dir}/.install",
+    cwd     => $install_dir,
+    onlyif  => "test -f ${install_dir}/.install",
+    timeout => 0,
+    user    => $user,
+  }
+
+  systemd::unit_file { 'sensu-web.service':
+    content => template('sensu/sensu-web.service.erb'),
+    notify  => Service['sensu-web'],
+  }
+
+  if versioncmp($facts['puppetversion'],'6.1.0') < 0 {
+    # Puppet 5 does not execute 'systemctl daemon-reload' automatically (https://tickets.puppetlabs.com/browse/PUP-3483)
+    # and camptocamp/systemd only creates this relationship when managing the service
+    Class['systemd::systemctl::daemon_reload'] -> Service['sensu-web']
+  }
+
+  service { 'sensu-web':
+    ensure    => 'running',
+    enable    => true,
+    subscribe => Exec['sensu-web-install'],
+  }
+}

--- a/spec/acceptance/08_web_spec.rb
+++ b/spec/acceptance/08_web_spec.rb
@@ -3,6 +3,11 @@ require 'spec_helper_acceptance'
 describe 'sensu::web class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
   node = hosts_as('sensu-agent')[0]
   backend = hosts_as('sensu-backend')[0]
+  before do
+    if fact_on(node, 'service_provider') != 'systemd'
+      skip("sensu::web is only supported on systemd systems")
+    end
+  end
   context 'default' do
     it 'should work without errors' do
       pp = <<-EOS
@@ -42,12 +47,6 @@ describe 'sensu::web class', if: ['base','full'].include?(RSpec.configuration.se
     end
     describe port(9080), :node => node do
       it { should be_listening }
-    end
-
-    it 'should have working web interface' do
-      on node, 'curl -I http://127.0.0.1:9080' do
-        expect(stdout).to include('HTTP/1.1 200 OK')
-      end
     end
   end
 end

--- a/spec/acceptance/08_web_spec.rb
+++ b/spec/acceptance/08_web_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper_acceptance'
+
+describe 'sensu::web class', if: ['base','full'].include?(RSpec.configuration.sensu_mode) do
+  node = hosts_as('sensu-agent')[0]
+  backend = hosts_as('sensu-backend')[0]
+  context 'default' do
+    it 'should work without errors' do
+      pp = <<-EOS
+      class { '::sensu':
+        api_host => 'sensu-backend',
+        password => 'P@ssw0rd!',
+      }
+      class { 'sensu::web': }
+      EOS
+      backend_pp = <<-EOS
+      class { '::sensu':
+        password => 'P@ssw0rd!',
+      }
+      class { 'sensu::backend': }
+      EOS
+
+      if RSpec.configuration.sensu_use_agent
+        site_pp = <<-EOS
+          node 'sensu-agent' { #{pp} }
+          node 'sensu-backend' { #{backend_pp} }
+        EOS
+        puppetserver = hosts_as('puppetserver')[0]
+        create_remote_file(puppetserver, "/etc/puppetlabs/code/environments/production/manifests/site.pp", site_pp)
+        on backend, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0,2]
+        on node, puppet("agent -t --detailed-exitcodes"), acceptable_exit_codes: [0]
+      else
+        apply_manifest_on(backend, backend_pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_failures => true)
+        apply_manifest_on(node, pp, :catch_changes  => true)
+      end
+    end
+
+    describe service('sensu-web'), :node => node do
+      it { should be_enabled }
+      it { should be_running }
+    end
+    describe port(9080), :node => node do
+      it { should be_listening }
+    end
+
+    it 'should have working web interface' do
+      on node, 'curl -I http://127.0.0.1:9080' do
+        expect(stdout).to include('HTTP/1.1 200 OK')
+      end
+    end
+  end
+end

--- a/spec/acceptance/sensu_bolt_tasks_spec.rb
+++ b/spec/acceptance/sensu_bolt_tasks_spec.rb
@@ -324,13 +324,18 @@ end
 
 describe 'sensu backend_upgrade task', if: RSpec.configuration.sensu_mode == 'full' do
   backend = hosts_as('sensu-backend')[0]
+  if RSpec.configuration.add_ci_repo
+    version = '5.21.0-22325'
+  else
+    version = '5.21.0-14262'
+  end
   context 'setup' do
     it 'is successful' do
       on backend, 'yum remove -y sensu-go\*'
       on backend, 'rm -rf /var/lib/sensu/sensu-backend/etcd /root/.config'
       pp = <<-EOS
         class { 'sensu':
-          version => '5.21.0-14262',
+          version => '#{version}',
         }
         include sensu::backend
       EOS

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -35,13 +35,14 @@ describe 'sensu::agent', :type => :class do
         end
         it { should_not contain_archive('sensu-go-agent.msi') }
 
-        context 'on systemd host', if: (facts[:kernel] == 'Linux' && Puppet.version.to_s =~ %r{^5}) do
-          let(:facts) { facts.merge({:service_provider => 'systemd'}) }
+        if Gem::Version.new(facts[:puppetversion]) < Gem::Version.new('6.1.0') && facts['service_provider'] == 'systemd'
           it { should contain_package('sensu-go-agent').that_notifies('Exec[sensu systemctl daemon-reload]') }
           it { should contain_exec('sensu systemctl daemon-reload').that_comes_before('Service[sensu-agent]') }
+        else
+          it { should_not contain_package('sensu-go-agent').that_notifies('Exec[sensu systemctl daemon-reload]') }
+          it { should_not contain_exec('sensu systemctl daemon-reload').that_comes_before('Service[sensu-agent]') }
         end
-        it { should_not contain_package('sensu-go-agent').that_notifies('Exec[sensu systemctl daemon-reload]') }
-        it { should_not contain_exec('sensu systemctl daemon-reload').that_comes_before('Service[sensu-agent]') }
+
 
         it {
           should contain_package('sensu-go-agent').with({
@@ -51,9 +52,9 @@ describe 'sensu::agent', :type => :class do
             'provider' => platforms[facts[:osfamily]][:package_provider],
             'before'   => 'File[sensu_etc_dir]',
             'require'  => platforms[facts[:osfamily]][:package_require],
-            'notify'   => 'Service[sensu-agent]',
           })
         }
+        it { should contain_package('sensu-go-agent').that_notifies('Service[sensu-agent]') }
 
         it {
           should contain_datacat_collector('sensu_agent_config').with({

--- a/spec/classes/common_spec.rb
+++ b/spec/classes/common_spec.rb
@@ -18,6 +18,7 @@ describe 'sensu::common', :type => :class do
         else
           it { should contain_class('sensu::repo')}
         end
+        it { should contain_class('sensu::common::user') }
         it { should contain_class('sensu::ssl') }
 
         if facts[:osfamily] == 'windows'

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -1,0 +1,113 @@
+require 'spec_helper'
+
+describe 'sensu::web', :type => :class do
+  on_supported_os.each do |os, os_facts|
+    # Windows is not supported for web
+    if os_facts[:os]['family'] == 'windows'
+      next
+    end
+    context "on #{os}" do
+      let(:facts) { os_facts }
+      let(:node) { 'test.example.com' }
+      let(:params) { }
+
+      # Class only supported for systemd
+      if os_facts['service_provider'] != 'systemd'
+        it { is_expected.to compile.and_raise_error(/only supported on systems that support systemd/) }
+        next
+      end
+
+      context 'with default values for all parameters' do
+        it { should compile.with_all_deps }
+
+        it { should create_class('sensu::web') }
+        it { should contain_class('sensu') }
+        it { should contain_class('sensu::common::user')}
+        it { should contain_class('yarn') }
+
+        it do
+          is_expected.to contain_file('sensu-web-dir').with({
+            ensure: 'directory',
+            path: '/opt/sensu-web',
+            owner: 'sensu',
+            group: 'sensu',
+            mode: '0755',
+            before: 'Vcsrepo[sensu-web]',
+          })
+        end
+
+        it do
+          is_expected.to contain_vcsrepo('sensu-web').with({
+            ensure: 'latest',
+            path: '/opt/sensu-web',
+            provider: 'git',
+            revision: 'v1.0.1',
+            source: 'https://github.com/sensu/web.git',
+            user: 'sensu',
+            notify: 'Exec[sensu-web-touch-install]',
+          })
+        end
+
+        it do
+          is_expected.to contain_exec('sensu-web-touch-install').with({
+            path: '/usr/bin:/bin',
+            command: 'touch /opt/sensu-web/.install',
+            refreshonly: true,
+            user: 'sensu',
+            before: 'Exec[sensu-web-install]',
+          })
+        end
+
+        it do
+          is_expected.to contain_exec('sensu-web-install').with({
+            path: '/usr/bin:/bin:/usr/sbin:/sbin',
+            command: 'yarn install && rm -f /opt/sensu-web/.install',
+            cwd: '/opt/sensu-web',
+            onlyif: 'test -f /opt/sensu-web/.install',
+            timeout: '0',
+            user: 'sensu',
+          })
+        end
+
+        systemd_unit_content = <<-END.gsub(/^\s+\|/, '')
+        |[Unit]
+        |Description=Sensu Go Web
+        |After=network-online.target multi-user.target
+        |Wants=network-online.target
+        |
+        |[Service]
+        |Environment=NODE_ENV=production
+        |Environment=PORT=9080
+        |Environment=API_URL=https://test.example.com:8080
+        |WorkingDirectory=/opt/sensu-web
+        |User=sensu
+        |Group=sensu
+        |ExecStart=/usr/bin/yarn node scripts serve
+        |
+        |[Install]
+        |WantedBy=multi-user.target
+        END
+        it do
+          is_expected.to contain_systemd__unit_file('sensu-web.service').with(
+            content: systemd_unit_content,
+            notify: 'Service[sensu-web]',
+          )
+        end
+
+        if Gem::Version.new(os_facts[:puppetversion]) < Gem::Version.new('6.1.0')
+          it { is_expected.to contain_class('systemd::systemctl::daemon_reload').that_comes_before('Service[sensu-web]') }
+        end
+
+        it do
+          is_expected.to contain_service('sensu-web').with(
+            ensure: 'running',
+            enable: 'true',
+            subscribe: 'Exec[sensu-web-install]',
+          )
+        end
+      end # end defaults
+
+    end
+  end
+end
+

--- a/spec/classes/web_spec.rb
+++ b/spec/classes/web_spec.rb
@@ -23,7 +23,9 @@ describe 'sensu::web', :type => :class do
         it { should create_class('sensu::web') }
         it { should contain_class('sensu') }
         it { should contain_class('sensu::common::user')}
+        it { should contain_class('nodejs') }
         it { should contain_class('yarn') }
+        it { should contain_package('nodejs').that_comes_before('Package[yarn]') }
 
         it do
           is_expected.to contain_file('sensu-web-dir').with({
@@ -66,6 +68,7 @@ describe 'sensu::web', :type => :class do
             onlyif: 'test -f /opt/sensu-web/.install',
             timeout: '0',
             user: 'sensu',
+            require: 'Package[yarn]',
           })
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,6 +75,8 @@ add_custom_fact :service_provider, ->(os, facts) {
     else
       'systemd'
     end
+  when 'windows'
+    'windows'
   else
     'systemd'
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,8 @@ add_custom_fact :puppet_localcacert, ->(os, facts) {
   end
 }
 
+# Must add this fact from stdlib because
+# rspec-puppet-facts and facterdb only mock core Facter facts
 add_custom_fact :service_provider, ->(os, facts) {
   case facts[:osfamily]
   when 'RedHat'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,19 @@ add_custom_fact :puppet_localcacert, ->(os, facts) {
   end
 }
 
+add_custom_fact :service_provider, ->(os, facts) {
+  case facts[:osfamily]
+  when 'RedHat'
+    if facts[:os]['release']['major'].to_i < 7
+      'init'
+    else
+      'systemd'
+    end
+  else
+    'systemd'
+  end
+}
+
 # Gets an array of types that have sensuctl provider
 # This logic is similar to that used by sensuctl_config type
 # Used in sensuctl_config tests

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -60,13 +60,17 @@ RSpec.configure do |c|
     on setup_nodes, puppet('module', 'install', 'sensu-sensuclassic'), { :acceptable_exit_codes => [0,1] }
     # Install soft module dependencies
     on setup_nodes, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 8.0.0"'), { :acceptable_exit_codes => [0,1] }
+    on setup_nodes, puppet('module', 'install', 'puppetlabs-vcsrepo', '--version', '">= 3.1.1 <4.0.0"'), { :acceptable_exit_codes => [0,1] }
+    on setup_nodes, puppet('module', 'install', 'rehan-git', '--version', '">= 1.4.1 <2.0.0"'), { :acceptable_exit_codes => [0,1] }
+    on setup_nodes, puppet('module', 'install', 'puppet-nodejs', '--version', '">= 8.0.0 <9.0.0"'), { :acceptable_exit_codes => [0,1] }
+    on setup_nodes, puppet('module', 'install', 'initforthe-yarn', '--version', '">= 1.1.0 <2.0.0"'), { :acceptable_exit_codes => [0,1] }
+    on setup_nodes, puppet('module', 'install', 'camptocamp-systemd', '--version', '2.8.0'), { :acceptable_exit_codes => [0,1] }
     if collection == 'puppet6'
       on setup_nodes, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
     end
     # Dependencies only needed to test some examples
     if RSpec.configuration.sensu_mode == 'examples'
       on setup_nodes, puppet('module', 'install', 'puppet-logrotate', '--version', '4.0.0')
-      on setup_nodes, puppet('module', 'install', 'camptocamp-systemd', '--version', '2.8.0')
       on setup_nodes, puppet('module', 'install', 'saz-rsyslog', '--version', '5.0.0')
       # rsyslog template relies on rsyslog_version fact so pre-install rsyslog
       # to keep things idempotent within minimal docker containers

--- a/templates/sensu-web.service.erb
+++ b/templates/sensu-web.service.erb
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sensu Go Web
+After=network-online.target multi-user.target
+Wants=network-online.target
+
+[Service]
+Environment=NODE_ENV=production
+Environment=PORT=<%= @port %>
+Environment=API_URL=<%= @api_url %>
+WorkingDirectory=<%= @install_dir %>
+User=<%= @_service_user %>
+Group=<%= @_service_group %>
+ExecStart=/usr/bin/yarn node scripts serve
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds support for Sensu Go Web.

There is code in this project that requires being run from a git repo, as I tried downloading the tag tarball and running and that did not work.  Because there is no good way to download latest stable release, we must define a version, so updated docs to reflect this being a key parameter.  This is only supported for systemd hosts even though this could run on non-systemd.  The reason was simply the simplicity of deploying a systemd service and not having to maintain a complicated sysVinit script.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1263