### PR TITLE
Agent timeout parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -333,6 +333,7 @@ The following parameters are available in the `sensu::agent` class:
 * [`log_file`](#-sensu--agent--log_file)
 * [`agent_entity_config_provider`](#-sensu--agent--agent_entity_config_provider)
 * [`validate_entity`](#-sensu--agent--validate_entity)
+* [`timeout`](#-sensu--agent--timeout)
 
 ##### <a name="-sensu--agent--version"></a>`version`
 
@@ -537,6 +538,14 @@ Sets whether to validate the agent's entity before attempting
 to configure the entity
 
 Default value: `true`
+
+##### <a name="-sensu--agent--timeout"></a>`timeout`
+
+Data type: `Integer`
+
+Sets the timeout for validate entity
+
+Default value: `10`
 
 ### <a name="sensu--api"></a>`sensu::api`
 

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -77,6 +77,8 @@
 # @param validate_entity
 #   Sets whether to validate the agent's entity before attempting
 #   to configure the entity
+# @param timeout
+#   Sets the timeout for validate entity
 #
 class sensu::agent (
   Optional[String] $version = undef,
@@ -102,8 +104,8 @@ class sensu::agent (
   Optional[Stdlib::Absolutepath] $log_file = undef,
   Enum['sensuctl','sensu_api'] $agent_entity_config_provider = 'sensu_api',
   Boolean $validate_entity = true,
+  Integer $timeout = 10,
 ) {
-
   include sensu
   include sensu::common
   include sensu::api
@@ -208,8 +210,8 @@ class sensu::agent (
         before => Package['sensu-go-agent'],
       }
     } elsif $package_source {
-        $package_provider = undef
-        $_package_source = $package_source
+      $package_provider = undef
+      $_package_source = $package_source
     } else {
       include chocolatey
       $package_provider = 'chocolatey'
@@ -284,9 +286,9 @@ class sensu::agent (
     systemd::dropin_file { 'sensu-agent-start.conf':
       unit    => 'sensu-agent.service',
       content => join([
-        '[Service]',
-        'ExecStart=',
-        "ExecStart=${service_path} start -c ${sensu::agent_config_path}",
+          '[Service]',
+          'ExecStart=',
+          "ExecStart=${service_path} start -c ${sensu::agent_config_path}",
       ], "\n"),
       notify  => Service['sensu-agent'],
     }
@@ -304,6 +306,7 @@ class sensu::agent (
       ensure    => 'present',
       namespace => $config['namespace'],
       provider  => 'sensu_api',
+      timeout   => $timeout,
     }
   }
 }


### PR DESCRIPTION
`sensu::agent` has now a `timeout` parameter that is passed to `sensu_agent_entity_validator`. The option is now accessible instead of being in a private class. The default value is kept to the original private class value.

This is useful to prevent false positive Puppet errors if the agent <-> backend connection is having issues or the backend service is reloading.