### PR TITLE
Use maintained systemd dependencies

### DIFF
--- a/.fixtures-latest.yml
+++ b/.fixtures-latest.yml
@@ -31,6 +31,6 @@ fixtures:
     windows_env:
       repo: https://github.com/voxpupuli/puppet-windows_env.git
     systemd:
-      repo: https://github.com/camptocamp/puppet-systemd.git
+      repo: https://github.com/voxpupuli/puppet-systemd.git
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -43,7 +43,7 @@ fixtures:
       repo: https://github.com/voxpupuli/puppet-windows_env.git
       ref: 'v3.0.0'
     systemd:
-      repo: https://github.com/camptocamp/puppet-systemd.git
-      ref: '2.0.0'
+      repo: https://github.com/puppet/puppet-systemd.git
+      ref: '4.2.0'
   symlinks:
     sensu: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -21,7 +21,7 @@
       "version_requirement": ">= 6.4.0 < 8.0.0"
     },
     {
-      "name": "camptocamp/systemd",
+      "name": "puppet/systemd",
       "version_requirement": ">= 2.0.0 < 4.0.0"
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppet/systemd",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
## Description

camptocamp module for systemd is not maintained since 16/08/21, use voxpupuli module instead

## Motivation and Context
camptocamp systemd is no longer maintained and have old dependencies (such as stdlib) that prevents Puppet modules upgrade