### PR TITLE
Update links to Sensu docs pages in README and REFERENCE

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Breaking changes:
 
 ## Setup
 
-### What sensu effects
+### What sensu affects
 
 This module will install packages, create configuration and start services necessary to manage Sensu agents and backend.
 
@@ -549,7 +549,7 @@ The types `sensu_ad_auth` and `sensu_ldap_auth` require a valid enterprise licen
 
 ### Contact routing
 
-See [Sensu Go - Contact Routing](https://docs.sensu.io/sensu-go/latest/guides/contact-routing/) for details. The following is one way to configure contact routing in Puppet.
+See [Sensu Go - Route alerts with event filters](https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-filter/route-alerts/) for details. The following is one way to configure contact routing in Puppet.
 
 Add the sensu-go-has-contact-filter bonsai asset:
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -490,7 +490,7 @@ Data type: `Array[String[1]]`
 The agent entity redact list
 Passing `redact` as part of `config_hash` takes precedence
 Defaults come from Sensu documentation:
-https://docs.sensu.io/sensu-go/latest/reference/agent/#security-configuration-flags
+https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#security-configuration-flags
 
 Default value: `['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret']`
 
@@ -746,7 +746,7 @@ Data type: `Boolean`
 Sets if the Sensu agent user should be disabled
 Not applicable if `manage_agent_user` is `false`
 This is useful if using agent TLS authentication
-See https://docs.sensu.io/sensu-go/latest/guides/securing-sensu/#sensu-agent-tls-authentication
+See [Sensu Go - Secure Sensu](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication)
 
 Default value: ``false``
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -490,7 +490,7 @@ Data type: `Array[String[1]]`
 The agent entity redact list
 Passing `redact` as part of `config_hash` takes precedence
 Defaults come from Sensu documentation:
-https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#security-configuration-flags
+https://docs.sensu.io/sensu-go/latest/reference/agent/#security-configuration-flags
 
 Default value: `['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret']`
 
@@ -746,7 +746,7 @@ Data type: `Boolean`
 Sets if the Sensu agent user should be disabled
 Not applicable if `manage_agent_user` is `false`
 This is useful if using agent TLS authentication
-See [Sensu Go - Secure Sensu](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication)
+See https://docs.sensu.io/sensu-go/latest/guides/securing-sensu/#sensu-agent-tls-authentication
 
 Default value: ``false``
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -66,7 +66,7 @@
 #   The agent entity redact list
 #   Passing `redact` as part of `config_hash` takes precedence
 #   Defaults come from Sensu documentation:
-#   https://docs.sensu.io/sensu-go/latest/reference/agent/#security-configuration-flags
+#   https://docs.sensu.io/sensu-go/latest/observability-pipeline/observe-schedule/agent/#security-configuration-flags
 # @param show_diff
 #   Sets show_diff parameter for agent.yml configuration file
 # @param log_file

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -50,7 +50,7 @@
 #   Sets if the Sensu agent user should be disabled
 #   Not applicable if `manage_agent_user` is `false`
 #   This is useful if using agent TLS authentication
-#   See https://docs.sensu.io/sensu-go/latest/guides/securing-sensu/#sensu-agent-tls-authentication
+#   See [Sensu Go - Secure Sensu](https://docs.sensu.io/sensu-go/latest/operations/deploy-sensu/secure-sensu/#optional-configure-sensu-agent-mtls-authentication)
 # @param show_diff
 #   Sets show_diff parameter for backend.yml configuration file
 # @param license_source


### PR DESCRIPTION
## Description
- In README.md:
    - Updates Sensu docs link for contact routing
    - Changes "affect" to "effect" to fix broken TOC link
- In manifest backend.pp:
    - Updates Sensu docs link for securing Sensu agent TLS
- In manifest agent.pp:
    - Updates Sensu docs link for agent security config flags

## Related Issue
None

## Motivation and Context
I found these backlinks because I am working on redirects in the Sensu docs.
