### PR TITLE
Address issues with sensuctl configure and errors

### DIFF
--- a/lib/puppet/provider/sensu_postgres_config/sensuctl.rb
+++ b/lib/puppet/provider/sensu_postgres_config/sensuctl.rb
@@ -23,7 +23,8 @@ Puppet::Type.type(:sensu_postgres_config).provide(:sensuctl, :parent => Puppet::
     data.each do |d|
       config = {}
       config[:ensure] = :present
-      config[:name] = d['metadata']['name']
+      config[:name] = d.fetch('metadata', {}).fetch('name', nil)
+      next if config[:name].nil?
       d['spec'].each_pair do |key,value|
         if !!value == value
           value = value.to_s.to_sym

--- a/lib/puppet/provider/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl.rb
@@ -71,6 +71,8 @@ class Puppet::Provider::Sensuctl < Puppet::Provider
     else
       cmd = [sensuctl_cmd] + args
     end
+    opts[:failonfail] = true unless opts.key?(:failonfail)
+    opts[:combine] = true unless opts.key?(:combine)
     execute(cmd, opts)
   end
   def sensuctl(*args)

--- a/lib/puppet/provider/sensuctl_configure/sensuctl.rb
+++ b/lib/puppet/provider/sensuctl_configure/sensuctl.rb
@@ -4,7 +4,8 @@ Puppet::Type.type(:sensuctl_configure).provide(:sensuctl, :parent => Puppet::Pro
   desc "Provider sensuctl_configure using sensuctl"
 
   def exists?
-    File.file?(config_path)
+    return false unless File.file?(config_path)
+    sensuctl_config.key?('access_token') || sensuctl_config.key?('refresh_token')
   end
 
   def initialize(value = {})

--- a/spec/fixtures/unit/provider/sensuctl_configure/sensuctl/cluster
+++ b/spec/fixtures/unit/provider/sensuctl_configure/sensuctl/cluster
@@ -1,0 +1,10 @@
+{
+  "api-url": "https://example.com:8080",
+  "trusted-ca-file": "/etc/sensu/ssl/ca.crt",
+  "insecure-skip-tls-verify": false,
+  "access_token": "baz",
+  "expires_at": 1679580582,
+  "refresh_token": "foobar",
+  "APIKey": "",
+  "timeout": 0
+}

--- a/spec/fixtures/unit/provider/sensuctl_configure/sensuctl/cluster-dne
+++ b/spec/fixtures/unit/provider/sensuctl_configure/sensuctl/cluster-dne
@@ -1,0 +1,8 @@
+{
+  "api-url": "https://example.com:8080",
+  "trusted-ca-file": "/etc/sensu/ssl/ca.crt",
+  "insecure-skip-tls-verify": false,
+  "expires_at": 1679580582,
+  "APIKey": "",
+  "timeout": 0
+}

--- a/spec/unit/provider/sensu_cluster_federation/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_cluster_federation/sensuctl_spec.rb
@@ -12,12 +12,12 @@ describe Puppet::Type.type(:sensu_cluster_federation).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.out'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.out'))
       expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a check' do
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.out'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.out'))
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('test')
     end

--- a/spec/unit/provider/sensu_cluster_federation_member/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_cluster_federation_member/sensuctl_spec.rb
@@ -13,12 +13,12 @@ describe Puppet::Type.type(:sensu_cluster_federation_member).provider(:sensuctl)
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.out'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.out'))
       expect(provider.instances.length).to eq(2)
     end
 
     it 'should return the resource for a check' do
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.out'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.out'))
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('https://10.0.0.1:8080 in test')
     end
@@ -30,7 +30,7 @@ describe Puppet::Type.type(:sensu_cluster_federation_member).provider(:sensuctl)
       expected_spec = {
         :api_urls => ['https://10.0.0.1:8080','https://10.0.0.2:8080','https://10.0.0.3:8080'],
       }
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.out'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.out'))
       expect(resource.provider).to receive(:sensuctl_create).with('Cluster', expected_metadata, expected_spec, 'federation/v1')
       resource.provider.create
       property_hash = resource.provider.instance_variable_get("@property_hash")
@@ -44,7 +44,7 @@ describe Puppet::Type.type(:sensu_cluster_federation_member).provider(:sensuctl)
       expected_spec = {
         :api_urls => ['https://10.0.0.1:8080','https://10.0.0.2:8080'],
       }
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.out'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.Cluster','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.out'))
       expect(resource.provider).to receive(:sensuctl_create).with('Cluster', expected_metadata, expected_spec, 'federation/v1')
       resource.provider.destroy
       property_hash = resource.provider.instance_variable_get("@property_hash")

--- a/spec/unit/provider/sensu_etcd_replicator/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_etcd_replicator/sensuctl_spec.rb
@@ -16,12 +16,12 @@ describe Puppet::Type.type(:sensu_etcd_replicator).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.EtcdReplicator','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.EtcdReplicator','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.txt'))
       expect(provider.instances.length).to eq(2)
     end
 
     it 'should return the resource for a check' do
-      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.EtcdReplicator','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      allow(provider).to receive(:sensuctl).with(['dump','federation/v1.EtcdReplicator','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.txt'))
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('role_replicator')
     end

--- a/spec/unit/provider/sensu_postgres_config/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_postgres_config/sensuctl_spec.rb
@@ -12,12 +12,12 @@ describe Puppet::Type.type(:sensu_postgres_config).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(provider).to receive(:sensuctl).with(['dump','store/v1.PostgresConfig','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      allow(provider).to receive(:sensuctl).with(['dump','store/v1.PostgresConfig','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.txt'))
       expect(provider.instances.length).to eq(1)
     end
 
     it 'should return the resource for a postres config' do
-      allow(provider).to receive(:sensuctl).with(['dump','store/v1.PostgresConfig','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      allow(provider).to receive(:sensuctl).with(['dump','store/v1.PostgresConfig','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.txt'))
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('my-postgres')
     end

--- a/spec/unit/provider/sensu_secrets_vault_provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensu_secrets_vault_provider/sensuctl_spec.rb
@@ -17,12 +17,12 @@ describe Puppet::Type.type(:sensu_secrets_vault_provider).provider(:sensuctl) do
 
   describe 'self.instances' do
     it 'should create instances' do
-      allow(provider).to receive(:sensuctl).with(['dump','secrets/v1.Provider','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      allow(provider).to receive(:sensuctl).with(['dump','secrets/v1.Provider','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.txt'))
       expect(provider.instances.length).to eq(3)
     end
 
     it 'should return the resource for a check' do
-      allow(provider).to receive(:sensuctl).with(['dump','secrets/v1.Provider','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      allow(provider).to receive(:sensuctl).with(['dump','secrets/v1.Provider','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.txt'))
       property_hash = provider.instances[0].instance_variable_get("@property_hash")
       expect(property_hash[:name]).to eq('my_vault')
     end

--- a/spec/unit/provider/sensuctl_configure/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_configure/sensuctl_spec.rb
@@ -12,6 +12,26 @@ describe Puppet::Type.type(:sensuctl_configure).provider(:sensuctl) do
     })
   end
 
+  describe 'exists?' do
+    before(:each) do
+      allow(Dir).to receive(:home).and_return('/root')
+    end
+    it 'should exist' do
+      allow(File).to receive(:file?).with('/root/.config/sensu/sensuctl/cluster').and_return(true)
+      allow(File).to receive(:read).with('/root/.config/sensu/sensuctl/cluster').and_return(my_fixture_read('cluster'))
+      expect(resource.provider.exists?).to eq(true)
+    end
+    it 'should not exist if no tokens' do
+      allow(File).to receive(:file?).with('/root/.config/sensu/sensuctl/cluster').and_return(true)
+      allow(File).to receive(:read).with('/root/.config/sensu/sensuctl/cluster').and_return(my_fixture_read('cluster-dne'))
+      expect(resource.provider.exists?).to eq(false)
+    end
+    it 'should not exist if no file' do
+      allow(File).to receive(:file?).with('/root/.config/sensu/sensuctl/cluster').and_return(false)
+      expect(resource.provider.exists?).to eq(false)
+    end
+  end
+
   describe 'config_format' do
     it 'should have value' do
       allow(resource.provider).to receive(:sensuctl).with(['config','view','--format','json']).and_return(my_fixture_read('config_list.json'))

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -125,14 +125,14 @@ describe Puppet::Provider::Sensuctl do
 
   context 'sensuctl_auth_types' do
     it 'should return auth and their types' do
-      allow(subject).to receive(:sensuctl).with(['auth','list','--format','yaml']).and_return(my_fixture_read('auths.txt'))
+      allow(subject).to receive(:sensuctl).with(['auth','list','--format','yaml'], failonfail: false).and_return(my_fixture_read('auths.txt'))
       expect(subject.sensuctl_auth_types).to eq({"activedirectory"=>"AD", "activedirectory2"=>"AD", "openldap"=>"LDAP"})
     end
   end
 
   context 'dump' do
     it 'dumps multiple resources' do
-      allow(subject).to receive(:sensuctl).with(['dump','federation/v1.EtcdReplicator','--format','yaml','--all-namespaces']).and_return(my_fixture_read('dump.txt'))
+      allow(subject).to receive(:sensuctl).with(['dump','federation/v1.EtcdReplicator','--format','yaml','--all-namespaces'], failonfail: false).and_return(my_fixture_read('dump.txt'))
       ret = subject.dump('federation/v1.EtcdReplicator')
       expect(ret.size).to eq(2)
       expect(ret[0]['metadata']['name']).to eq('role_replicator')

--- a/spec/unit/provider/sensuctl_spec.rb
+++ b/spec/unit/provider/sensuctl_spec.rb
@@ -58,6 +58,20 @@ describe Puppet::Provider::Sensuctl do
     end
   end
 
+  context 'sensuctl' do
+    it 'should handle a command' do
+      allow(subject).to receive(:which).with('sensuctl').and_return('/usr/bin/sensuctl')
+      expect(subject).to receive(:execute).with(['/usr/bin/sensuctl', 'create', '--file', 'foo'], {failonfail: true, combine: true})
+      subject.sensuctl(['create', '--file', 'foo'])
+    end
+
+    it 'should handle failonfail=false' do
+      allow(subject).to receive(:which).with('sensuctl').and_return('/usr/bin/sensuctl')
+      expect(subject).to receive(:execute).with(['/usr/bin/sensuctl', 'create', '--file', 'foo'], {failonfail: false, combine: true})
+      subject.sensuctl(['create', '--file', 'foo'], failonfail: false)
+    end
+  end
+
   context 'sensuctl_create' do
     let(:tmp) { Tempfile.new() }
     before(:each) do


### PR DESCRIPTION
Ensure 'sensuctl configure' is re-run if no access or refresh tokens
Ensure that any errors running sensuctl commands like 'sensuctl create' will be reported by Puppet

