### PR TITLE
Fix sensu_agent_entity_config purging to not purge entity subscription

### DIFF
--- a/lib/puppet/type/sensu_resources.rb
+++ b/lib/puppet/type/sensu_resources.rb
@@ -131,6 +131,11 @@ Puppet::Type.newtype(:sensu_resources) do
     if resource[:key] == 'sensu.io/managed_by'
       return false
     end
+    # Do not purge entity subscription as it can not be deleted
+    # https://github.com/sensu/sensu-puppet/pull/1280
+    if resource[:config] == 'subscriptions' && resource[:value] == "entity:#{resource[:entity]}"
+      return false
+    end
     if ! self[:agent_entity_configs].nil? && ! self[:agent_entity_configs].include?(resource[:config])
       return false
     end

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -117,7 +117,7 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     end
 
     describe command('puppet resource package sensu-agent ensure=absent provider=chocolatey') do
-      its(:exit_status) { is_expected.to eq 0 }
+      its(:stdout) { is_expected.to match /absent/ }
     end
 
     describe command('puppet apply --debug --detailed-exitcodes C:\manifest-agent.pp ; Write-Output "EXITCODE=$LastExitCode"') do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,12 @@ RSpec.configure do |config|
     # facts being exercised with something like
     # Facter.collection.loader.load(:ipaddress)
     Facter.clear
+
+    # Ensure Puppet config initialization doesn't try and create directories that may not be writable
+    Puppet[:logdir] = '/tmp'
+    Puppet[:confdir] = '/tmp'
+    Puppet[:vardir] = '/tmp'
+    Puppet[:codedir] = '/tmp'
   end
   config.default_facts = {
     :environment               => 'rp_env',

--- a/spec/unit/facter/sensu_puppet_facts_spec.rb
+++ b/spec/unit/facter/sensu_puppet_facts_spec.rb
@@ -4,10 +4,6 @@ require 'facter/sensu_puppet_facts'
 describe SensuPuppetFacts do
   subject { SensuPuppetFacts }
   before(:each) do
-    Puppet[:logdir] = '/tmp'
-    Puppet[:confdir] = '/tmp'
-    Puppet[:vardir] = '/tmp'
-    Puppet[:codedir] = '/tmp'
     subject.add_facts
   end
   after(:each) do

--- a/spec/unit/sensu_resources_spec.rb
+++ b/spec/unit/sensu_resources_spec.rb
@@ -121,6 +121,19 @@ describe Puppet::Type.type(:sensu_resources) do
     expect(catalog.resources.size).to eq(1)
     expect(ret).to include(instance_config)
   end
+  # Do not purge entity subscription as it can not be deleted
+  # https://github.com/sensu/sensu-puppet/pull/1280
+  it 'should not purge sensu_agent_entity_config for subscription entity' do
+    config[:name] = 'sensu_agent_entity_config'
+    instance_config = Puppet::Type.type(:sensu_agent_entity_config).new(:name => 'subscriptions value entity:agent on agent in dev')
+    allow(instance_config.class).to receive(:instances).and_return([instance_config])
+    expect(instance_config).not_to receive(:purging)
+    catalog = Puppet::Resource::Catalog.new
+    catalog.add_resource resource
+    ret = resource.generate
+    expect(catalog.resources.size).to eq(1)
+    expect(ret).not_to include(instance_config)
+  end
   it 'should not purge sensu_agent_entity_config if config does not match agent_entity_configs' do
     config[:name] = 'sensu_agent_entity_config'
     config[:agent_entity_configs] = ['labels','annotations']


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Avoid purging the entity subscription that cannot be deleted.  This was actually not an issue with 6.1.0 because of a bug with Sensu Go but the fix with 6.1.1 now correctly makes this entity subscription not be able to be deleted so we must ignore it when purging.
