### PR TITLE
Adding the option to opt out on entity validation

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -74,7 +74,8 @@
 #   Defaults to `C:\ProgramData\sensu\log\sensu-agent.log`
 # @param agent_entity_config_provider
 #   The provider to use when managing sensu_agent_entity_config resources
-#
+# @param validate_agent_entity
+#   Determines if sensuctl and sensu_api types will validate if the entity exists within its namespace
 class sensu::agent (
   Optional[String] $version = undef,
   Optional[String[1]] $package_source = undef,
@@ -98,6 +99,7 @@ class sensu::agent (
   Boolean $show_diff = true,
   Optional[Stdlib::Absolutepath] $log_file = undef,
   Enum['sensuctl','sensu_api'] $agent_entity_config_provider = 'sensu_api',
+  Boolean $validate_agent_entity = true,
 ) {
 
   include sensu
@@ -295,9 +297,11 @@ class sensu::agent (
     subscribe => $service_subscribe,
   }
 
-  sensu_agent_entity_validator { $config['name']:
-    ensure    => 'present',
-    namespace => $config['namespace'],
-    provider  => 'sensu_api',
+  if $validate_agent_entity {
+    sensu_agent_entity_validator { $config['name']:
+      ensure    => 'present',
+      namespace => $config['namespace'],
+      provider  => 'sensu_api',
+    }
   }
 }

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -15,10 +15,12 @@ class sensu::api {
     validate_namespaces => $sensu::validate_namespaces,
   }
 
-  sensu_api_validator { 'sensu':
-    ensure           => 'present',
-    sensu_api_server => $sensu::api_host,
-    sensu_api_port   => $sensu::api_port,
-    use_ssl          => $sensu::use_ssl,
+  if ! $sensu::agent::agent_managed_entity {
+    sensu_api_validator { 'sensu':
+      ensure           => 'present',
+      sensu_api_server => $sensu::api_host,
+      sensu_api_port   => $sensu::api_port,
+      use_ssl          => $sensu::use_ssl,
+    }
   }
 }


### PR DESCRIPTION
# Pull Request Checklist

Adding the option to opt out on entity validation

## Description

When the agent is configured to be self managed, both connecting to the Sensu API for agent configuration and validation gets in the way.

## Related Issue

https://github.com/sensu/sensu-puppet/issues/1322

Fixes # .

## Motivation and Context

I use Sensu myself and I've always deployed agents to be "standalone" and would like to be able to continue that way.

## How Has This Been Tested?

Deployed it within my org, added:
```
sensu::agent::agent_managed_entity: true
sensu::agent::validate_agent_entity: false
```
to my Hiera-config, and have thing working as before

## General

I might need some help in this PR with tests etc.
