### PR TITLE
allow disable api validation

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -119,6 +119,7 @@ The following parameters are available in the `sensu` class:
 * [`agent_password`](#-sensu--agent_password)
 * [`agent_entity_config_password`](#-sensu--agent_entity_config_password)
 * [`validate_namespaces`](#-sensu--validate_namespaces)
+* [`validate_api`](#-sensu--validate_api)
 
 ##### <a name="-sensu--version"></a>`version`
 
@@ -276,6 +277,14 @@ Default value: `undef`
 Data type: `Boolean`
 
 Determines if sensuctl and sensu_api types will validate their namespace exists
+
+Default value: `true`
+
+##### <a name="-sensu--validate_api"></a>`validate_api`
+
+Data type: `Boolean`
+
+Determines if sensu_api types will validate the connexion
 
 Default value: `true`
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -295,9 +295,11 @@ class sensu::agent (
     subscribe => $service_subscribe,
   }
 
-  sensu_agent_entity_validator { $config['name']:
-    ensure    => 'present',
-    namespace => $config['namespace'],
-    provider  => 'sensu_api',
+  if ! $sensu::agent::agent_managed_entity {
+    sensu_agent_entity_validator { $config['name']:
+      ensure    => 'present',
+      namespace => $config['namespace'],
+      provider  => 'sensu_api',
+    }
   }
 }

--- a/manifests/api.pp
+++ b/manifests/api.pp
@@ -8,17 +8,19 @@
 class sensu::api {
   include sensu
 
-  sensu_api_config { 'sensu':
-    url                 => $sensu::api_url,
-    username            => 'admin',
-    password            => $sensu::password,
-    validate_namespaces => $sensu::validate_namespaces,
-  }
+  if $sensu::validate_api {
+    sensu_api_config { 'sensu':
+      url                 => $sensu::api_url,
+      username            => 'admin',
+      password            => $sensu::password,
+      validate_namespaces => $sensu::validate_namespaces,
+    }
 
-  sensu_api_validator { 'sensu':
-    ensure           => 'present',
-    sensu_api_server => $sensu::api_host,
-    sensu_api_port   => $sensu::api_port,
-    use_ssl          => $sensu::use_ssl,
+    sensu_api_validator { 'sensu':
+      ensure           => 'present',
+      sensu_api_server => $sensu::api_host,
+      sensu_api_port   => $sensu::api_port,
+      use_ssl          => $sensu::use_ssl,
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,8 @@
 #   Defaults to value used for `agent_password`.
 # @param validate_namespaces
 #   Determines if sensuctl and sensu_api types will validate their namespace exists
+# @param validate_api
+#   enable api validation
 class sensu (
   String $version = 'installed',
   Stdlib::Absolutepath $etc_dir = '/etc/sensu',
@@ -80,6 +82,7 @@ class sensu (
   String $agent_password = 'P@ssw0rd!',
   Optional[String] $agent_entity_config_password = undef,
   Boolean $validate_namespaces = true,
+  Boolean $validate_api = true,
 ) {
 
   if $ssl_ca_content {


### PR DESCRIPTION
# Pull Request Checklist

Add option to disable api validation when deploying sensu agent

## Description
Currently, when you deploy a sensu agent it makes 2 sensu API call, but I don't wan't explose the credential on agent side

## Related Issue
https://github.com/sensu/sensu-puppet/issues/1322
Apply requested change in the following PR https://github.com/sensu/sensu-puppet/pull/1328


Fixes # .

## Motivation and Context
I use Sensu myself and I've always deployed agents to be "standalone" and would like to be able to continue that way.

## How Has This Been Tested?
Deployed it within my org, added:
```
sensu::validate_api: false
sensu::agent::agent_managed_entity: true
```

## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [ ] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
