### PR TITLE
Fix descriptions

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -4846,25 +4846,19 @@ Generate targets from Sensu Go
 
 Data type: `Optional[String[1]]`
 
-
+Namespace to pull entities from
 
 ##### `subscription`
 
 Data type: `Optional[String[1]]`
 
-
+Find entities with this subscription
 
 ##### `interface_list`
 
 Data type: `Optional[Array]`
 
-
-
-##### `uri_ipaddress`
-
-Data type: `Optional[Boolean]`
-
-
+Interfaces to search if more than one present
 
 ### `silenced`
 

--- a/lib/puppet/type/sensu_agent_entity_config.rb
+++ b/lib/puppet/type/sensu_agent_entity_config.rb
@@ -54,15 +54,7 @@ DESC
   extend PuppetX::Sensu::Type
   add_autorequires()
 
-  ensurable do
-    newvalue(:present) do
-      @resource.provider.create
-    end
-    newvalue(:absent) do
-      @resource.provider.destroy
-    end
-    defaultto(:present)
-  end
+  ensurable
 
   newparam(:name, :namevar => true) do
     desc <<-EOS

--- a/tasks/resolve_reference.json
+++ b/tasks/resolve_reference.json
@@ -3,16 +3,16 @@
   "input_method": "stdin",
   "parameters": {
     "namespace": {
+      "description": "Namespace to pull entities from",
       "type": "Optional[String[1]]"
     },
     "subscription": {
+      "description": "Find entities with this subscription",
       "type": "Optional[String[1]]"
     },
     "interface_list": {
+      "description": "Interfaces to search if more than one present",
       "type": "Optional[Array]"
-    },
-    "uri_ipaddress": {
-      "type": "Optional[Boolean]"
     }
   }
 }

--- a/tasks/resolve_reference.rb
+++ b/tasks/resolve_reference.rb
@@ -22,7 +22,7 @@ class SensuResolveReference
     entities
   end
 
-  def self.entities_to_targets(entities, interface_list, uri_ipaddress)
+  def self.entities_to_targets(entities, interface_list)
     targets = []
     entities.each do |e|
       target = {}
@@ -65,7 +65,6 @@ class SensuResolveReference
     namespace = params['namespace']
     subscription = params['subscription']
     interface_list = params['interface_list']
-    uri_ipaddress = params['uri_ipaddress']
 
     entities = sensuctl_entities(namespace)
 
@@ -73,7 +72,7 @@ class SensuResolveReference
       entities.select! { |e| e['subscriptions'].include?(subscription) }
     end
 
-    targets = entities_to_targets(entities, interface_list, uri_ipaddress)
+    targets = entities_to_targets(entities, interface_list)
     targets
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use `ensurable` without a block, which has the same result.  I think the block was used during early development before the final solution for provider was created.  The Puppet code responsible for `ensuable` maintains what was deleted here.

The `uri_address` for the resolve_reference task never did anything and was never documented in README where we document what that task does.  I am not sure why it was ever present but it doesn't do anything.

## Related Issue
<!--- Suggest creating an issue first and then referencing it here. -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Fixes #1300
