### PR TITLE
Add output_metric_tags property to sensu_check

### DIFF
--- a/lib/puppet/type/sensu_check.rb
+++ b/lib/puppet/type/sensu_check.rb
@@ -239,6 +239,29 @@ DESC
     newvalues(/.*/, :absent)
   end
 
+  newproperty(:output_metric_tags, :array_matching => :all, :parent => PuppetX::Sensu::ArrayOfHashesProperty) do
+    desc <<-EOS
+    Custom tags you can apply to enrich metric points produced by check output metric extraction."
+    Consists of Array of Hashes, each Hash must contain `name` and `value` keys.
+    EOS
+
+    validate do |tag|
+      if ! tag.is_a?(Hash)
+        raise ArgumentError, "Each tag must be a Hash not #{tag.class}"
+      end
+      required_keys = ['name','value']
+      keys = tag.keys.map { |k| k.to_s }
+      if required_keys.sort != keys.sort
+        raise ArgumentError, "tag must contain only 'name' and 'value' keys"
+      end
+      tag.each_pair do |key, value|
+        if ! value.is_a?(String)
+          raise ArgumentError, "#{key} must be a String, not #{value.class}"
+        end
+      end
+    end
+  end
+
   newproperty(:max_output_size, :parent => PuppetX::Sensu::IntegerProperty) do
     desc 'Maximum size, in bytes, of stored check outputs.'
   end

--- a/spec/acceptance/sensu_check_spec.rb
+++ b/spec/acceptance/sensu_check_spec.rb
@@ -20,6 +20,7 @@ describe 'sensu_check', if: RSpec.configuration.sensu_mode == 'types' do
           'entity_attributes' => ["entity.Class == 'proxy'"],
         },
         output_metric_format             => 'nagios_perfdata',
+        output_metric_tags               => [{'name' => 'instance', 'value' => '{{ .name }}'}],
         labels                           => { 'foo' => 'baz' },
         secrets                          => [
           {'name' => 'TEST', 'secret' => 'test'}
@@ -76,6 +77,7 @@ describe 'sensu_check', if: RSpec.configuration.sensu_mode == 'types' do
         expect(data['check_hooks']).to eq([{'0' => ['always.sh']},{'1' => ['test.sh']},{'critical' => ['httpd-restart']}])
         expect(data['proxy_requests']['entity_attributes']).to eq(["entity.Class == 'proxy'"])
         expect(data['output_metric_format']).to eq('nagios_perfdata')
+        expect(data['output_metric_tags']).to eq([{'name' => 'instance', 'value' => '{{ .name }}'}])
         expect(data['metadata']['labels']['foo']).to eq('baz')
         expect(data['secrets']).to eq([{'name' => 'TEST', 'secret' => 'test'}])
       end
@@ -161,6 +163,10 @@ describe 'sensu_check', if: RSpec.configuration.sensu_mode == 'types' do
           'entity_attributes' => ['System.OS==linux'],
         },
         output_metric_format             => 'graphite_plaintext',
+        output_metric_tags               => [
+          {'name' => 'instance', 'value' => '{{ .name }}'},
+          {'name' => 'prometheus_type', 'value' => 'gauge'},
+        ],
         labels                           => { 'foo' => 'bar' },
         secrets                          => [
           {'name' => 'TEST', 'secret' => 'test2'}
@@ -201,6 +207,9 @@ describe 'sensu_check', if: RSpec.configuration.sensu_mode == 'types' do
         expect(data['check_hooks']).to eq([{'critical' => ['httpd-restart']},{'warning' => ['httpd-restart']}])
         expect(data['proxy_requests']['entity_attributes']).to eq(['System.OS==linux'])
         expect(data['output_metric_format']).to eq('graphite_plaintext')
+        expect(data['output_metric_tags']).to include({'name' => 'instance', 'value' => '{{ .name }}'})
+        expect(data['output_metric_tags']).to include({'name' => 'prometheus_type', 'value' => 'gauge'})
+        expect(data['output_metric_tags'].size).to eq(2)
         expect(data['metadata']['labels']['foo']).to eq('bar')
         expect(data['secrets']).to eq([{'name' => 'TEST', 'secret' => 'test2'}])
       end

--- a/spec/unit/sensu_check_spec.rb
+++ b/spec/unit/sensu_check_spec.rb
@@ -335,6 +335,25 @@ describe Puppet::Type.type(:sensu_check) do
     end
   end
 
+  describe 'output_metric_tags' do
+    it 'should accept a valid value' do
+      config[:output_metric_tags] = [{'name' => 'instance', 'value' => '{{ .name }}'}]
+      expect(check[:output_metric_tags]).to eq([{'name' => 'instance', 'value' => '{{ .name }}'}])
+    end
+    it 'requires hash for each tag' do
+      config[:output_metric_tags] = ['foo']
+      expect { check }.to raise_error(Puppet::Error, /must be a Hash/)
+    end
+    it 'requires valid keys for tag' do
+      config[:output_metric_tags] = [{'name' => 'instance'}]
+      expect { check }.to raise_error(Puppet::Error, /tag must contain/)
+    end
+    it 'requires strings for values' do
+      config[:output_metric_tags] = [{'name' => 'instance', 'value' => false}]
+      expect { check }.to raise_error(Puppet::Error, /must be a String/)
+    end
+  end
+
   describe 'proxy_requests' do
     it 'accepts valid value' do
       config[:proxy_requests] = {'entity_attributes' => ['foo==bar'],'splay' => true, 'splay_coverage' => 60}


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the `output_metric_tags` property to `sensu_check`.  This was something added in Sensu Go 6.1. Because there is no default value applied, there is not version check since this new property is opt-in.

https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/checks/#output-metric-tags
