### PR TITLE
Fix for when version query returns malformed version

### DIFF
--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -240,7 +240,10 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
       @current_version = version
     end
     return true if @current_version.nil?
-    return Gem::Version.new(@current_version) >= Gem::Version.new(v)
+    Gem::Version.new(@current_version) >= Gem::Version.new(v)
+  rescue ArgumentError => e
+    Puppet.debug "Unable to compare version #{@current_version} with needed version #{v}: #{e}"
+    return true
   end
   def version_cmp(*args)
     self.class.version_cmp(*args)

--- a/spec/unit/provider/sensu_api_spec.rb
+++ b/spec/unit/provider/sensu_api_spec.rb
@@ -5,14 +5,29 @@ require 'ostruct'
 describe Puppet::Provider::SensuAPI do
   subject { Puppet::Provider::SensuAPI }
 
+  describe 'version' do
+    it 'returns version' do
+      allow(described_class).to receive(:api_request).with('/version', nil, {:failonfail => false}).and_return({'sensu_backend' => '6.1.0'})
+      expect(described_class.version).to eq('6.1.0')
+    end
+    it 'returns nil if no version' do
+      allow(described_class).to receive(:api_request).with('/version', nil, {:failonfail => false}).and_return({})
+      expect(described_class.version).to eq(nil)
+    end
+  end
+
   describe 'version_cmp' do
     it 'returns true' do
-      allow(described_class).to receive(:api_request).with('/version').and_return('6.1.0')
+      described_class.instance_variable_set('@current_version', '6.1.0')
+      expect(described_class.version_cmp('6.1.0')).to eq(true)
+    end
+    it 'returns true when malformed version' do
+      described_class.instance_variable_set('@current_version', '(devel)')
       expect(described_class.version_cmp('6.1.0')).to eq(true)
     end
     it 'returns false' do
-      allow(described_class).to receive(:api_request).with('/version').and_return('6.0.0')
-      expect(described_class.version_cmp('6.1.0')).to eq(true)
+      described_class.instance_variable_set('@current_version', '6.0.0')
+      expect(described_class.version_cmp('6.1.0')).to eq(false)
     end
   end
 end

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -130,16 +130,24 @@ describe Puppet::Provider::Sensuctl do
       allow(subject).to receive(:sensuctl).with(['version'], {:failonfail => false}).and_return('sensuctl version 6.1.0+ee, enterprise edition, build be1e65933de5be15a65066227f007ae369af1449, built 2020-10-02T01:15:38Z, built with go1.13.15')
       expect(subject.version).to eq('6.1.0')
     end
+    it 'returns nil without version match' do
+      allow(subject).to receive(:sensuctl).with(['version'], {:failonfail => false}).and_return('foobar')
+      expect(subject.version).to eq(nil)
+    end
   end
 
   describe 'version_cmp' do
     it 'returns true' do
-      allow(subject).to receive(:version).and_return('6.1.0')
+      described_class.instance_variable_set('@current_version', '6.1.0')
+      expect(subject.version_cmp('6.1.0')).to eq(true)
+    end
+    it 'returns true with malformed version' do
+      described_class.instance_variable_set('@current_version', '(devel)')
       expect(subject.version_cmp('6.1.0')).to eq(true)
     end
     it 'returns false' do
-      allow(subject).to receive(:version).and_return('6.0.0')
-      expect(subject.version_cmp('6.1.0')).to eq(true)
+      described_class.instance_variable_set('@current_version', '6.0.0')
+      expect(subject.version_cmp('6.1.0')).to eq(false)
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fix version comparison logic to be a bit more resilient so that if the version returned is not expected the code does not raise exceptions.

Some of the unit test changes were to address the unit tests essentially testing nothing and not being really valid tests.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1278