### PR TITLE
Add token_file parameter to sensu_secrets_vault_provider

### DIFF
--- a/lib/puppet/provider/sensu_secrets_vault_provider/sensuctl.rb
+++ b/lib/puppet/provider/sensu_secrets_vault_provider/sensuctl.rb
@@ -57,12 +57,25 @@ Puppet::Type.type(:sensu_secrets_vault_provider).provide(:sensuctl, :parent => P
     end
   end
 
+  def get_token
+    if resource[:token_file]
+      token = File.read(resource[:token_file]).chomp
+    else
+      token = @property_flush[:token] || resource[:token]
+    end
+    token
+  rescue Errno::ENOENT => e
+    raise Puppet::Error "Unable to read token_file #{resource[:token_file]}: #{e}"
+  end
+
   def create
     spec = {}
     metadata = {}
     metadata[:name] = resource[:name]
     spec[:client] = {}
+    spec[:client][:token] = get_token
     type_properties.each do |property|
+      next if property == :token
       value = resource[property]
       next if value.nil?
       next if value == :absent || value == [:absent]
@@ -85,7 +98,9 @@ Puppet::Type.type(:sensu_secrets_vault_provider).provide(:sensuctl, :parent => P
       metadata = {}
       metadata[:name] = resource[:name]
       spec[:client] = {}
+      spec[:client][:token] = get_token
       type_properties.each do |property|
+        next if property == :token
         if @property_flush[property]
           value = @property_flush[property]
         else

--- a/lib/puppet/type/sensu_secrets_vault_provider.rb
+++ b/lib/puppet/type/sensu_secrets_vault_provider.rb
@@ -60,6 +60,10 @@ DESC
     end
   end
 
+  newparam(:token_file) do
+    desc 'Path to file that contains token to use for authentication.'
+  end
+
   newproperty(:version) do
     desc 'HashiCorp Vault HTTP API version'
   end
@@ -142,13 +146,18 @@ DESC
   validate do
     required_properties = [
       :address,
-      :token,
       :version,
     ]
     required_properties.each do |property|
       if self[:ensure] == :present && self[property].nil?
         fail "You must provide a #{property}"
       end
+    end
+    if self[:ensure] == :present && self[:token].nil? && self[:token_file].nil?
+      fail "You must provide either token or token_file"
+    end
+    if self[:ensure] == :present && self[:token] && self[:token_file]
+      fail "token and token_file are mutually exclusive"
     end
   end
 end

--- a/spec/unit/provider/sensu_secrets_vault_provider/sensu_api_spec.rb
+++ b/spec/unit/provider/sensu_secrets_vault_provider/sensu_api_spec.rb
@@ -32,6 +32,18 @@ describe Puppet::Type.type(:sensu_secrets_vault_provider).provider(:sensu_api) d
     end
   end
 
+  describe 'get_token' do
+    it 'uses token' do
+      expect(resource.provider.get_token).to eq('secret')
+    end
+    it 'reads token file' do
+      allow(File).to receive(:read).with('/token').and_return("foobar\n")
+      config.delete(:token)
+      config[:token_file] = '/token'
+      expect(resource.provider.get_token).to eq('foobar')
+    end
+  end
+
   describe 'create' do
     it 'should create an auth' do
       expected_spec = {

--- a/spec/unit/provider/sensu_secrets_vault_provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_secrets_vault_provider/sensuctl_spec.rb
@@ -28,6 +28,18 @@ describe Puppet::Type.type(:sensu_secrets_vault_provider).provider(:sensuctl) do
     end
   end
 
+  describe 'get_token' do
+    it 'uses token' do
+      expect(resource.provider.get_token).to eq('secret')
+    end
+    it 'reads token file' do
+      allow(File).to receive(:read).with('/token').and_return("foobar\n")
+      config.delete(:token)
+      config[:token_file] = '/token'
+      expect(resource.provider.get_token).to eq('foobar')
+    end
+  end
+
   describe 'create' do
     it 'should create a check' do
       expected_metadata = {

--- a/spec/unit/sensu_secrets_vault_provider_spec.rb
+++ b/spec/unit/sensu_secrets_vault_provider_spec.rb
@@ -212,13 +212,27 @@ describe Puppet::Type.type(:sensu_secrets_vault_provider) do
 
   [
     :address,
-    :token,
     :version,
   ].each do |property|
     it "should require property when ensure => present" do
       config.delete(property)
       config[:ensure] = :present
       expect { resource }.to raise_error(Puppet::Error, /You must provide a #{property}/)
+    end
+  end
+
+  describe 'token validation' do
+    it 'should require either token or token_file' do
+      config.delete(:token)
+      config.delete(:token_file)
+      config[:ensure] = :present
+      expect { resource }.to raise_error(Puppet::Error, /You must provide either token/)
+    end
+    it 'should require mutually exclusive token and token_file' do
+      config[:token] = 'foo'
+      config[:token_file] = '/foo'
+      config[:ensure] = :present
+      expect { resource }.to raise_error(Puppet::Error, /token and token_file are mutually exclusive/)
     end
   end
 end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds the `token_file` parameter to `sensu_secrets_vault_provider` that allows the token to be read from a file rather than from the `token` property.