### PR TITLE
Drop Puppet 5 support, update module dependency version ranges

### DIFF
--- a/.github/workflows/acceptance-cluster.yaml
+++ b/.github/workflows/acceptance-cluster.yaml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         puppet:
-        - puppet5
         - puppet6
         - puppet7
         use_agent:

--- a/.github/workflows/acceptance-full.yaml
+++ b/.github/workflows/acceptance-full.yaml
@@ -20,7 +20,6 @@ jobs:
         - types
         - examples
         puppet:
-        - puppet5
         - puppet6
         - puppet7
         use_agent:
@@ -28,10 +27,6 @@ jobs:
         ci_build:
         - no
         include:
-        - sensu_mode: types
-          puppet: puppet5
-          use_agent: yes
-          ci_build: no
         - sensu_mode: types
           puppet: puppet6
           use_agent: yes

--- a/.github/workflows/acceptance-full.yaml
+++ b/.github/workflows/acceptance-full.yaml
@@ -35,9 +35,8 @@ jobs:
           puppet: puppet7
           use_agent: yes
           ci_build: no
-        # TODO: Uncomment once bolt tests are updated to work with latest bolt
-        #- sensu_mode: bolt
-        #  puppet: puppet6
+        - sensu_mode: bolt
+          puppet: puppet6
     env:
       BEAKER_debug: true
     name: ${{ matrix.set }} ${{ matrix.puppet }} (mode=${{ matrix.sensu_mode }} use-agent=${{ matrix.use_agent }} CI=${{ matrix.ci_build }})

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -25,19 +25,13 @@ jobs:
         - amazonlinux-2
         - amazonlinux-201803
         puppet:
-        - puppet5
         - puppet6
         - puppet7
         ci_build:
         - no
         exclude:
-        - puppet: puppet5
-          ci_build: yes
         - puppet: puppet7
           ci_build: yes
-        # Puppet 5 is not built for Ubuntu 20.04
-        - puppet: puppet5
-          set: ubuntu-2004
     env:
       BEAKER_debug: true
     name: ${{ matrix.set }} ${{ matrix.puppet }} (ci=${{ matrix.ci_build }})

--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -16,10 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-        - ruby: 2.4.9
-          puppet: 5
-          fixtures: .fixtures.yml
-          allow_failure: false
         - ruby: 2.5.7
           puppet: 6
           fixtures: .fixtures.yml
@@ -28,10 +24,6 @@ jobs:
           puppet: 7
           fixtures: .fixtures.yml
           allow_failure: false
-        - ruby: 2.4.9
-          puppet: 5
-          fixtures: .fixtures-latest.yml
-          allow_failure: true
         - ruby: 2.5.7
           puppet: 6
           fixtures: .fixtures-latest.yml

--- a/README.md
+++ b/README.md
@@ -181,14 +181,14 @@ Plugin sync is required if the custom sensu types and providers are used.
 #### Soft module dependencies
 
 For systems using `apt`:
-  * [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module (`>= 5.0.1 < 8.0.0`)
+  * [puppetlabs/apt](https://forge.puppet.com/puppetlabs/apt) module (`>= 5.0.1 < 9.0.0`)
 
 For systems using `yum` and Puppet >= 6.0.0:
   * [puppetlabs/yumrepo_core](https://forge.puppet.com/puppetlabs/yumrepo_core) module (`>= 1.0.1 < 2.0.0`)
 
 For Windows:
-  * [puppetlabs/chocolatey](https://forge.puppet.com/puppetlabs/chocolatey) module (`>= 3.0.0 < 5.0.0`)
-  * [puppet/windows_env](https://forge.puppet.com/puppet/windows_env) module (`>= 3.0.0 < 4.0.0`)
+  * [puppetlabs/chocolatey](https://forge.puppet.com/puppetlabs/chocolatey) module (`>= 3.0.0 < 7.0.0`)
+  * [puppet/windows_env](https://forge.puppet.com/puppet/windows_env) module (`>= 3.0.0 < 5.0.0`)
   * [puppet/archive](https://forge.puppet.com/puppet/archive) module (`>= 3.0.0 < 5.0.0`)
 
 ### Beginning with Sensu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,11 +27,11 @@ install:
 - ps: Copy-Item -Path "${ENV:APPVEYOR_BUILD_FOLDER}/lib/facter" -Destination C:/ProgramData/PuppetLabs/puppet/cache/lib/facter -Recurse
 - set PATH=C:\Program Files\Puppet Labs\Puppet\bin;%PATH%
 - puppet --version
-- puppet module install puppetlabs-stdlib
-- puppet module install puppetlabs-chocolatey
-- puppet module install puppet-archive
-- puppet module install puppet-windows_env
-- puppet module install richardc-datacat
+- puppet module install puppetlabs-stdlib --version ">= 5.1.0 < 7.0.0"
+- puppet module install puppetlabs-chocolatey --version ">= 3.0.0 < 7.0.0"
+- puppet module install puppet-archive --version ">= 3.0.0 < 5.0.0"
+- puppet module install puppet-windows_env --version ">= 3.0.0 < 5.0.0"
+- puppet module install richardc-datacat --version ">= 0.6.0 < 2.0.0"
 - puppet config set --section main certname sensu_agent
 - facter -p --debug
 - ruby -v
@@ -48,10 +48,6 @@ image:
   - Visual Studio 2019
 environment:
   matrix:
-    - PUPPET_GEM_VERSION: '~>5.x'
-      FACTER_GEM_VERSION: '~>2.x'
-      PUPPET_REPO: puppet5
-      RUBY_VERSION: 24-x64
     - PUPPET_GEM_VERSION: '~>6.x'
       FACTER_GEM_VERSION: '~>2.x'
       PUPPET_REPO: puppet6

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -216,14 +216,6 @@ class sensu::agent (
     $_package_source = undef
   }
 
-  # See https://docs.sensu.io/sensu-go/latest/installation/upgrade/
-  # Only necessary for Puppet < 6.1.0,
-  # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
-  if versioncmp($facts['puppetversion'],'6.1.0') < 0 and $facts['service_provider'] == 'systemd' {
-    Package['sensu-go-agent'] ~> Class['systemd::systemctl::daemon_reload']
-    Class['systemd::systemctl::daemon_reload'] -> Service['sensu-agent']
-  }
-
   package { 'sensu-go-agent':
     ensure   => $_version,
     name     => $package_name,

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -236,14 +236,6 @@ class sensu::backend (
     include sensu::backend::agent_resources
   }
 
-  # See https://docs.sensu.io/sensu-go/latest/installation/upgrade/
-  # Only necessary for Puppet < 6.1.0,
-  # See https://github.com/puppetlabs/puppet/commit/f8d5c60ddb130c6429ff12736bfdb4ae669a9fd4
-  if versioncmp($facts['puppetversion'],'6.1.0') < 0 and $facts['service_provider'] == 'systemd' {
-    Package['sensu-go-backend'] ~> Class['systemd::systemctl::daemon_reload']
-    Class['systemd::systemctl::daemon_reload'] -> Service['sensu-backend']
-  }
-
   sensu_user { 'admin':
     ensure                    => 'present',
     password                  => $sensu::password,

--- a/metadata.json
+++ b/metadata.json
@@ -18,11 +18,11 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.4.0 < 7.0.0"
+      "version_requirement": ">= 6.4.0 < 8.0.0"
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -77,7 +77,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 5.0.0 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 8.0.0"
     }
   ],
   "tags": [

--- a/spec/acceptance/sensu_bolt_tasks_spec.rb
+++ b/spec/acceptance/sensu_bolt_tasks_spec.rb
@@ -306,7 +306,6 @@ describe 'sensu bolt inventory', if: RSpec.configuration.sensu_mode == 'bolt' do
       apply_manifest_on(backend, pp, :catch_failures => true)
       apply_manifest_on(agent, agent_pp, :catch_failures => true)
       inventory_cfg1 = <<-EOS
-version: 2
 groups:
   - name: linux
     targets:

--- a/spec/classes/agent_spec.rb
+++ b/spec/classes/agent_spec.rb
@@ -36,14 +36,6 @@ describe 'sensu::agent', :type => :class do
         end
         it { should_not contain_archive('sensu-go-agent.msi') }
 
-        context 'on systemd host', if: (facts[:kernel] == 'Linux' && Puppet.version.to_s =~ %r{^5}) do
-          let(:facts) { facts.merge({:service_provider => 'systemd'}) }
-          it { should contain_package('sensu-go-agent').that_notifies('Class[systemd::systemctl::daemon_reload]') }
-          it { should contain_class('systemd::systemctl::daemon_reload').that_comes_before('Service[sensu-agent]') }
-        end
-        it { should_not contain_package('sensu-go-agent').that_notifies('Class[systemd::systemctl::daemon_reload]') }
-        it { should_not contain_class('systemd::systemctl::daemon_reload').that_comes_before('Service[sensu-agent]') }
-
         it {
           should contain_sensu_agent_entity_setup('puppet').with({
             'url'       => 'https://localhost:8080',

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -22,14 +22,6 @@ describe 'sensu::backend', :type => :class do
         it { should contain_class('sensu::backend::agent_resources') }
         it { should_not contain_class('sensu::backend::datastore::postgresql') }
 
-        context 'on systemd host', if: Puppet.version.to_s =~ %r{^5} do
-          let(:facts) { facts.merge({:service_provider => 'systemd'}) }
-          it { should contain_package('sensu-go-backend').that_notifies('Class[systemd::systemctl::daemon_reload]') }
-          it { should contain_class('systemd::systemctl::daemon_reload').that_comes_before('Service[sensu-backend]') }
-        end
-        it { should_not contain_package('sensu-go-backend').that_notifies('Class[systemd::systemctl::daemon_reload]') }
-        it { should_not contain_class('systemd::systemctl::daemon_reload').that_comes_before('Service[sensu-backend]') }
-
         it { should have_sensu_user_resource_count(3) }
         it {
           should contain_sensu_user('admin').with({

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -6,10 +6,9 @@ require 'simp/beaker_helpers'
 
 include Simp::BeakerHelpers
 run_puppet_install_helper
-install_module_dependencies
 install_module
 pluginsync_on(hosts)
-collection = ENV['BEAKER_PUPPET_COLLECTION'] || 'puppet5'
+collection = ENV['BEAKER_PUPPET_COLLECTION'] || 'puppet6'
 project_dir = File.absolute_path(File.join(File.dirname(__FILE__), '..'))
 
 RSpec.configure do |c|
@@ -59,21 +58,18 @@ RSpec.configure do |c|
 
   # Configure all nodes in nodeset
   c.before :suite do
-    # Install sensuclassic to ensure no conflicts
-    on setup_nodes, puppet('module', 'install', 'sensu-sensuclassic'), { :acceptable_exit_codes => [0,1] }
     # Install soft module dependencies
-    on setup_nodes, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 8.0.0"'), { :acceptable_exit_codes => [0,1] }
-    if collection == 'puppet6'
-      on setup_nodes, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
-    end
+    on setup_nodes, puppet('module', 'install', 'puppetlabs-apt', '--version', '">= 5.0.1 < 9.0.0"'), { :acceptable_exit_codes => [0,1] }
+    on setup_nodes, puppet('module', 'install', 'puppetlabs-yumrepo_core', '--version', '">= 1.0.1 < 2.0.0"'), { :acceptable_exit_codes => [0,1] }
     # Dependencies only needed to test some examples
     if RSpec.configuration.sensu_mode == 'examples'
-      on setup_nodes, puppet('module', 'install', 'puppet-logrotate', '--version', '4.0.0')
+      on setup_nodes, puppet('module', 'install', 'puppet-logrotate', '--version', '5.0.0')
       on setup_nodes, puppet('module', 'install', 'saz-rsyslog', '--version', '5.0.0')
       # rsyslog template relies on rsyslog_version fact so pre-install rsyslog
       # to keep things idempotent within minimal docker containers
       on hosts, puppet('resource', 'package', 'rsyslog', 'ensure=present')
     end
+    install_module_dependencies
     ssldir = File.join(project_dir, 'tests/ssl')
     scp_to(hosts, ssldir, '/etc/puppetlabs/puppet/')
     hosts.each do |host|

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -122,17 +122,24 @@ EOS
     end
 
     # Setup Puppet Bolt
-    if RSpec.configuration.sensu_mode == 'full'
+    if RSpec.configuration.sensu_mode == 'bolt'
       on setup_nodes, puppet("resource package puppet-bolt ensure=installed")
-      bolt_cfg = <<-EOS
-modulepath: "/etc/puppetlabs/code/modules:/etc/puppetlabs/code/environments/production/modules"
-ssh:
-  host-key-check: false
-  user: root
-  password: root
+      bolt_inventory_cfg = <<-EOS
+config:
+  transport: ssh
+  ssh:
+    host-key-check: false
+    user: root
+    password: root
+EOS
+      bolt_project_cfg = <<-EOS
+modulepath:
+- "/etc/puppetlabs/code/modules"
+- "/etc/puppetlabs/code/environments/production/modules"
 EOS
       on setup_nodes, 'mkdir -p -m 0755 /root/.puppetlabs/bolt'
-      create_remote_file(setup_nodes, '/root/.puppetlabs/bolt/bolt.yaml', bolt_cfg)
+      create_remote_file(setup_nodes, '/root/.puppetlabs/bolt/inventory.yaml', bolt_inventory_cfg)
+      create_remote_file(setup_nodes, '/root/.puppetlabs/bolt/bolt-project.yaml', bolt_project_cfg)
     end
   end
 end

--- a/tests/provision_basic_debian.sh
+++ b/tests/provision_basic_debian.sh
@@ -31,7 +31,7 @@ apt-key adv --fetch-keys http://apt.puppetlabs.com/DEB-GPG-KEY-puppet
 apt-get -y install wget
 
 # install and configure puppet
-deb_install http://apt.puppetlabs.com/puppet5-release-${CODENAME}.deb
+deb_install http://apt.puppetlabs.com/puppet6-release-${CODENAME}.deb
 apt-get update
 apt-get -y install puppet-agent
 ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
@@ -52,8 +52,8 @@ EOF
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version ">= 5.1.0 < 7.0.0"
-puppet module install puppetlabs/apt --version ">= 5.0.1 < 8.0.0"
+puppet module install puppetlabs/stdlib --version ">= 5.1.0 < 8.0.0"
+puppet module install puppetlabs/apt --version ">= 5.0.1 < 9.0.0"
 puppet module install richardc-datacat --version ">= 0.6.2 < 2.0.0"
 
 puppet resource host sensu-backend.example.com ensure=present ip=192.168.52.10 host_aliases=sensu-backend

--- a/tests/provision_basic_el.sh
+++ b/tests/provision_basic_el.sh
@@ -21,7 +21,7 @@ rpm -qa | grep -q puppet
 if [ $? -ne 0 ]
 then
 
-    rpm_install http://yum.puppetlabs.com/puppet5-release-el-${release}.noarch.rpm
+    rpm_install http://yum.puppetlabs.com/puppet6-release-el-${release}.noarch.rpm
     yum -y install puppet-agent
     ln -s /opt/puppetlabs/puppet/bin/puppet /usr/bin/puppet
 fi
@@ -30,7 +30,7 @@ fi
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version ">= 5.1.0 < 7.0.0"
+puppet module install puppetlabs/stdlib --version ">= 5.1.0 < 8.0.0"
 puppet module install richardc-datacat --version ">= 0.6.2 < 2.0.0"
 
 puppet resource host sensu-backend.example.com ensure=present ip=192.168.52.10 host_aliases=sensu-backend

--- a/tests/provision_basic_win.ps1
+++ b/tests/provision_basic_win.ps1
@@ -5,7 +5,7 @@ if ( Get-Command "puppet" -ErrorAction SilentlyContinue ) {
   [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
   Set-ExecutionPolicy Bypass -Scope Process -Force; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))
   # Install puppet
-  iex "choco install puppet-agent --yes --version=5.5.19"
+  iex "choco install puppet-agent --yes --version=6.21.1"
 }
 
 $hiera_file = "C:\ProgramData\PuppetLabs\puppet\etc\hiera.yaml"


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Drop Puppet 5 support, that version is now EOL.
Update module dependency version ranges.
Fix and add back Bolt acceptance tests