### PR TITLE
Puppet8

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -2,7 +2,7 @@ fixtures:
   repositories:
     apt:
       repo: https://github.com/puppetlabs/puppetlabs-apt.git
-      ref: 5.0.1
+      ref: 9.1.0
     stdlib:
       repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
       ref: 9.3.0
@@ -11,39 +11,39 @@ fixtures:
       ref: 0.6.2
     yumrepo_core:
       repo: https://github.com/puppetlabs/puppetlabs-yumrepo_core
-      ref: 1.0.1
+      ref: 2.0.0
       puppet_version: ">= 6.0.0"
     chocolatey:
       repo: https://github.com/puppetlabs/puppetlabs-chocolatey.git
-      ref: 3.0.0
+      ref: 8.0.0
     # Needed by chocolatey
     registry:
       repo: https://github.com/puppetlabs/puppetlabs-registry.git
-      ref: 1.0.0
+      ref: 5.0.1
     # Needed by chocolatey
     powershell:
       repo: https://github.com/puppetlabs/puppetlabs-powershell.git
-      ref: 1.0.1
+      ref: 6.0.0
     # Need by postgresql
     augeas_core:
       repo: https://github.com/puppetlabs/puppetlabs-augeas_core
-      ref: 1.0.4
+      ref: 1.3.0
       puppet_version: ">= 6.0.0"
     # Need by postgresql
     concat:
       repo: https://github.com/puppetlabs/puppetlabs-concat.git
-      ref: v6.0.0
+      ref: 9.0.0
     postgresql:
       repo: https://github.com/puppetlabs/puppetlabs-postgresql.git
-      ref: v6.4.0
+      ref: 9.1.0
     archive:
       repo: https://github.com/voxpupuli/puppet-archive.git
-      ref: 'v3.0.0'
+      ref: 7.0.0
     windows_env:
       repo: https://github.com/voxpupuli/puppet-windows_env.git
-      ref: 'v3.0.0'
+      ref: 5.0.0
     systemd:
       repo: https://github.com/camptocamp/puppet-systemd.git
-      ref: '2.0.0'
+      ref: 5.2.0
   symlinks:
     sensu: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,7 +5,7 @@ fixtures:
       ref: 5.0.1
     stdlib:
       repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
-      ref: 5.1.0
+      ref: 9.3.0
     datacat:
       repo: https://github.com/richardc/puppet-datacat.git
       ref: 0.6.2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,9 +28,9 @@ install:
 - set PATH=C:\Program Files\Puppet Labs\Puppet\bin;%PATH%
 - puppet --version
 - puppet module install puppetlabs-stdlib --version ">= 9.0.0 < 10.0.0"
-- puppet module install puppetlabs-chocolatey --version ">= 3.0.0 < 7.0.0"
-- puppet module install puppet-archive --version ">= 3.0.0 < 5.0.0"
-- puppet module install puppet-windows_env --version ">= 3.0.0 < 5.0.0"
+- puppet module install puppetlabs-chocolatey --version ">= 8.0.0 < 9.0.0"
+- puppet module install puppet-archive --version ">= 7.0.0 < 8.0.0"
+- puppet module install puppet-windows_env --version ">= 5.0.0 < 6.0.0"
 - puppet module install richardc-datacat --version ">= 0.6.0 < 2.0.0"
 - puppet config set --section main certname sensu_agent
 - facter -p --debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
 - puppet module install puppetlabs-stdlib --version ">= 9.0.0 < 10.0.0"
 - puppet module install puppetlabs-chocolatey --version ">= 8.0.0 < 9.0.0"
 - puppet module install puppet-archive --version ">= 7.0.0 < 8.0.0"
-- puppet module install puppet-windows_env --version ">= 5.0.0 < 6.0.0"
+- puppet module install puppetlabs-windows_env --version ">= 5.0.0 < 6.0.0"
 - puppet module install richardc-datacat --version ">= 0.6.0 < 2.0.0"
 - puppet config set --section main certname sensu_agent
 - facter -p --debug

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ install:
 - ps: Copy-Item -Path "${ENV:APPVEYOR_BUILD_FOLDER}/lib/facter" -Destination C:/ProgramData/PuppetLabs/puppet/cache/lib/facter -Recurse
 - set PATH=C:\Program Files\Puppet Labs\Puppet\bin;%PATH%
 - puppet --version
-- puppet module install puppetlabs-stdlib --version ">= 5.1.0 < 7.0.0"
+- puppet module install puppetlabs-stdlib --version ">= 9.0.0 < 10.0.0"
 - puppet module install puppetlabs-chocolatey --version ">= 3.0.0 < 7.0.0"
 - puppet module install puppet-archive --version ">= 3.0.0 < 5.0.0"
 - puppet module install puppet-windows_env --version ">= 3.0.0 < 5.0.0"

--- a/lib/facter/sensu_facts.rb
+++ b/lib/facter/sensu_facts.rb
@@ -3,9 +3,9 @@ require 'facter'
 module SensuFacts
   def self.which(cmd)
     path = nil
-    if File.exists?("C:\\Program Files\\sensu\\sensu-agent\\bin\\#{cmd}.exe")
+    if File.exist?("C:\\Program Files\\sensu\\sensu-agent\\bin\\#{cmd}.exe")
       path = "C:\\Program Files\\sensu\\sensu-agent\\bin\\#{cmd}.exe"
-    elsif File.exists?("C:\\Program Files\\Sensu\\#{cmd}.exe")
+    elsif File.exist?("C:\\Program Files\\Sensu\\#{cmd}.exe")
       path = "C:\\Program Files\\Sensu\\#{cmd}.exe"
     else
       path = Facter::Core::Execution.which(cmd)

--- a/lib/puppet/type/sensu_secrets_vault_provider.rb
+++ b/lib/puppet/type/sensu_secrets_vault_provider.rb
@@ -155,7 +155,7 @@ DESC
   end
 
   def refresh
-    if provider.exists? && @parameters[:ensure].value.to_s == 'present' && ! @parameters[:token_file].value.nil?
+    if provider.exist? && @parameters[:ensure].value.to_s == 'present' && ! @parameters[:token_file].value.nil?
       provider.flush(true)
     end
   end

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 9.0.0 < 7.0.0"
+      "version_requirement": ">= 9.0.0 < 10.0.0"
     },
     {
       "name": "richardc/datacat",

--- a/metadata.json
+++ b/metadata.json
@@ -18,11 +18,11 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.4.0 < 8.0.0"
+      "version_requirement": ">= 9.1.0 < 10.0.0"
     },
     {
       "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.1.0 < 7.0.0"
+      "version_requirement": ">= 9.0.0 < 7.0.0"
     },
     {
       "name": "richardc/datacat",
@@ -43,7 +43,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {
@@ -73,7 +74,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.1.0 < 8.0.0"
+      "version_requirement": ">= 6.1.0 < 9.0.0"
     }
   ],
   "tags": [

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -29,7 +29,7 @@ RSpec.configure do |c|
   else
     enterprise_file = File.join(project_dir, 'tests/sensu_license.json')
   end
-  if File.exists?(enterprise_file)
+  if File.exist?(enterprise_file)
     scp_to(hosts_as('sensu-backend'), enterprise_file, '/root/sensu_license.json')
     c.sensu_test_enterprise = true
   else
@@ -38,7 +38,7 @@ RSpec.configure do |c|
 
   ci_build = File.join(project_dir, 'tests/ci_build.sh')
   secrets = File.join(project_dir, 'tests/secrets')
-  if File.exists?(secrets) && (ENV['BEAKER_sensu_ci_build'] == 'yes' || ENV['BEAKER_sensu_ci_build'] == 'true')
+  if File.exist?(secrets) && (ENV['BEAKER_sensu_ci_build'] == 'yes' || ENV['BEAKER_sensu_ci_build'] == 'true')
     c.sensu_manage_repo = false
     c.add_ci_repo = true
   end

--- a/tests/provision_basic_debian.sh
+++ b/tests/provision_basic_debian.sh
@@ -53,7 +53,7 @@ puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu 
 
 # setup module dependencies
 puppet module install puppetlabs/stdlib --version ">= 9.0.0< 10.0.0"
-puppet module install puppetlabs/apt --version ">= 5.0.1 < 9.0.0"
+puppet module install puppetlabs/apt --version ">= 9.0.0 < 10.0.0"
 puppet module install richardc-datacat --version ">= 0.6.2 < 2.0.0"
 
 puppet resource host sensu-backend.example.com ensure=present ip=192.168.52.10 host_aliases=sensu-backend

--- a/tests/provision_basic_debian.sh
+++ b/tests/provision_basic_debian.sh
@@ -52,7 +52,7 @@ EOF
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version ">= 5.1.0 < 8.0.0"
+puppet module install puppetlabs/stdlib --version ">= 9.0.0< 10.0.0"
 puppet module install puppetlabs/apt --version ">= 5.0.1 < 9.0.0"
 puppet module install richardc-datacat --version ">= 0.6.2 < 2.0.0"
 

--- a/tests/provision_basic_el.sh
+++ b/tests/provision_basic_el.sh
@@ -30,7 +30,7 @@ fi
 puppet resource file /etc/puppetlabs/code/environments/production/modules/sensu ensure=link target=/vagrant
 
 # setup module dependencies
-puppet module install puppetlabs/stdlib --version ">= 5.1.0 < 8.0.0"
+puppet module install puppetlabs/stdlib --version ">= 9.0.0< 10.0.0"
 puppet module install richardc-datacat --version ">= 0.6.2 < 2.0.0"
 
 puppet resource host sensu-backend.example.com ensure=present ip=192.168.52.10 host_aliases=sensu-backend


### PR DESCRIPTION
# Pull Request Checklist

## Description
Update and support Stdlib 9 & puppet8

## Related Issue


Fixes # .

## Motivation and Context
Since Puppet 8 has been release, a lot of module use stdlib 9 but currently this module doesn't support it because it use a removed function (`exists`)

## How Has This Been Tested?
Test on a Puppet 8 server on 2 different OS (debian 11 & CentOS 9)


## General

- [x] Update `README.md` with any necessary configuration snippets

- [x] New parameters are documented

- [x] New parameters have tests

- [x] Tests pass - `bundle exec rake validate lint spec`
