### PR TITLE
Hotfix/dep warnings

### DIFF
--- a/manifests/plugins.pp
+++ b/manifests/plugins.pp
@@ -67,11 +67,11 @@ class sensu::plugins (
     require => $package_require,
   }
 
-  ensure_packages($dependencies)
+  stdlib::ensure_packages($dependencies)
   $dependencies.each |$package| {
     Package[$package] -> Sensu_plugin <| |> # lint:ignore:spaceship_operator_without_tag
   }
-  ensure_packages($gem_dependencies, {'provider' => 'sensu_gem', 'require' => [Package[$dependencies],Package['sensu-plugins-ruby']]})
+  stdlib::ensure_packages($gem_dependencies, {'provider' => 'sensu_gem', 'require' => [Package[$dependencies],Package['sensu-plugins-ruby']]})
 
   if $plugins =~ Array {
     $plugins.each |$plugin| {

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,7 @@
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.4.0 < 8.0.0"
+      "version_requirement": ">= 6.4.0 < 9.0.0"
     },
     {
       "name": "camptocamp/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -10,15 +10,15 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 5.1.0 < 9.0.0"
+      "version_requirement": ">= 5.1.0"
     },
     {
       "name": "richardc/datacat",
-      "version_requirement": ">= 0.6.0 < 2.0.0"
+      "version_requirement": ">= 0.6.0"
     },
     {
       "name": "puppetlabs/postgresql",
-      "version_requirement": ">= 6.4.0 < 9.0.0"
+      "version_requirement": ">= 6.4.0"
     },
     {
       "name": "puppet/systemd",

--- a/metadata.json
+++ b/metadata.json
@@ -21,8 +21,8 @@
       "version_requirement": ">= 6.4.0 < 9.0.0"
     },
     {
-      "name": "camptocamp/systemd",
-      "version_requirement": ">= 2.0.0 < 4.0.0"
+      "name": "puppet/systemd",
+      "version_requirement": ">= 2.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Update plugins.pp to use the properly namespaced `stdlib::ensure_packages()` function so that we stop getting deprecation warnings about it in the test suite.