### PR TITLE
Support Puppet 7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,10 @@ matrix:
     env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 6"
     stage: unit
     bundler_args: --without system_tests development
+  - rvm: 2.5.7
+    env: CHECK="validate lint strings:generate reference" PUPPET_GEM_VERSION="~> 7"
+    stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.4.9
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5"
     stage: unit
@@ -47,6 +51,14 @@ matrix:
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
     stage: unit
     bundler_args: --without system_tests development
+  - rvm: 2.7.0
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 7"
+    stage: unit
+    bundler_args: --without system_tests development
+  - rvm: 2.7.0
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 7" FIXTURES_YML=".fixtures-latest.yml"
+    stage: unit
+    bundler_args: --without system_tests development
   - rvm: 2.4.9
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=full
@@ -55,6 +67,11 @@ matrix:
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=full
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_sensu_mode=full
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
@@ -74,6 +91,11 @@ matrix:
     stage: acceptance
   - rvm: 2.5.7
     services: docker
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_sensu_mode=examples
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=examples
     script: bundle exec rake beaker
     stage: acceptance
@@ -85,6 +107,11 @@ matrix:
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_sensu_mode=types
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
@@ -102,6 +129,11 @@ matrix:
     env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=types BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
     stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_sensu_mode=types BEAKER_sensu_use_agent=yes
+    script: bundle exec rake beaker
+    stage: acceptance
   - rvm: 2.4.9
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=cluster
@@ -112,6 +144,11 @@ matrix:
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster
     script: bundle exec rake beaker
     stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_sensu_mode=cluster
+    script: bundle exec rake beaker
+    stage: acceptance
   - rvm: 2.4.9
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet5 BEAKER_sensu_mode=cluster BEAKER_sensu_use_agent=yes
@@ -120,6 +157,11 @@ matrix:
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=cluster BEAKER_sensu_use_agent=yes
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="centos-7-cluster" BEAKER_PUPPET_COLLECTION=puppet7 BEAKER_sensu_mode=cluster BEAKER_sensu_use_agent=yes
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
@@ -139,6 +181,11 @@ matrix:
     stage: acceptance
   - rvm: 2.5.7
     services: docker
+    env: BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet7
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-8" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
@@ -154,6 +201,11 @@ matrix:
     stage: acceptance
   - rvm: 2.5.7
     services: docker
+    env: BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet7
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="debian-9" BEAKER_PUPPET_COLLECTION=puppet6 
     script: bundle exec rake beaker
     stage: acceptance
@@ -165,6 +217,11 @@ matrix:
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet6
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="debian-10" BEAKER_PUPPET_COLLECTION=puppet7
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
@@ -204,6 +261,11 @@ matrix:
     stage: acceptance
   - rvm: 2.5.7
     services: docker
+    env: BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet7
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="ubuntu-1804" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
@@ -215,6 +277,11 @@ matrix:
   - rvm: 2.5.7
     services: docker
     env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet6
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
+    env: BEAKER_set="amazonlinux-2" BEAKER_PUPPET_COLLECTION=puppet7
     script: bundle exec rake beaker
     stage: acceptance
   - rvm: 2.5.7
@@ -234,6 +301,11 @@ matrix:
     stage: acceptance
   - rvm: 2.5.7
     services: docker
+    env: BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet7
+    script: bundle exec rake beaker
+    stage: acceptance
+  - rvm: 2.5.7
+    services: docker
     env: BEAKER_sensu_ci_build=yes BEAKER_set="amazonlinux-201803" BEAKER_PUPPET_COLLECTION=puppet6
     script: bundle exec rake beaker
     stage: acceptance
@@ -244,6 +316,8 @@ matrix:
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 5" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.7
     env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 6" FIXTURES_YML=".fixtures-latest.yml"
+  - rvm: 2.7.0
+    env: CHECK="parallel_spec" PUPPET_GEM_VERSION="~> 7" FIXTURES_YML=".fixtures-latest.yml"
   - rvm: 2.5.7
     env: BEAKER_sensu_ci_build=yes BEAKER_set="centos-7" BEAKER_PUPPET_COLLECTION=puppet6 BEAKER_sensu_mode=full
   - rvm: 2.5.7

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,11 @@ if puppetversion = ENV['PUPPET_GEM_VERSION']
 else
   gem 'puppet', :require => false
 end
-gem 'facter', '< 4.0', :require => false
+if facterversion = ENV['FACTER_GEM_VERSION']
+  gem 'facter', facterversion, :require => false
+else
+  gem 'facter', :require => false
+end
 
 group :development, :unit_tests do
   gem 'rake'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,11 +49,11 @@ image:
 environment:
   matrix:
     - PUPPET_GEM_VERSION: '~>5.x'
-      FACTER_GEM_VERSION: '~>3.x'
+      FACTER_GEM_VERSION: '~>2.x'
       PUPPET_REPO: puppet5
       RUBY_VERSION: 24-x64
     - PUPPET_GEM_VERSION: '~>6.x'
-      FACTER_GEM_VERSION: '~>3.x'
+      FACTER_GEM_VERSION: '~>2.x'
       PUPPET_REPO: puppet6
       RUBY_VERSION: 25-x64
     - PUPPET_GEM_VERSION: '~>7.x'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -49,10 +49,16 @@ image:
 environment:
   matrix:
     - PUPPET_GEM_VERSION: '~>5.x'
+      FACTER_GEM_VERSION: '~>3.x'
       PUPPET_REPO: puppet5
       RUBY_VERSION: 24-x64
     - PUPPET_GEM_VERSION: '~>6.x'
+      FACTER_GEM_VERSION: '~>3.x'
       PUPPET_REPO: puppet6
       RUBY_VERSION: 25-x64
+    - PUPPET_GEM_VERSION: '~>7.x'
+      FACTER_GEM_VERSION: '~>4.x'
+      PUPPET_REPO: puppet7
+      RUBY_VERSION: 26-x64
 matrix:
   fast_finish: false

--- a/metadata.json
+++ b/metadata.json
@@ -76,7 +76,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 7.0.0"
+      "version_requirement": ">= 5.0.0 < 8.0.0"
     }
   ],
   "tags": [

--- a/spec/acceptance/03_no_ssl_spec.rb
+++ b/spec/acceptance/03_no_ssl_spec.rb
@@ -75,4 +75,16 @@ describe 'sensu without SSL', if: ['base','full'].include?(RSpec.configuration.s
       its(:exit_status) { should eq 0 }
     end
   end
+
+  context 're-enables SSL' do
+    it 'should work without errors' do
+      backend_pp = <<-EOS
+      class { '::sensu':
+        password => 'P@ssw0rd!',
+      }
+      class { 'sensu::backend': }
+      EOS
+      apply_manifest_on(backend, backend_pp, :catch_failures => true)
+    end
+  end
 end

--- a/spec/acceptance/nodesets/centos-7-cluster.yml
+++ b/spec/acceptance/nodesets/centos-7-cluster.yml
@@ -13,7 +13,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - "sed -i -r '/^tsflags/d' /etc/yum.conf"
-      - 'yum install -y wget which'
+      - 'yum install -y wget which iproute'
     docker_container_name: 'sensu-backend1-el7'
   sensu-backend2:
     roles:
@@ -27,7 +27,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - "sed -i -r '/^tsflags/d' /etc/yum.conf"
-      - 'yum install -y wget which'
+      - 'yum install -y wget which iproute'
     docker_container_name: 'sensu-backend2-el7'
   sensu-backend3:
     roles:
@@ -41,7 +41,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - "sed -i -r '/^tsflags/d' /etc/yum.conf"
-      - 'yum install -y wget which'
+      - 'yum install -y wget which iproute'
     docker_container_name: 'sensu-backend3-el7'
 CONFIG:
   log_level: debug

--- a/spec/acceptance/nodesets/centos-8.yml
+++ b/spec/acceptance/nodesets/centos-8.yml
@@ -11,7 +11,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - 'yum install -y dnf-utils'
-      - 'dnf config-manager --set-enabled PowerTools'
+      - 'dnf config-manager --set-enabled powertools'
       - 'dnf install -y wget which initscripts iproute langpacks-en glibc-all-langpacks'
     docker_container_name: 'sensu-agent-el8'
   sensu-backend:
@@ -28,7 +28,7 @@ HOSTS:
       - '/usr/sbin/init'
     docker_image_commands:
       - 'yum install -y dnf-utils'
-      - 'dnf config-manager --set-enabled PowerTools'
+      - 'dnf config-manager --set-enabled powertools'
       - 'dnf install -y wget which initscripts iproute langpacks-en glibc-all-langpacks'
     docker_container_name: 'sensu-backend-el8'
 CONFIG:

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -6,6 +6,15 @@ require 'json'
 #       the Sensu Go backend inside the Appveyor Windows testing environment
 
 describe 'sensu::cli class', if: Gem.win_platform? do
+  let(:facter_command) do
+    puppet_version = `puppet --version`
+    if Gem::Version.new(puppet_version) >= Gem::Version.new('7.0.0')
+      'puppet facts show'
+    else
+      'facter -p --json'
+    end
+  end
+
   context 'default' do
     pp = <<-EOS
     class { '::sensu':
@@ -36,7 +45,7 @@ describe 'sensu::cli class', if: Gem.win_platform? do
     end
     describe 'sensuctl.version fact' do
       it 'has version fact' do
-        output = `facter --json -p sensuctl`
+        output = `#{facter_command} sensuctl`
         data = JSON.parse(output.strip)
         expect(data['sensuctl']['version']).to match(/^[0-9\.]+/)
       end
@@ -89,7 +98,7 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     end
     describe 'sensu_agent.version fact' do
       it 'has version fact' do
-        output = `facter --json -p sensu_agent`
+        output = `#{facter_command} sensu_agent`
         data = JSON.parse(output.strip)
         expect(data['sensu_agent']['version']).to match(/^[0-9\.]+/)
       end
@@ -136,7 +145,7 @@ describe 'sensu::agent class', if: Gem.win_platform? do
     end
     describe 'sensu_agent.version fact' do
       it 'has version fact' do
-        output = `facter --json -p sensu_agent`
+        output = `#{facter_command} sensu_agent`
         data = JSON.parse(output.strip)
         expect(data['sensu_agent']['version']).to match(/^[0-9\.]+/)
       end

--- a/spec/acceptance/windows_spec.rb
+++ b/spec/acceptance/windows_spec.rb
@@ -54,6 +54,15 @@ describe 'sensu::cli class', if: Gem.win_platform? do
 end
 
 describe 'sensu::agent class', if: Gem.win_platform? do
+  let(:facter_command) do
+    puppet_version = `puppet --version`
+    if Gem::Version.new(puppet_version) >= Gem::Version.new('7.0.0')
+      'puppet facts show'
+    else
+      'facter -p --json'
+    end
+  end
+
   context 'default' do
     pp = <<-EOS
     class { '::sensu': }

--- a/spec/unit/facter/sensu_facts_spec.rb
+++ b/spec/unit/facter/sensu_facts_spec.rb
@@ -44,6 +44,8 @@ describe "SensuFacts" do
     end
 
     it 'returns nil' do
+      allow(Facter::Core::Execution).to receive(:which).with('sensuctl').and_return(nil)
+      allow(Facter::Core::Execution).to receive(:which).with('sensu-agent').and_return(nil)
       allow(Facter::Core::Execution).to receive(:which).with('sensu-backend').and_return(nil)
       SensuFacts.add_backend_facts
       expect(Facter.fact(:sensu_backend).value).to be_nil


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Add support for Puppet 7 (and Facter 4)

I did not use Ruby 2.7.0 for acceptance tests because the RVM version of Ruby used for beaker tests has zero impact on the tests, the version of Ruby and Puppet used for the test is set by `BEAKER_PUPPET_COLLECTION` so you can use whatever version of Ruby is supported by the beaker code and it won't impact the version of Ruby used for actual acceptance tests.  The beaker library is not yet validated on Ruby 2.7 so I opted for safest approach while still testing proper version of Puppet and Ruby inside Docker.  It's sort of like installing RVM Ruby 2.0.0 on a host and it having no impact on Puppet Ruby because Puppet Ruby is embedded in the puppet-agent package, and the beaker tests are using puppet-agent packages.