### PR TITLE
Support Postgres DSN that contains no password

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,8 @@ class { 'sensu::backend':
 }
 ```
 
+**NOTE** Set `postgresql_password` to `false` if you want the DSN to only contain a username.
+
 ### Installing Plugins
 
 Plugin management is handled by the `sensu::plugins` class.

--- a/manifests/backend.pp
+++ b/manifests/backend.pp
@@ -153,7 +153,7 @@ class sensu::backend (
   Boolean $manage_postgresql_db = true,
   String $postgresql_name = 'postgresql',
   String $postgresql_user = 'sensu',
-  String $postgresql_password = 'changeme',
+  Variant[String, Boolean] $postgresql_password = 'changeme',
   Stdlib::Host $postgresql_host = 'localhost',
   Stdlib::Port $postgresql_port = 5432,
   String $postgresql_dbname = 'sensu',

--- a/spec/classes/backend_datastore_postgresql_spec.rb
+++ b/spec/classes/backend_datastore_postgresql_spec.rb
@@ -52,7 +52,25 @@ describe 'sensu::backend::datastore::postgresql', :type => :class do
       it { should_not contain_file('sensu-backend postgresql_crl') }
       it { should_not contain_file('sensu-backend postgresql_cert') }
       it { should_not contain_file('sensu-backend postgresql_key') }
-      
+
+      context 'with an empty password' do
+        let(:pre_condition) do
+          <<-EOS
+          class { '::postgresql::globals': version => '11' }
+          class { '::postgresql::server': }
+          class { 'sensu::backend': postgresql_password => false }
+          EOS
+        end
+
+        it do
+          should contain_sensu_postgres_config('postgresql').with({
+            :ensure    => 'present',
+            :dsn       => sensitive('postgresql://sensu@localhost:5432/sensu?sslmode=require'),
+            :pool_size => '20',
+          })
+        end
+      end
+
       context 'sslmode defined' do
         let(:pre_condition) do
           <<-EOS


### PR DESCRIPTION
Allow the Postgres connection DNS to contain no password which can be needed in situations like with Cloud SQL.