### PR TITLE
Fix catalog compile errors when API validation is disabled on backends

### DIFF
--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -369,6 +369,11 @@ class sensu::backend (
     subscribe => $service_subscribe,
   }
 
+  if $sensu::validate_api {
+    $init_require = Sensu_api_validator['sensu']
+  } else {
+    $init_require = undef
+  }
   exec { 'sensu-backend init':
     path        => '/usr/bin:/bin:/usr/sbin:/sbin',
     command     => "sensu-backend init --config-file ${sensu::etc_dir}/backend.yml",
@@ -381,7 +386,7 @@ class sensu::backend (
     # If exit code is 3, do not need to run sensu-backend init again
     # If exit is not 3, run sensu-backend init
     unless      => "sensu-backend init --config-file ${sensu::etc_dir}/backend.yml ; [ \$? -eq 3 ] && exit 0 || exit 1",
-    require     => Sensu_api_validator['sensu'],
+    require     => $init_require,
     before      => [
       Sensu_user['admin'],
       Sensuctl_configure['puppet'],

--- a/spec/classes/backend_spec.rb
+++ b/spec/classes/backend_spec.rb
@@ -391,6 +391,19 @@ describe 'sensu::backend', :type => :class do
           it { should contain_file('sensu-backend_env_vars').with_content(service_env_vars_content) }
         end
       end
+
+      context 'when validate_api => false' do
+        let(:pre_condition) do
+          <<-PP
+            class { 'sensu':
+              validate_api => false,
+            }
+          PP
+        end
+
+        it { should compile.with_all_deps }
+        it { is_expected.to contain_exec('sensu-backend init').without_require }
+      end
     end
   end
 end


### PR DESCRIPTION
Error without this change using updated tests before fixing the error:

```
       error during compilation: Could not find resource 'Sensu_api_validator[sensu]' in parameter 'require' (file: /Users/tdockendorf/git/sensu-puppet/spec/fixtures/modules/sensu/manifests/backend.pp, line: 384) on node test.example.com
```