### PR TITLE
Support refresh of sensu_secrets_vault_provider token_file

### DIFF
--- a/lib/puppet/provider/sensu_secrets_vault_provider/sensu_api.rb
+++ b/lib/puppet/provider/sensu_secrets_vault_provider/sensu_api.rb
@@ -95,8 +95,8 @@ Puppet::Type.type(:sensu_secrets_vault_provider).provide(:sensu_api, :parent => 
     @property_hash[:ensure] = :present
   end
 
-  def flush
-    if !@property_flush.empty?
+  def flush(update = false)
+    if !@property_flush.empty? || update
       spec = {}
       metadata = {}
       metadata[:name] = resource[:name]

--- a/lib/puppet/provider/sensu_secrets_vault_provider/sensuctl.rb
+++ b/lib/puppet/provider/sensu_secrets_vault_provider/sensuctl.rb
@@ -92,8 +92,8 @@ Puppet::Type.type(:sensu_secrets_vault_provider).provide(:sensuctl, :parent => P
     @property_hash[:ensure] = :present
   end
 
-  def flush
-    if !@property_flush.empty?
+  def flush(update = false)
+    if !@property_flush.empty? || update
       spec = {}
       metadata = {}
       metadata[:name] = resource[:name]

--- a/lib/puppet/type/sensu_secrets_vault_provider.rb
+++ b/lib/puppet/type/sensu_secrets_vault_provider.rb
@@ -61,7 +61,18 @@ DESC
   end
 
   newparam(:token_file) do
-    desc 'Path to file that contains token to use for authentication.'
+    desc <<-EOS
+    Path to file that contains token to use for authentication.
+
+    To update this resource with new content for the file, requires sending notify event from the file resource.
+
+    Example:
+
+    file { '/etc/sensu/provider-secret':
+      ...
+      notify => Sensu_secrets_vault_provider['my-vault'],
+    }
+    EOS
   end
 
   newproperty(:version) do
@@ -140,6 +151,12 @@ DESC
         end
       end
       value
+    end
+  end
+
+  def refresh
+    if provider.exists? && @parameters[:ensure].value.to_s == 'present' && ! @parameters[:token_file].value.nil?
+      provider.flush(true)
     end
   end
 


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Allow the file for sensu_secrets_vault_provider's token_file parameter to trigger a refresh that will force an update of the token value.

The acceptance tests were changed so that the resources testing token_file had only change taking place being the token_file contents to verify that a refresh event triggers the change without other properties triggering a change.  The changes of other properties are tested with other resources in the same tests.
