### PR TITLE
Fix agent to use correct API URL for agent entity configs

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -155,13 +155,8 @@ class sensu::agent (
       }
     }
   }
-  # Get first backend listed and use that address for API calls to configure
-  # sensu_agent_entity_config resources
-  $_backend = $config['backend-url'][0]
-  $_backend_without_prefix = $_backend.regsubst('^(ws|wss)://', '')
-  $_backend_host = split($_backend_without_prefix, /:/)[0]
   sensu_agent_entity_setup { 'puppet':
-    url      => "${sensu::api_protocol}://${_backend_host}:${sensu::api_port}",
+    url      => $sensu::api_url,
     username => 'puppet-agent_entity_config',
     password => $sensu::_agent_entity_config_password,
   }

--- a/spec/classes/backend_datastore_postgresql_spec.rb
+++ b/spec/classes/backend_datastore_postgresql_spec.rb
@@ -20,7 +20,7 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
       it do
         should contain_sensu_postgres_config('postgresql').with({
           :ensure        => 'present',
-          :dsn           => 'postgresql://sensu:changeme@localhost:5432/sensu?sslmode=require',
+          :dsn           => sensitive('postgresql://sensu:changeme@localhost:5432/sensu?sslmode=require'),
           :pool_size     => '20',
           :strict        => 'false',
           :batch_buffer  => '0',
@@ -64,7 +64,7 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
         it do
           should contain_sensu_postgres_config('postgresql').with({
             :ensure    => 'present',
-            :dsn       => 'postgresql://sensu:changeme@localhost:5432/sensu?sslmode=disable',
+            :dsn       => sensitive('postgresql://sensu:changeme@localhost:5432/sensu?sslmode=disable'),
             :pool_size => '20',
           })
         end
@@ -267,7 +267,7 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
         it do
           should contain_sensu_postgres_config('postgresql').with({
            :ensure    => 'absent',
-           :dsn       => 'postgresql://sensu:changeme@localhost:5432/sensu?sslmode=require',
+           :dsn       => sensitive('postgresql://sensu:changeme@localhost:5432/sensu?sslmode=require'),
            :pool_size => '20',
          })
         end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use the correct API URL when configuring agents to connect to API to manage their entity config.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Replaces #1284 
