### PR TITLE
Fix sensu-backend init to work with non-default etc_dir

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -376,6 +376,7 @@ class sensu::backend (
 
   exec { 'sensu-backend init':
     path        => '/usr/bin:/bin:/usr/sbin:/sbin',
+    command     => "sensu-backend init --config-file ${sensu::etc_dir}/backend.yml",
     environment => [
       'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=admin',
       "SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=${sensu::password}",
@@ -384,7 +385,7 @@ class sensu::backend (
     # sensu-backend init will exit with code 3 if already run
     # If exit code is 3, do not need to run sensu-backend init again
     # If exit is not 3, run sensu-backend init
-    unless      => 'sensu-backend init ; [ $? -eq 3 ] && exit 0 || exit 1',
+    unless      => "sensu-backend init --config-file ${sensu::etc_dir}/backend.yml ; [ \$? -eq 3 ] && exit 0 || exit 1",
     require     => Sensu_api_validator['sensu'],
     before      => [
       Sensu_user['admin'],

--- a/spec/acceptance/00_backend_spec.rb
+++ b/spec/acceptance/00_backend_spec.rb
@@ -99,6 +99,7 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
       pp = <<-EOS
       class { '::sensu':
         etc_dir  => '/etc/sensugo',
+        ssl_dir  => '/etc/sensugo/ssl',
         password => 'supersecret',
       }
       class { 'sensu::backend':
@@ -108,6 +109,11 @@ describe 'sensu::backend class', if: ['base','full'].include?(RSpec.configuratio
       }
       EOS
 
+      # Cleanup sensu-backend to verify 'sensu-backend init' works with changed etc_dir
+      on node, 'puppet resource service sensu-backend ensure=stopped'
+      on node, 'rm -rf /etc/sensu'
+      on node, 'rm -rf /root/.config'
+      on node, 'rm -rf /var/lib/sensu/sensu-backend/etcd'
       if RSpec.configuration.sensu_use_agent
         site_pp = "node 'sensu-backend' { #{pp} }"
         puppetserver = hosts_as('puppetserver')[0]

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -240,12 +240,13 @@ describe 'sensu::backend', :type => :class do
         it {
           should contain_exec('sensu-backend init').with({
             'path'        => '/usr/bin:/bin:/usr/sbin:/sbin',
+            'command'     => 'sensu-backend init --config-file /etc/sensu/backend.yml',
             'environment' => [
               'SENSU_BACKEND_CLUSTER_ADMIN_USERNAME=admin',
               'SENSU_BACKEND_CLUSTER_ADMIN_PASSWORD=P@ssw0rd!',
             ],
             'returns'     => [0, 3],
-            'unless'      => 'sensu-backend init ; [ $? -eq 3 ] && exit 0 || exit 1',
+            'unless'      => 'sensu-backend init --config-file /etc/sensu/backend.yml ; [ $? -eq 3 ] && exit 0 || exit 1',
             'require'     => 'Sensu_api_validator[sensu]',
             'before'      => [
               'Sensu_user[admin]',


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes the the behavior when `sensu::etc_dir` is changed from the default value with regard to `sensu-backend init`

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1295