### PR TITLE
Set SensuAPIValidator timeout comments to 30 seconds

### DIFF
--- a/lib/puppet/type/sensu_api_validator.rb
+++ b/lib/puppet/type/sensu_api_validator.rb
@@ -42,7 +42,7 @@ DESC
   end
 
   newparam(:timeout) do
-    desc 'The max number of seconds that the validator should wait before giving up and deciding that sensu_api is not running; defaults to 15 seconds.'
+    desc 'The max number of seconds that the validator should wait before giving up and deciding that sensu_api is not running; defaults to 30 seconds.'
     defaultto 30
 
     validate do |value|


### PR DESCRIPTION
Match comments and REFERENCE file.


# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->
Comments in `sensu_api_validator.rb` and REFERENCE.md files say that the timeout is set to 15 but it's actually set to 30.
Set it to 15 to keep it consistent.