### PR TITLE
Remove various deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 #### Table of Contents
 
 1. [Module Description](#module-description)
-    * [Deprecations](#deprecations)
     * [Updating this module from 4.x to 5.x](#updating-this-module-from-4x-to-5x)
     * [Updating this module from 3.x to 4.x](#updating-this-module-from-3x-to-4x)
 2. [Setup - The basics of getting started with Sensu](#setup)
@@ -73,38 +72,6 @@ Version 4 of this module supports Sensu Go >= 5.16.0 < 6.0.0.
 Version 5 of this module supports Sensu Go >= 6.0.0 < 7.0.0.
 
 Users wishing to use the previous Ruby based Sensu should use the [sensu/sensuclassic](https://forge.puppet.com/sensu/sensuclassic) module.
-
-### Deprecations
-
-#### sensu\_asset
-
-The `url`, `sha512`, `filters` and `headers` properties for `sensu_asset` are deprecated in favor of passing these values as part of `builds` property.
-Using these deprecated properties will still work but issue a warning when the Puppet catalog is applied.
-
-Before:
-
-```puppet
-sensu_asset { 'test':
-  ensure  => 'present',
-  url     => 'http://example.com/asset/example.tar',
-  sha512  => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
-  filters  => ["entity.system.os == 'linux'"],
-}
-```
-
-After:
-```puppet
-sensu_asset { 'test':
-  ensure => 'present',
-  builds => [
-    {
-      'url'     => 'http://example.com/asset/example.tar',
-      'sha512'  => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
-      'filters' => ["entity.system.os == 'linux'"],
-    },
-  ],
-}
-```
 
 ### Updating this module from 4.x to 5.x
 

--- a/lib/puppet/provider/sensu_user/sensuctl.rb
+++ b/lib/puppet/provider/sensu_user/sensuctl.rb
@@ -55,12 +55,6 @@ Puppet::Type.type(:sensu_user).provide(:sensuctl, :parent => Puppet::Provider::S
   def password_hash(password)
     begin
       hash = sensuctl(['user', 'hash-password', password])
-      # TODO: Remove once no longer need to support Sensu Go before 5.21
-      # Returns nil if output does not start with $, which means a hash was not provided
-      # If the hash-password command is not present, sensuctl will exit 0 and print help
-      if hash !~ /\$/
-        return nil
-      end
       return hash.strip
     rescue Exception => e
       Puppet.warning("Unable to generate password hash for user #{resource[:name]}: #{e.to_s}")

--- a/lib/puppet/type/sensu_ad_auth.rb
+++ b/lib/puppet/type/sensu_ad_auth.rb
@@ -76,7 +76,7 @@ DESC
     Keys:
     * host: required
     * port: required
-    * group_search: required for Sensu 5, optional for Sensu 6 (omit to use memberOf with Sensu 6)
+    * group_search: optional (omit to use memberOf)
     * user_search: required
     * binding: optional Hash
     * insecure: default is `false`

--- a/lib/puppet/type/sensu_asset.rb
+++ b/lib/puppet/type/sensu_asset.rb
@@ -94,19 +94,6 @@ DESC
     end
   end
 
-  newproperty(:url) do
-    desc "The URL location of the asset."
-  end
-
-  newproperty(:sha512) do
-    desc "The checksum of the asset"
-  end
-
-  newproperty(:filters, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
-    desc "A set of filters used by the agent to determine of the asset should be installed."
-    newvalues(/.*/, :absent)
-  end
-
   newproperty(:builds, :array_matching => :all, :parent => PuppetX::Sensu::ArrayOfHashesProperty) do
     desc <<-EOS
     A list of asset builds used to define multiple artifacts which provide the named asset.
@@ -202,21 +189,12 @@ DESC
     if self[:bonsai]
       return
     end
-    if ! self[:builds]
-      required_properties = [
-        :url,
-        :sha512,
-      ]
-      required_properties.each do |property|
-        if self[:ensure] == :present && self[property].nil?
-          fail "You must provide a #{property}"
-        end
-      end
-    end
-    if self[:url] || self[:sha512] || self[:filters] || self[:headers]
-      Puppet.warning("#{PuppetX::Sensu::Type.error_prefix(self)} Using url, sha512, filters, or headers properties for single build is deprecated, use builds property")
-      if self[:builds]
-        fail "Defining builds with url, sha512, or filters is not suppoed, they are mutually exclusive. Use only builds property"
+    required_properties = [
+      :builds,
+    ]
+    required_properties.each do |property|
+      if self[:ensure] == :present && self[property].nil?
+        fail "You must provide a #{property}"
       end
     end
     PuppetX::Sensu::Type.validate_namespace(self)

--- a/lib/puppet/type/sensu_user.rb
+++ b/lib/puppet/type/sensu_user.rb
@@ -81,13 +81,6 @@ DESC
     end
   end
 
-  newparam(:old_password) do
-    desc "DEPRECATED - The user's old password, needed in order to change a user's password"
-    validate do |value|
-      Puppet.warning("Sensu_user[#{@resource[:name]}]: The old_password parameter is unnecessary and will be removed in a future release")
-    end
-  end
-
   newproperty(:groups, :array_matching => :all, :parent => PuppetX::Sensu::ArrayProperty) do
     desc "Groups to which the user belongs."
   end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,15 +53,11 @@
 #   Sensu backend port used to configure sensuctl and verify API access.
 # @param password
 #   Sensu backend admin password used to confiure sensuctl.
-# @param old_password
-#   DEPRECATED - Sensu backend admin old password needed when changing password.
 # @param agent_password
 #   The sensu agent password
 # @param agent_entity_config_password
 #   The password used when configuring Sensu Agent entity config items
 #   Defaults to value used for `agent_password`.
-# @param agent_old_password
-#   DEPRECATED - The sensu agent old password needed when changing agent_password
 # @param validate_namespaces
 #   Determines if sensuctl and sensu_api types will validate their namespace exists
 class sensu (
@@ -81,19 +77,10 @@ class sensu (
   String $api_host = $trusted['certname'],
   Stdlib::Port $api_port = 8080,
   String $password = 'P@ssw0rd!',
-  Optional[String] $old_password = undef,
   String $agent_password = 'P@ssw0rd!',
   Optional[String] $agent_entity_config_password = undef,
-  Optional[String] $agent_old_password = undef,
   Boolean $validate_namespaces = true,
 ) {
-
-  if $old_password {
-    warning('Sensu: old_password parameter is unnecessary and will be removed in a future release')
-  }
-  if $agent_old_password {
-    warning('Sensu: agent_old_password parameter is unnecessary and will be removed in a future release')
-  }
 
   if $ssl_ca_content {
     $_ssl_ca_source = undef

--- a/spec/acceptance/sensu_asset_spec.rb
+++ b/spec/acceptance/sensu_asset_spec.rb
@@ -6,15 +6,6 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_mode == 'types' do
     it 'should work without errors' do
       pp = <<-EOS
       include sensu::backend
-      sensu_asset { 'test2':
-        url      => 'http://example.com/asset/example.tar',
-        sha512   => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b',
-        filters  => ["entity.system.os == 'linux'"],
-        headers  => {
-          "Authorization" => 'Bearer $TOKEN',
-          "X-Forwarded-For" => "client1, proxy1, proxy2"
-        },
-      }
       sensu_asset { 'test':
         ensure => 'present',
         builds => [
@@ -276,7 +267,6 @@ describe 'sensu_asset', if: RSpec.configuration.sensu_mode == 'types' do
       pp = <<-EOS
       include sensu::backend
       sensu_asset { 'test': ensure => 'absent' }
-      sensu_asset { 'test2': ensure => 'absent' }
       sensu_asset { 'test-api':
         ensure   => 'absent',
         provider => 'sensu_api',

--- a/spec/unit/sensu_asset_spec.rb
+++ b/spec/unit/sensu_asset_spec.rb
@@ -264,43 +264,6 @@ describe Puppet::Type.type(:sensu_asset) do
       config[:builds] = [{'url' => 'http://example.com', 'sha512' => 'foo', 'foo' => 'bar'}]
       expect { asset }.to raise_error(Puppet::Error, /foo is not a valid key for a build/)
     end
-    it 'should error if url property defined' do
-      config[:url] = 'http://foo.com'
-      catalog.add_resource asset
-      expect { asset.pre_run_check }.to raise_error(Puppet::Error, /mutually exclusive/)
-    end
-    it 'should error if sha512 property defined' do
-      config[:sha512] = 'foo'
-      catalog.add_resource asset
-      expect { asset.pre_run_check }.to raise_error(Puppet::Error, /mutually exclusive/)
-    end
-    it 'should error if filters property defined' do
-      config[:filters] = ['foo==bar']
-      catalog.add_resource asset
-      expect { asset.pre_run_check }.to raise_error(Puppet::Error, /mutually exclusive/)
-    end
-    it 'should error if headers property defined' do
-      config[:headers] = {'foo' => 'bar'}
-      catalog.add_resource asset
-      expect { asset.pre_run_check }.to raise_error(Puppet::Error, /mutually exclusive/)
-    end
-  end
-
-  describe 'deprecating' do
-    let(:catalog) do
-      catalog = Puppet::Resource::Catalog.new
-      namespace = Puppet::Type.type(:sensu_namespace).new(:name => 'default')
-      catalog.add_resource namespace
-      catalog
-    end
-    it 'should deprecate url' do
-      config[:url] = 'http://foo.com'
-      config[:sha512] = 'foo'
-      config.delete(:builds)
-      expect(Puppet).to receive(:warning).with(/Sensu_asset\[test\]:.*deprecated/)
-      catalog.add_resource asset
-      asset.pre_run_check
-    end
   end
 
   include_examples 'autorequires' do

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -381,7 +381,7 @@ describe Puppet::Type.type(:sensu_check) do
   end
 
   it 'should autorequire sensu_asset' do
-    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :builds => [{'url' => 'http://example.com/asset/example.tar', 'sha512' => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'}])
     catalog = Puppet::Resource::Catalog.new
     config[:runtime_assets] = ['test']
     catalog.add_resource check

--- a/spec/unit/sensu_filter_spec.rb
+++ b/spec/unit/sensu_filter_spec.rb
@@ -216,7 +216,7 @@ describe Puppet::Type.type(:sensu_filter) do
   end
 
   it 'should autorequire sensu_asset' do
-    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :builds => [{'url' => 'http://example.com/asset/example.tar', 'sha512' => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'}])
     catalog = Puppet::Resource::Catalog.new
     config[:runtime_assets] = ['test']
     catalog.add_resource filter

--- a/spec/unit/sensu_handler_spec.rb
+++ b/spec/unit/sensu_handler_spec.rb
@@ -292,7 +292,7 @@ describe Puppet::Type.type(:sensu_handler) do
   end
 
   it 'should autorequire sensu_asset' do
-    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :builds => [{'url' => 'http://example.com/asset/example.tar', 'sha512' => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'}])
     catalog = Puppet::Resource::Catalog.new
     config[:runtime_assets] = ['test']
     catalog.add_resource handler

--- a/spec/unit/sensu_hook_spec.rb
+++ b/spec/unit/sensu_hook_spec.rb
@@ -203,7 +203,7 @@ describe Puppet::Type.type(:sensu_hook) do
   end
 
   it 'should autorequire sensu_asset' do
-    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :builds => [{'url' => 'http://example.com/asset/example.tar', 'sha512' => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'}])
     catalog = Puppet::Resource::Catalog.new
     config[:runtime_assets] = ['test']
     catalog.add_resource hook

--- a/spec/unit/sensu_mutator_spec.rb
+++ b/spec/unit/sensu_mutator_spec.rb
@@ -205,7 +205,7 @@ describe Puppet::Type.type(:sensu_mutator) do
   end
 
   it 'should autorequire sensu_asset' do
-    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :url => 'http://example.com/asset/example.tar', :sha512 => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b')
+    asset = Puppet::Type.type(:sensu_asset).new(:name => 'test', :builds => [{'url' => 'http://example.com/asset/example.tar', 'sha512' => '4f926bf4328fbad2b9cac873d117f771914f4b837c9c85584c38ccf55a3ef3c2e8d154812246e5dda4a87450576b2c58ad9ab40c9e2edc31b288d066b195b21b'}])
     catalog = Puppet::Resource::Catalog.new
     config[:runtime_assets] = ['test']
     catalog.add_resource mutator


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
This removes various deprecations prior to major release to support Sensu 6.

* Remove mention of Sensu 5 from sensu_ad_auth docs
* Remove old_password and old_agent_password parameters and warnings
* Remove deprecated properties from sensu_asset
* Remove code to support Sensu Go before version 5.21