### PR TITLE
Improved handling of changes to sensu::etc_dir

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -30,5 +30,7 @@ fixtures:
       repo: git://github.com/voxpupuli/puppet-archive.git
     windows_env:
       repo: git://github.com/voxpupuli/puppet-windows_env.git
+    systemd:
+      repo: git://github.com/camptocamp/puppet-systemd.git
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -42,5 +42,8 @@ fixtures:
     windows_env:
       repo: git://github.com/voxpupuli/puppet-windows_env.git
       ref: 'v3.0.0'
+    systemd:
+      repo: git://github.com/camptocamp/puppet-systemd.git
+      ref: '2.0.0'
   symlinks:
     sensu: "#{source_dir}"

--- a/Gemfile
+++ b/Gemfile
@@ -61,6 +61,7 @@ group :system_tests do
   gem 'beaker-puppet_install_helper', :require => false
   gem 'beaker-rspec',                 :require => false
   gem 'serverspec',                   :require => false
+  gem 'simp-beaker-helpers',          :require => false
 end
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -100,10 +100,11 @@ Beginning with Sensu Go 6, some changes to `agent.yml` will only bootstrap an ag
 If you wish to make changes to values such as `subscriptions`, `labels` or `annotations` after a host is added to Sensu this must be done
 via the Sensu Go API. To support this it's now required that agents have the ability to make API calls.
 
-In order to ensure agents can make API calls either via API or sensuctl the agent must be told about the admin password:
+In order to ensure agents can make API calls either via API or sensuctl the agent must be told about the admin password and API host:
 
 ```
 class { 'sensu':
+  api_host                     => 'sensu-backend.example.com',
   agent_entity_config_password => 'supersecret',
 }
 class { 'sensu::agent':
@@ -324,6 +325,10 @@ sensu::agent_entity_config_password: supersecret
 This module supports Windows Sensu Go agent via chocolatey beginning with version 5.12.0.
 
 ```puppet
+class { 'sensu':
+  api_host                     => 'sensu-backend.example.com',
+  agent_entity_config_password => 'supersecret',
+}
 class { 'sensu::agent':
   backends      => ['sensu-backend.example.com:8081'],
   subscriptions => ['windows'],
@@ -1219,6 +1224,8 @@ Examples can be found in the [examples](https://github.com/sensu/sensu-puppet/tr
 * [Slack Alerts](https://github.com/sensu/sensu-puppet/blob/master/examples/slack_alerts.pp) - Example of setting up Slack alerts
 
 ## Limitations
+
+Changing `sensu::etc_dir` is only supported on systems using systemd.
 
 The type `sensu_user` does not at this time support `ensure => absent` due to a limitation with sensuctl, see [sensu-go#2540](https://github.com/sensu/sensu-go/issues/2540).
 

--- a/lib/puppet/type/sensu_cluster_role.rb
+++ b/lib/puppet/type/sensu_cluster_role.rb
@@ -54,7 +54,7 @@ DESC
         end
       end
       rule.each_pair do |k,v|
-        if ! v.is_a?(Array)
+        if ! v.nil? && ! v.is_a?(Array)
           raise ArgumentError, "Rule's #{k} must be an Array"
         end
       end

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -129,7 +129,7 @@ class sensu (
       $os_package_require = []
     }
     'Debian': {
-      $os_package_require = [Class['::apt::update']]
+      $os_package_require = [Class['apt::update']]
     }
     'windows': {
       $os_package_require = []
@@ -142,16 +142,11 @@ class sensu (
   # $package_require is used by sensu::agent and sensu::backend
   # package resources
   if $manage_repo {
-    $package_require = [Class['::sensu::repo']] + $os_package_require
+    $package_require = [Class['sensu::repo']] + $os_package_require
   } else {
     $package_require = undef
   }
 
   include sensu::resources
 
-  exec { 'sensu systemctl daemon-reload':
-    path        => '/usr/bin:/bin:/usr/sbin:/sbin',
-    command     => 'systemctl daemon-reload',
-    refreshonly => true,
-  }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -19,6 +19,10 @@
     {
       "name": "puppetlabs/postgresql",
       "version_requirement": ">= 6.4.0 < 7.0.0"
+    },
+    {
+      "name": "camptocamp/systemd",
+      "version_requirement": ">= 2.0.0 < 3.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/spec/acceptance/nodesets/centos-8.yml
+++ b/spec/acceptance/nodesets/centos-8.yml
@@ -10,7 +10,9 @@ HOSTS:
     docker_cmd:
       - '/usr/sbin/init'
     docker_image_commands:
-      - 'dnf install -y wget which initscripts iproute'
+      - 'yum install -y dnf-utils'
+      - 'dnf config-manager --set-enabled PowerTools'
+      - 'dnf install -y wget which initscripts iproute langpacks-en glibc-all-langpacks'
     docker_container_name: 'sensu-agent-el8'
   sensu-backend:
     roles:
@@ -25,7 +27,9 @@ HOSTS:
     docker_cmd:
       - '/usr/sbin/init'
     docker_image_commands:
-      - 'dnf install -y wget which initscripts iproute'
+      - 'yum install -y dnf-utils'
+      - 'dnf config-manager --set-enabled PowerTools'
+      - 'dnf install -y wget which initscripts iproute langpacks-en glibc-all-langpacks'
     docker_container_name: 'sensu-backend-el8'
 CONFIG:
   log_level: debug

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -9,14 +9,6 @@ describe 'sensu', :type => :class do
 
         it { should contain_class('sensu')}
         it { should contain_class('sensu::resources') }
-
-        it do
-          should contain_exec('sensu systemctl daemon-reload').with({
-            'path'        => '/usr/bin:/bin:/usr/sbin:/sbin',
-            'command'     => 'systemctl daemon-reload',
-            'refreshonly' => 'true',
-          })
-        end
       end
 
       context 'with use_ssl => false' do

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -2,10 +2,13 @@ require 'beaker-rspec'
 require 'beaker-puppet'
 require 'beaker/module_install_helper'
 require 'beaker/puppet_install_helper'
+require 'simp/beaker_helpers'
 
+include Simp::BeakerHelpers
 run_puppet_install_helper
 install_module_dependencies
 install_module
+pluginsync_on(hosts)
 collection = ENV['BEAKER_PUPPET_COLLECTION'] || 'puppet5'
 project_dir = File.absolute_path(File.join(File.dirname(__FILE__), '..'))
 
@@ -66,7 +69,6 @@ RSpec.configure do |c|
     # Dependencies only needed to test some examples
     if RSpec.configuration.sensu_mode == 'examples'
       on setup_nodes, puppet('module', 'install', 'puppet-logrotate', '--version', '4.0.0')
-      on setup_nodes, puppet('module', 'install', 'camptocamp-systemd', '--version', '2.8.0')
       on setup_nodes, puppet('module', 'install', 'saz-rsyslog', '--version', '5.0.0')
       # rsyslog template relies on rsyslog_version fact so pre-install rsyslog
       # to keep things idempotent within minimal docker containers

--- a/tests/sensu-agent.pp
+++ b/tests/sensu-agent.pp
@@ -1,3 +1,6 @@
+class { 'sensu':
+  api_host => 'sensu-backend.example.com',
+}
 class { 'sensu::agent':
   backends => ['sensu-backend.example.com:8081'],
 }


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for changing `etc_dir` in the `sensu` class.  Previously changing that value would move configs but not tell the Sensu daemons where to find the configs.

This handling only works with systemd based sytems, adds dependency on campotcamp/systemd

Added a few improvements to documentation around `sensu` class and how to properly ensure agents can communicate with backend API.