### PR TITLE
more relaxed data types for Annotations

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -94,7 +94,7 @@ class sensu::agent (
   Optional[Array[Sensu::Backend_URL]] $backends = undef,
   String[1] $entity_name = $facts['networking']['fqdn'],
   Optional[Array[String[1]]] $subscriptions = undef,
-  Optional[Hash[String[1],String]] $annotations = undef,
+  Optional[Hash[String[1],Variant[Array, Hash, String]]] $annotations = undef,
   Optional[Hash[String[1],String]] $labels = undef,
   String[1] $namespace = 'default',
   Array[String[1]] $redact = ['password','passwd','pass','api_key','api_token','access_key','secret_key','private_key','secret'],


### PR DESCRIPTION
Annotations data type is too restricted, that makes it not compatible with remediation for example:
https://github.com/sensu/sensu-remediation-handler?tab=readme-ov-file#example-check-definition-and-remediation-request-configuration

```puppet
  sensu_check { 'check-puppet-errors-with-remidiation':
    ensure         => present,
    command        => 'check-puppet-errors',
    interval       => 300,
    subscriptions  => ['linux'],
    runtime_assets => ['nmollerup/sensu-check-puppet'],
    annotations    => {
      'comment'                                                    => 'The last Puppet run had failures. Investigation needed',
      'io.sensu.remediation.config.actions'                        => [
        {
          'description' => 'Retry another Puppet run.',
          'request'     => 'remediation-puppet-linux',
          'occurrences' => [1],
          'severities'  => [1,2]
        },
      ],
    },
    handlers       => ['remediation'],
  }
```