### PR TITLE
Support HTTP proxies with sensu_bonsai_asset

### DIFF
--- a/.github/workflows/acceptance-cluster.yaml
+++ b/.github/workflows/acceptance-cluster.yaml
@@ -39,7 +39,7 @@ jobs:
       if: ${{ env.SENSU_SECRETS_PASSWORD != null }}
       run: ./tests/decrypt-secrets.sh
     - name: Run tests
-      run: bundle exec rake beaker
+      run: bundle exec rake acceptance
       env:
         BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet }}
         BEAKER_set: centos-7-cluster

--- a/.github/workflows/acceptance-full.yaml
+++ b/.github/workflows/acceptance-full.yaml
@@ -54,7 +54,7 @@ jobs:
       if: ${{ env.SENSU_SECRETS_PASSWORD != null }}
       run: ./tests/decrypt-secrets.sh
     - name: Run tests
-      run: bundle exec rake beaker
+      run: bundle exec rake acceptance
       env:
         BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet }}
         BEAKER_set: centos-7

--- a/.github/workflows/acceptance.yaml
+++ b/.github/workflows/acceptance.yaml
@@ -49,7 +49,7 @@ jobs:
       if: ${{ env.SENSU_SECRETS_PASSWORD != null }}
       run: ./tests/decrypt-secrets.sh
     - name: Run tests
-      run: bundle exec rake beaker
+      run: bundle exec rake acceptance
       env:
         BEAKER_PUPPET_COLLECTION: ${{ matrix.puppet }}
         BEAKER_set: ${{ matrix.set }}

--- a/lib/puppet/provider/sensu_bonsai_asset/sensu_api.rb
+++ b/lib/puppet/provider/sensu_bonsai_asset/sensu_api.rb
@@ -44,8 +44,8 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensu_api, :parent => Puppet::Pr
     end
   end
 
-  def self.latest_version(namespace, name)
-    get_bonsai_latest_version(namespace, name)
+  def self.latest_version(namespace, name, opts = {})
+    get_bonsai_latest_version(namespace, name, opts)
   end
 
   def exists?
@@ -72,10 +72,13 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensu_api, :parent => Puppet::Pr
       method = 'post'
       url = "assets"
     end
+    proxy_opts = {}
+    proxy_opts[:http_proxy] = resource[:bonsai_http_proxy] if resource[:bonsai_http_proxy]
+    proxy_opts[:no_proxy] = resource[:bonsai_no_proxy] if resource[:bonsai_no_proxy]
     if version && version.to_s != 'latest'
       version_match = version
     else
-      version_match = self.class.latest_version(resource[:bonsai_namespace], resource[:bonsai_name])
+      version_match = self.class.latest_version(resource[:bonsai_namespace], resource[:bonsai_name], proxy_opts)
     end
     bonsai_asset_data = get_bonsai_asset(name)
     if bonsai_asset_data.nil? || bonsai_asset_data.empty?
@@ -105,7 +108,7 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensu_api, :parent => Puppet::Pr
     opt = {
       :method => method,
       :namespace => resource[:namespace],
-    }
+    }.merge(proxy_opts)
     api_request(url, asset, opt)
   end
 

--- a/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
+++ b/lib/puppet/provider/sensu_bonsai_asset/sensuctl.rb
@@ -46,8 +46,8 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensuctl, :parent => Puppet::Pro
     end
   end
 
-  def self.latest_version(namespace, name)
-    Puppet::Provider::SensuAPI.get_bonsai_latest_version(namespace, name)
+  def self.latest_version(namespace, name, opts = {})
+    Puppet::Provider::SensuAPI.get_bonsai_latest_version(namespace, name, opts)
   end
 
   def exists?
@@ -76,8 +76,14 @@ Puppet::Type.type(:sensu_bonsai_asset).provide(:sensuctl, :parent => Puppet::Pro
     cmd << resource[:rename]
     cmd << '--namespace'
     cmd << resource[:namespace]
+    opts = {}
+    if resource[:bonsai_http_proxy] || resource[:bonsai_no_proxy]
+      opts[:custom_environment] = {}
+      opts[:custom_environment]['http_proxy'] = resource[:bonsai_http_proxy] if resource[:bonsai_http_proxy]
+      opts[:custom_environment]['no_proxy'] = resource[:bonsai_no_proxy] if resource[:bonsai_no_proxy]
+    end
     begin
-      sensuctl(cmd)
+      sensuctl(cmd, opts)
     rescue Exception => e
       raise Puppet::Error, "#{cmd.join(' ')} failed\nError message: #{e.message}"
     end

--- a/lib/puppet/type/sensu_bonsai_asset.rb
+++ b/lib/puppet/type/sensu_bonsai_asset.rb
@@ -69,7 +69,10 @@ DESC
         should = @should
       end
       if should == :latest || should == 'latest'
-        latest_version = provider.class.latest_version(@resource[:bonsai_namespace], @resource[:bonsai_name])
+        opts = {}
+        opts[:http_proxy] = @resource[:bonsai_http_proxy] if @resource[:bonsai_http_proxy]
+        opts[:no_proxy] = @resource[:bonsai_no_proxy] if @resource[:bonsai_no_proxy]
+        latest_version = provider.class.latest_version(@resource[:bonsai_namespace], @resource[:bonsai_name], opts)
         @latest = latest_version
         return is == @latest
       else
@@ -95,6 +98,14 @@ DESC
     defaultto do
       "#{@resource[:bonsai_namespace]}/#{@resource[:bonsai_name]}"
     end
+  end
+
+  newparam(:bonsai_http_proxy) do
+    desc "Proxy to use for Bonsai HTTP requests"
+  end
+
+  newparam(:bonsai_no_proxy) do
+    desc "Addresses to not proxy when making bonsai HTTP requests"
   end
 
   # Generate sensu_asset resource to avoid resource purging deleting

--- a/spec/unit/provider/sensu_bonsai_asset/sensu_api_spec.rb
+++ b/spec/unit/provider/sensu_bonsai_asset/sensu_api_spec.rb
@@ -32,7 +32,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensu_api) do
 
   describe 'self.latest_version' do
     it 'should return latest version' do
-      allow(Puppet::Provider::SensuAPI).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler').and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
+      allow(Puppet::Provider::SensuAPI).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler', {}).and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
       latest_version = provider.latest_version('sensu', 'sensu-pagerduty-handler')
       expect(latest_version).to eq('1.2.0')
     end

--- a/spec/unit/provider/sensu_bonsai_asset/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_bonsai_asset/sensuctl_spec.rb
@@ -25,7 +25,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensuctl) do
 
   describe 'self.latest_version' do
     it 'should return latest version' do
-      allow(Puppet::Provider::SensuAPI).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler').and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
+      allow(Puppet::Provider::SensuAPI).to receive(:get_bonsai_asset).with('sensu/sensu-pagerduty-handler', {}).and_return(JSON.parse(my_fixture_read('bonsai_asset.json')))
       latest_version = provider.latest_version('sensu', 'sensu-pagerduty-handler')
       expect(latest_version).to eq('1.2.0')
     end
@@ -34,7 +34,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensuctl) do
   describe 'create' do
     it 'should create a bonsai_asset' do
       expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
-      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd, {})
       resource.provider.create
       property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
@@ -42,7 +42,7 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensuctl) do
     it 'should create a bonsai_asset for latest' do
       config[:version] = 'latest'
       expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
-      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd, {})
       resource.provider.create
       property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
@@ -50,7 +50,15 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensuctl) do
     it 'should create a bonsai_asset for a version' do
       config[:version] = '1.2.0'
       expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler:1.2.0','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
-      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd, {})
+      resource.provider.create
+      property_hash = resource.provider.instance_variable_get("@property_hash")
+      expect(property_hash[:ensure]).to eq(:present)
+    end
+    it 'supports HTTP proxy requests' do
+      config[:bonsai_http_proxy] = 'foo.bar'
+      expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd, {:custom_environment => {'http_proxy' => 'foo.bar'}})
       resource.provider.create
       property_hash = resource.provider.instance_variable_get("@property_hash")
       expect(property_hash[:ensure]).to eq(:present)
@@ -60,13 +68,13 @@ describe Puppet::Type.type(:sensu_bonsai_asset).provider(:sensuctl) do
   describe 'flush' do
     it 'should install latest bonsai asset' do
       expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
-      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd, {})
       resource.provider.version = 'latest'
       resource.provider.flush
     end
     it 'should install a version of bonsai asset' do
       expected_cmd = ['asset','add','sensu/sensu-pagerduty-handler:1.2.0','--rename','sensu/sensu-pagerduty-handler','--namespace','default']
-      expect(resource.provider).to receive(:sensuctl).with(expected_cmd)
+      expect(resource.provider).to receive(:sensuctl).with(expected_cmd, {})
       resource.provider.version = '1.2.0'
       resource.provider.flush
     end


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

Add `bonsai_http_proxy` and `bonsai_no_proxy` to `sensu_bonsai_asset` to support HTTP proxy configurations when fetching Bonsai assets.