### PR TITLE
Bump stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.1.0 < 7.0.0"
+      "version_requirement": ">= 5.1.0 < 9.0.0"
     },
     {
       "name": "richardc/datacat",


### PR DESCRIPTION
# Pull Request Checklist

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Bump stdlib dependency upper boundary to < 9.0.0 in metadata.json 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
puppet-stdlib v8.5.0 has been out for some time know. To guarantee compatibility with other modules through librarian-puppet, the dependency in metadata.json of sensu-puppet should increase the upper boundary higher than puppet-stdlib 7.0.0.
Especially when upgrading puppet modules from puppet v6 to v7, lots of modules needed this change.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on 3 virtual monitoring servers running sensu agent and sensu backend. System has been running stable since 2021.
